### PR TITLE
ML-17: Add global config for routes

### DIFF
--- a/src/server/common/constants/routes.js
+++ b/src/server/common/constants/routes.js
@@ -1,0 +1,7 @@
+export const routes = {
+  COORDINATES_TYPE_CHOICE:
+    '/exemption/how-do-you-want-to-provide-the-coordinates',
+  PROJECT_NAME: '/exemption/project-name',
+  PUBLIC_REGISTER: '/exemption/public-register',
+  TASK_LIST: '/exemption/task-list'
+}

--- a/src/server/exemption/index.js
+++ b/src/server/exemption/index.js
@@ -2,6 +2,7 @@ import { projectNameRoutes } from '~/src/server/exemption/project-name/index.js'
 import { publicRegisterRoutes } from '~/src/server/exemption/public-register/index.js'
 import { taskListRoutes } from '~/src/server/exemption/task-list/index.js'
 import { siteDetailsRoutes } from '~/src/server/exemption/site-details/index.js'
+import { routes } from '~/src/server/common/constants/routes.js'
 
 /**
  * Sets up the routes used in the exemption home page.
@@ -24,7 +25,7 @@ export const exemption = {
           method: 'GET',
           path: '/exemption',
           handler: (_request, h) => {
-            return h.redirect('/exemption/project-name')
+            return h.redirect(routes.PROJECT_NAME)
           }
         }
       ])

--- a/src/server/exemption/project-name/controller.js
+++ b/src/server/exemption/project-name/controller.js
@@ -7,6 +7,7 @@ import {
   getExemptionCache,
   setExemptionCache
 } from '~/src/server/common/helpers/session-cache/utils.js'
+import { routes } from '~/src/server/common/constants/routes.js'
 
 import Wreck from '@hapi/wreck'
 import joi from 'joi'
@@ -16,7 +17,6 @@ const errorMessages = {
   PROJECT_NAME_MAX_LENGTH: 'Project name should be 250 characters or less'
 }
 
-export const PROJECT_NAME_ROUTE = '/exemption/project-name'
 export const PROJECT_NAME_VIEW_ROUTE = 'exemption/project-name/index'
 
 const projectNameViewSettings = {
@@ -107,7 +107,7 @@ export const projectNameSubmitController = {
         projectName: payload.projectName
       })
 
-      return h.redirect('/exemption/task-list')
+      return h.redirect(routes.TASK_LIST)
     } catch (e) {
       const { details } = e.data?.payload?.validation ?? {}
 

--- a/src/server/exemption/project-name/controller.test.js
+++ b/src/server/exemption/project-name/controller.test.js
@@ -1,5 +1,6 @@
 import { createServer } from '~/src/server/index.js'
 import { statusCodes } from '~/src/server/common/constants/status-codes.js'
+import { routes } from '~/src/server/common/constants/routes.js'
 import { mockExemption } from '~/src/server/test-helpers/mocks.js'
 import { config } from '~/src/config/config.js'
 import Wreck from '@hapi/wreck'
@@ -7,7 +8,6 @@ import { JSDOM } from 'jsdom'
 import {
   projectNameSubmitController,
   projectNameController,
-  PROJECT_NAME_ROUTE,
   PROJECT_NAME_VIEW_ROUTE
 } from '~/src/server/exemption/project-name/controller.js'
 import * as cacheUtils from '~/src/server/common/helpers/session-cache/utils.js'
@@ -45,7 +45,7 @@ describe('#projectNameController', () => {
   test('Should provide expected response and correctly pre populate data', async () => {
     const { result, statusCode } = await server.inject({
       method: 'GET',
-      url: PROJECT_NAME_ROUTE
+      url: routes.PROJECT_NAME
     })
 
     expect(result).toEqual(
@@ -66,7 +66,7 @@ describe('#projectNameController', () => {
 
     const { result, statusCode } = await server.inject({
       method: 'GET',
-      url: PROJECT_NAME_ROUTE
+      url: routes.PROJECT_NAME
     })
 
     expect(result).toEqual(
@@ -89,7 +89,7 @@ describe('#projectNameController', () => {
 
     const { statusCode, headers } = await server.inject({
       method: 'POST',
-      url: PROJECT_NAME_ROUTE,
+      url: routes.PROJECT_NAME,
       payload: { projectName: 'Project name' }
     })
 
@@ -100,7 +100,7 @@ describe('#projectNameController', () => {
 
     expect(statusCode).toBe(302)
 
-    expect(headers.location).toBe('/exemption/task-list')
+    expect(headers.location).toBe(routes.TASK_LIST)
   })
 
   test('Should correctly update existing project and redirect to the next page on success', async () => {
@@ -110,7 +110,7 @@ describe('#projectNameController', () => {
 
     const { statusCode, headers } = await server.inject({
       method: 'POST',
-      url: PROJECT_NAME_ROUTE,
+      url: routes.PROJECT_NAME,
       payload: { projectName: 'Project name' }
     })
 
@@ -124,7 +124,7 @@ describe('#projectNameController', () => {
 
     expect(statusCode).toBe(302)
 
-    expect(headers.location).toBe('/exemption/task-list')
+    expect(headers.location).toBe(routes.TASK_LIST)
   })
 
   test('projectNameController handler should render with correct context', () => {
@@ -172,7 +172,7 @@ describe('#projectNameController', () => {
 
     const { result, statusCode } = await server.inject({
       method: 'POST',
-      url: PROJECT_NAME_ROUTE,
+      url: routes.PROJECT_NAME,
       payload: { projectName: 'test' }
     })
 
@@ -202,7 +202,7 @@ describe('#projectNameController', () => {
 
     const { result } = await server.inject({
       method: 'POST',
-      url: PROJECT_NAME_ROUTE,
+      url: routes.PROJECT_NAME,
       payload: { projectName: 'test' }
     })
 
@@ -312,7 +312,7 @@ describe('#projectNameController', () => {
 
     const { result } = await server.inject({
       method: 'POST',
-      url: PROJECT_NAME_ROUTE,
+      url: routes.PROJECT_NAME,
       payload: { projectName: '' }
     })
 

--- a/src/server/exemption/project-name/index.js
+++ b/src/server/exemption/project-name/index.js
@@ -2,6 +2,7 @@ import {
   projectNameController,
   projectNameSubmitController
 } from '~/src/server/exemption/project-name/controller.js'
+import { routes } from '~/src/server/common/constants/routes.js'
 
 /**
  * Sets up the routes used in the project name page.
@@ -14,12 +15,12 @@ import {
 export const projectNameRoutes = [
   {
     method: 'GET',
-    path: '/exemption/project-name',
+    path: routes.PROJECT_NAME,
     ...projectNameController
   },
   {
     method: 'POST',
-    path: '/exemption/project-name',
+    path: routes.PROJECT_NAME,
     ...projectNameSubmitController
   }
 ]

--- a/src/server/exemption/project-name/index.test.js
+++ b/src/server/exemption/project-name/index.test.js
@@ -1,11 +1,12 @@
 import { projectNameRoutes } from '~/src/server/exemption/project-name/index.js'
+import { routes } from '~/src/server/common/constants/routes.js'
 
 describe('projectNameRoutes routes', () => {
   test('get route is formatted correctly', () => {
     expect(projectNameRoutes[0]).toEqual(
       expect.objectContaining({
         method: 'GET',
-        path: '/exemption/project-name'
+        path: routes.PROJECT_NAME
       })
     )
   })
@@ -14,7 +15,7 @@ describe('projectNameRoutes routes', () => {
     expect(projectNameRoutes[1]).toEqual(
       expect.objectContaining({
         method: 'POST',
-        path: '/exemption/project-name'
+        path: routes.PROJECT_NAME
       })
     )
   })

--- a/src/server/exemption/public-register/controller.js
+++ b/src/server/exemption/public-register/controller.js
@@ -7,11 +7,11 @@ import {
   errorDescriptionByFieldName,
   mapErrorsForDisplay
 } from '~/src/server/common/helpers/errors.js'
+import { routes } from '~/src/server/common/constants/routes.js'
 
 import Wreck from '@hapi/wreck'
 import joi from 'joi'
 
-export const PUBLIC_REGISTER_ROUTE = '/exemption/public-register'
 export const PUBLIC_REGISTER_VIEW_ROUTE = 'exemption/public-register/index'
 
 export const errorMessages = {
@@ -124,7 +124,7 @@ export const publicRegisterSubmitController = {
         }
       })
 
-      return h.redirect('/exemption/task-list')
+      return h.redirect(routes.TASK_LIST)
     } catch (e) {
       const validation = e.data?.payload?.validation
       const details = validation?.details

--- a/src/server/exemption/public-register/controller.test.js
+++ b/src/server/exemption/public-register/controller.test.js
@@ -7,11 +7,11 @@ import { JSDOM } from 'jsdom'
 import {
   publicRegisterController,
   publicRegisterSubmitController,
-  PUBLIC_REGISTER_ROUTE,
   PUBLIC_REGISTER_VIEW_ROUTE,
   errorMessages
 } from '~/src/server/exemption/public-register/controller.js'
 import * as cacheUtils from '~/src/server/common/helpers/session-cache/utils.js'
+import { routes } from '~/src/server/common/constants/routes.js'
 
 jest.mock('~/src/server/common/helpers/session-cache/utils.js')
 
@@ -52,7 +52,7 @@ describe('#publicRegisterController', () => {
   test('Should provide expected response and correctly pre populate data', async () => {
     const { result, statusCode } = await server.inject({
       method: 'GET',
-      url: PUBLIC_REGISTER_ROUTE
+      url: routes.PUBLIC_REGISTER
     })
 
     expect(result).toEqual(
@@ -93,7 +93,7 @@ describe('#publicRegisterController', () => {
 
     const { result, statusCode } = await server.inject({
       method: 'GET',
-      url: PUBLIC_REGISTER_ROUTE
+      url: routes.PUBLIC_REGISTER
     })
 
     expect(result).toEqual(
@@ -112,7 +112,7 @@ describe('#publicRegisterController', () => {
   test('Should correctly redirect to the next page on success', async () => {
     const { statusCode, headers } = await server.inject({
       method: 'POST',
-      url: PUBLIC_REGISTER_ROUTE,
+      url: routes.PUBLIC_REGISTER,
       payload: { consent: 'yes', reason: 'Test reason' }
     })
 
@@ -182,7 +182,7 @@ describe('#publicRegisterController', () => {
 
     const { result, statusCode } = await server.inject({
       method: 'POST',
-      url: PUBLIC_REGISTER_ROUTE,
+      url: routes.PUBLIC_REGISTER,
       payload: { consent: 'no' }
     })
 
@@ -214,7 +214,7 @@ describe('#publicRegisterController', () => {
 
     const { result } = await server.inject({
       method: 'POST',
-      url: PUBLIC_REGISTER_ROUTE,
+      url: routes.PUBLIC_REGISTER,
       payload: { consent: 'no' }
     })
 
@@ -350,7 +350,7 @@ describe('#publicRegisterController', () => {
 
     const { result } = await server.inject({
       method: 'POST',
-      url: PUBLIC_REGISTER_ROUTE,
+      url: routes.PUBLIC_REGISTER,
       payload: { consent: '' }
     })
 
@@ -366,7 +366,7 @@ describe('#publicRegisterController', () => {
 
     const { result } = await server.inject({
       method: 'POST',
-      url: PUBLIC_REGISTER_ROUTE,
+      url: routes.PUBLIC_REGISTER,
       payload: { consent: 'yes' }
     })
 

--- a/src/server/exemption/public-register/index.js
+++ b/src/server/exemption/public-register/index.js
@@ -2,6 +2,7 @@ import {
   publicRegisterController,
   publicRegisterSubmitController
 } from '~/src/server/exemption/public-register/controller.js'
+import { routes } from '~/src/server/common/constants/routes.js'
 
 /**
  * Sets up the routes used in the public register page.
@@ -14,12 +15,12 @@ import {
 export const publicRegisterRoutes = [
   {
     method: 'GET',
-    path: '/exemption/public-register',
+    path: routes.PUBLIC_REGISTER,
     ...publicRegisterController
   },
   {
     method: 'POST',
-    path: '/exemption/public-register',
+    path: routes.PUBLIC_REGISTER,
     ...publicRegisterSubmitController
   }
 ]

--- a/src/server/exemption/public-register/index.test.js
+++ b/src/server/exemption/public-register/index.test.js
@@ -1,11 +1,12 @@
 import { publicRegisterRoutes } from '~/src/server/exemption/public-register/index.js'
+import { routes } from '~/src/server/common/constants/routes.js'
 
 describe('publicRegisterRoutes routes', () => {
   test('get route is formatted correctly', () => {
     expect(publicRegisterRoutes[0]).toEqual(
       expect.objectContaining({
         method: 'GET',
-        path: '/exemption/public-register'
+        path: routes.PUBLIC_REGISTER
       })
     )
   })
@@ -14,7 +15,7 @@ describe('publicRegisterRoutes routes', () => {
     expect(publicRegisterRoutes[1]).toEqual(
       expect.objectContaining({
         method: 'POST',
-        path: '/exemption/public-register'
+        path: routes.PUBLIC_REGISTER
       })
     )
   })

--- a/src/server/exemption/site-details/coordinates-type/controller.js
+++ b/src/server/exemption/site-details/coordinates-type/controller.js
@@ -9,8 +9,6 @@ import {
 
 import joi from 'joi'
 
-export const PROVIDE_COORDINATES_CHOICE_ROUTE =
-  '/exemption/how-do-you-want-to-provide-the-coordinates'
 export const PROVIDE_COORDINATES_CHOICE_VIEW_ROUTE =
   'exemption/site-details/coordinates-type/index'
 

--- a/src/server/exemption/site-details/coordinates-type/controller.test.js
+++ b/src/server/exemption/site-details/coordinates-type/controller.test.js
@@ -2,14 +2,14 @@ import { createServer } from '~/src/server/index.js'
 import {
   coordinatesTypeController,
   coordinatesTypeSubmitController,
-  PROVIDE_COORDINATES_CHOICE_VIEW_ROUTE,
-  PROVIDE_COORDINATES_CHOICE_ROUTE
+  PROVIDE_COORDINATES_CHOICE_VIEW_ROUTE
 } from '~/src/server/exemption/site-details/coordinates-type/controller.js'
 import * as cacheUtils from '~/src/server/common/helpers/session-cache/utils.js'
 import { mockExemption } from '~/src/server/test-helpers/mocks.js'
 import { statusCodes } from '~/src/server/common/constants/status-codes.js'
 import { config } from '~/src/config/config.js'
 import { JSDOM } from 'jsdom'
+import { routes } from '~/src/server/common/constants/routes.js'
 
 jest.mock('~/src/server/common/helpers/session-cache/utils.js')
 
@@ -67,7 +67,7 @@ describe('#coordinatesTypeController', () => {
   test('Should provide expected response and correctly pre populate data', async () => {
     const { result, statusCode } = await server.inject({
       method: 'GET',
-      url: PROVIDE_COORDINATES_CHOICE_ROUTE
+      url: routes.COORDINATES_TYPE_CHOICE
     })
 
     expect(result).toEqual(

--- a/src/server/exemption/site-details/coordinates-type/index.js
+++ b/src/server/exemption/site-details/coordinates-type/index.js
@@ -1,8 +1,8 @@
 import {
   coordinatesTypeController,
-  coordinatesTypeSubmitController,
-  PROVIDE_COORDINATES_CHOICE_ROUTE
+  coordinatesTypeSubmitController
 } from '~/src/server/exemption/site-details/coordinates-type/controller.js'
+import { routes } from '~/src/server/common/constants/routes.js'
 
 /**
  * Sets up the routes used in the provide the coordinates choice page.
@@ -15,12 +15,12 @@ import {
 export const coordinatesTypeRoutes = [
   {
     method: 'GET',
-    path: PROVIDE_COORDINATES_CHOICE_ROUTE,
+    path: routes.COORDINATES_TYPE_CHOICE,
     ...coordinatesTypeController
   },
   {
     method: 'POST',
-    path: PROVIDE_COORDINATES_CHOICE_ROUTE,
+    path: routes.COORDINATES_TYPE_CHOICE,
     ...coordinatesTypeSubmitController
   }
 ]

--- a/src/server/exemption/task-list/controller.js
+++ b/src/server/exemption/task-list/controller.js
@@ -5,7 +5,6 @@ import { transformTaskList } from '~/src/server/exemption/task-list/utils.js'
 import Wreck from '@hapi/wreck'
 import Boom from '@hapi/boom'
 
-export const TASK_LIST_ROUTE = '/exemption/task-list'
 export const TASK_LIST_VIEW_ROUTE = 'exemption/task-list/index'
 
 const taskListViewSettings = {

--- a/src/server/exemption/task-list/controller.test.js
+++ b/src/server/exemption/task-list/controller.test.js
@@ -5,10 +5,10 @@ import { JSDOM } from 'jsdom'
 import * as cacheUtils from '~/src/server/common/helpers/session-cache/utils.js'
 import {
   taskListController,
-  TASK_LIST_ROUTE,
   TASK_LIST_VIEW_ROUTE
 } from '~/src/server/exemption/task-list/controller.js'
 import { mockExemption } from '~/src/server/test-helpers/mocks.js'
+import { routes } from '~/src/server/common/constants/routes.js'
 
 import Wreck from '@hapi/wreck'
 
@@ -43,7 +43,7 @@ describe('#taskListController', () => {
   test('Should provide expected response when loading page', async () => {
     const { result, statusCode } = await server.inject({
       method: 'GET',
-      url: TASK_LIST_ROUTE
+      url: routes.TASK_LIST
     })
 
     expect(result).toEqual(
@@ -89,7 +89,7 @@ describe('#taskListController', () => {
       projectName: 'Test Project',
       taskList: [
         {
-          href: '/exemption/project-name',
+          href: routes.PROJECT_NAME,
           status: {
             text: 'Completed'
           },
@@ -110,7 +110,7 @@ describe('#taskListController', () => {
           }
         },
         {
-          href: '/exemption/public-register',
+          href: routes.PUBLIC_REGISTER,
           status: {
             text: 'Completed'
           },

--- a/src/server/exemption/task-list/controller.test.js
+++ b/src/server/exemption/task-list/controller.test.js
@@ -98,7 +98,7 @@ describe('#taskListController', () => {
           }
         },
         {
-          href: '/exemption/how-do-you-want-to-provide-the-coordinates',
+          href: routes.COORDINATES_TYPE_CHOICE,
           status: {
             tag: {
               classes: 'govuk-tag--blue',

--- a/src/server/exemption/task-list/index.js
+++ b/src/server/exemption/task-list/index.js
@@ -1,4 +1,5 @@
 import { taskListController } from '~/src/server/exemption/task-list/controller.js'
+import { routes } from '~/src/server/common/constants/routes.js'
 
 /**
  * Sets up the routes used in the task list page.
@@ -11,7 +12,7 @@ import { taskListController } from '~/src/server/exemption/task-list/controller.
 export const taskListRoutes = [
   {
     method: 'GET',
-    path: '/exemption/task-list',
+    path: routes.TASK_LIST,
     ...taskListController
   }
 ]

--- a/src/server/exemption/task-list/utils.js
+++ b/src/server/exemption/task-list/utils.js
@@ -37,7 +37,7 @@ export const transformTaskList = (taskList) => {
       title: {
         text: 'Site details'
       },
-      href: '/exemption/how-do-you-want-to-provide-the-coordinates',
+      href: routes.COORDINATES_TYPE_CHOICE,
       status: setStatus(taskList.siteDetails)
     },
     {

--- a/src/server/exemption/task-list/utils.js
+++ b/src/server/exemption/task-list/utils.js
@@ -1,3 +1,5 @@
+import { routes } from '~/src/server/common/constants/routes.js'
+
 /**
  * Set text for front end display
  * @param { string } task
@@ -27,7 +29,7 @@ export const transformTaskList = (taskList) => {
       title: {
         text: 'Project name'
       },
-      href: '/exemption/project-name',
+      href: routes.PROJECT_NAME,
       status: setStatus(taskList.projectName)
     },
 
@@ -42,7 +44,7 @@ export const transformTaskList = (taskList) => {
       title: {
         text: 'Public register'
       },
-      href: '/exemption/public-register',
+      href: routes.PUBLIC_REGISTER,
       status: setStatus(taskList.publicRegister)
     }
   ]

--- a/src/server/exemption/task-list/utils.test.js
+++ b/src/server/exemption/task-list/utils.test.js
@@ -1,11 +1,12 @@
 import { transformTaskList } from '~/src/server/exemption/task-list/utils.js'
 import { mockExemptionTaskList } from '~/src/server/test-helpers/mocks.js'
+import { routes } from '~/src/server/common/constants/routes.js'
 
 describe('taskList utils', () => {
   test('transformTaskList correctly returns task list', () => {
     expect(transformTaskList(mockExemptionTaskList)).toEqual([
       {
-        href: '/exemption/project-name',
+        href: routes.PROJECT_NAME,
         status: { text: 'Completed' },
         title: { text: 'Project name' }
       },
@@ -15,7 +16,7 @@ describe('taskList utils', () => {
         title: { text: 'Site details' }
       },
       {
-        href: '/exemption/public-register',
+        href: routes.PUBLIC_REGISTER,
         status: { text: 'Completed' },
         title: { text: 'Public register' }
       }
@@ -25,7 +26,7 @@ describe('taskList utils', () => {
   test('transformTaskList correctly handles empty values', () => {
     expect(transformTaskList({})).toEqual([
       {
-        href: '/exemption/project-name',
+        href: routes.PROJECT_NAME,
         status: { tag: { text: 'Incomplete', classes: 'govuk-tag--blue' } },
         title: { text: 'Project name' }
       },
@@ -35,7 +36,7 @@ describe('taskList utils', () => {
         title: { text: 'Site details' }
       },
       {
-        href: '/exemption/public-register',
+        href: routes.PUBLIC_REGISTER,
         status: { tag: { text: 'Incomplete', classes: 'govuk-tag--blue' } },
         title: { text: 'Public register' }
       }

--- a/src/server/exemption/task-list/utils.test.js
+++ b/src/server/exemption/task-list/utils.test.js
@@ -11,7 +11,7 @@ describe('taskList utils', () => {
         title: { text: 'Project name' }
       },
       {
-        href: '/exemption/how-do-you-want-to-provide-the-coordinates',
+        href: routes.COORDINATES_TYPE_CHOICE,
         status: { tag: { text: 'Incomplete', classes: 'govuk-tag--blue' } },
         title: { text: 'Site details' }
       },
@@ -31,7 +31,7 @@ describe('taskList utils', () => {
         title: { text: 'Project name' }
       },
       {
-        href: '/exemption/how-do-you-want-to-provide-the-coordinates',
+        href: routes.COORDINATES_TYPE_CHOICE,
         status: { tag: { text: 'Incomplete', classes: 'govuk-tag--blue' } },
         title: { text: 'Site details' }
       },


### PR DESCRIPTION
Add a global config for routes to define them in one place rather than repeating strings.