### PR TITLE
Improve test organisation for controllers

### DIFF
--- a/src/server/exemption/project-name/controller.test.js
+++ b/src/server/exemption/project-name/controller.test.js
@@ -14,7 +14,7 @@ import * as cacheUtils from '~/src/server/common/helpers/session-cache/utils.js'
 
 jest.mock('~/src/server/common/helpers/session-cache/utils.js')
 
-describe('#projectNameController', () => {
+describe('#projectName', () => {
   /** @type {Server} */
   let server
   let getExemptionCacheSpy
@@ -42,303 +42,307 @@ describe('#projectNameController', () => {
     await server.stop({ timeout: 0 })
   })
 
-  test('Should provide expected response and correctly pre populate data', async () => {
-    const { result, statusCode } = await server.inject({
-      method: 'GET',
-      url: routes.PROJECT_NAME
+  describe('#projectNameController', () => {
+    test('Should provide expected response and correctly pre populate data', async () => {
+      const { result, statusCode } = await server.inject({
+        method: 'GET',
+        url: routes.PROJECT_NAME
+      })
+
+      expect(result).toEqual(
+        expect.stringContaining(`Project name | ${config.get('serviceName')}`)
+      )
+
+      const { document } = new JSDOM(result).window
+
+      expect(document.querySelector('#projectName').value).toBe(
+        mockExemptionState.projectName
+      )
+
+      expect(statusCode).toBe(statusCodes.ok)
     })
 
-    expect(result).toEqual(
-      expect.stringContaining(`Project name | ${config.get('serviceName')}`)
-    )
+    test('Should provide expected response and correctly not pre populate data if it is not present', async () => {
+      getExemptionCacheSpy.mockResolvedValueOnce({})
 
-    const { document } = new JSDOM(result).window
+      const { result, statusCode } = await server.inject({
+        method: 'GET',
+        url: routes.PROJECT_NAME
+      })
 
-    expect(document.querySelector('#projectName').value).toBe(
-      mockExemptionState.projectName
-    )
+      expect(result).toEqual(
+        expect.stringContaining(`Project name | ${config.get('serviceName')}`)
+      )
 
-    expect(statusCode).toBe(statusCodes.ok)
-  })
+      const { document } = new JSDOM(result).window
 
-  test('Should provide expected response and correctly not pre populate data if it is not present', async () => {
-    getExemptionCacheSpy.mockResolvedValueOnce({})
+      expect(document.querySelector('#projectName').value).toBeFalsy()
 
-    const { result, statusCode } = await server.inject({
-      method: 'GET',
-      url: routes.PROJECT_NAME
+      expect(statusCode).toBe(statusCodes.ok)
     })
 
-    expect(result).toEqual(
-      expect.stringContaining(`Project name | ${config.get('serviceName')}`)
-    )
+    test('projectNameController handler should render with correct context', () => {
+      const h = { view: jest.fn() }
 
-    const { document } = new JSDOM(result).window
+      projectNameController.handler({}, h)
 
-    expect(document.querySelector('#projectName').value).toBeFalsy()
+      expect(h.view).toHaveBeenCalledWith(PROJECT_NAME_VIEW_ROUTE, {
+        pageTitle: 'Project name',
+        heading: 'Project Name',
+        payload: mockExemptionState
+      })
 
-    expect(statusCode).toBe(statusCodes.ok)
-  })
+      getExemptionCacheSpy.mockResolvedValueOnce(null)
 
-  test('Should correctly create new project and redirect to the next page on success', async () => {
-    const apiPostMock = jest.spyOn(Wreck, 'post')
-    apiPostMock.mockResolvedValueOnce({
-      res: { statusCode: 200 },
-      payload: { data: 'test' }
-    })
+      projectNameController.handler({}, h)
 
-    const { statusCode, headers } = await server.inject({
-      method: 'POST',
-      url: routes.PROJECT_NAME,
-      payload: { projectName: 'Project name' }
-    })
-
-    expect(Wreck.post).toHaveBeenCalledWith(
-      `${config.get('backend').apiUrl}/exemption/project-name`,
-      { payload: { projectName: 'Project name' }, json: true }
-    )
-
-    expect(statusCode).toBe(302)
-
-    expect(headers.location).toBe(routes.TASK_LIST)
-  })
-
-  test('Should correctly update existing project and redirect to the next page on success', async () => {
-    getExemptionCacheSpy.mockReturnValueOnce(mockExemption)
-
-    jest.spyOn(Wreck, 'patch').mockImplementationOnce(() => jest.fn())
-
-    const { statusCode, headers } = await server.inject({
-      method: 'POST',
-      url: routes.PROJECT_NAME,
-      payload: { projectName: 'Project name' }
-    })
-
-    expect(Wreck.patch).toHaveBeenCalledWith(
-      `${config.get('backend').apiUrl}/exemption/project-name`,
-      {
-        payload: { projectName: 'Project name', id: mockExemption.id },
-        json: true
-      }
-    )
-
-    expect(statusCode).toBe(302)
-
-    expect(headers.location).toBe(routes.TASK_LIST)
-  })
-
-  test('projectNameController handler should render with correct context', () => {
-    const h = { view: jest.fn() }
-
-    projectNameController.handler({}, h)
-
-    expect(h.view).toHaveBeenCalledWith(PROJECT_NAME_VIEW_ROUTE, {
-      pageTitle: 'Project name',
-      heading: 'Project Name',
-      payload: mockExemptionState
-    })
-
-    getExemptionCacheSpy.mockResolvedValueOnce(null)
-
-    projectNameController.handler({}, h)
-
-    expect(h.view).toHaveBeenNthCalledWith(2, PROJECT_NAME_VIEW_ROUTE, {
-      pageTitle: 'Project name',
-      heading: 'Project Name',
-      payload: { projectName: undefined }
+      expect(h.view).toHaveBeenNthCalledWith(2, PROJECT_NAME_VIEW_ROUTE, {
+        pageTitle: 'Project name',
+        heading: 'Project Name',
+        payload: { projectName: undefined }
+      })
     })
   })
 
-  test('Should show error messages with invalid data', async () => {
-    const apiPostMock = jest.spyOn(Wreck, 'post')
-    apiPostMock.mockRejectedValueOnce({
-      res: { statusCode: 200 },
-      data: {
-        payload: {
-          validation: {
-            source: 'payload',
-            keys: ['projectName'],
-            details: [
-              {
-                field: 'projectName',
-                message: 'PROJECT_NAME_REQUIRED',
-                type: 'string.empty'
-              }
-            ]
+  describe('#projectNameSubmitController', () => {
+    test('Should correctly create new project and redirect to the next page on success', async () => {
+      const apiPostMock = jest.spyOn(Wreck, 'post')
+      apiPostMock.mockResolvedValueOnce({
+        res: { statusCode: 200 },
+        payload: { data: 'test' }
+      })
+
+      const { statusCode, headers } = await server.inject({
+        method: 'POST',
+        url: routes.PROJECT_NAME,
+        payload: { projectName: 'Project name' }
+      })
+
+      expect(Wreck.post).toHaveBeenCalledWith(
+        `${config.get('backend').apiUrl}/exemption/project-name`,
+        { payload: { projectName: 'Project name' }, json: true }
+      )
+
+      expect(statusCode).toBe(302)
+
+      expect(headers.location).toBe(routes.TASK_LIST)
+    })
+
+    test('Should correctly update existing project and redirect to the next page on success', async () => {
+      getExemptionCacheSpy.mockReturnValueOnce(mockExemption)
+
+      jest.spyOn(Wreck, 'patch').mockImplementationOnce(() => jest.fn())
+
+      const { statusCode, headers } = await server.inject({
+        method: 'POST',
+        url: routes.PROJECT_NAME,
+        payload: { projectName: 'Project name' }
+      })
+
+      expect(Wreck.patch).toHaveBeenCalledWith(
+        `${config.get('backend').apiUrl}/exemption/project-name`,
+        {
+          payload: { projectName: 'Project name', id: mockExemption.id },
+          json: true
+        }
+      )
+
+      expect(statusCode).toBe(302)
+
+      expect(headers.location).toBe(routes.TASK_LIST)
+    })
+
+    test('Should show error messages with invalid data', async () => {
+      const apiPostMock = jest.spyOn(Wreck, 'post')
+      apiPostMock.mockRejectedValueOnce({
+        res: { statusCode: 200 },
+        data: {
+          payload: {
+            validation: {
+              source: 'payload',
+              keys: ['projectName'],
+              details: [
+                {
+                  field: 'projectName',
+                  message: 'PROJECT_NAME_REQUIRED',
+                  type: 'string.empty'
+                }
+              ]
+            }
           }
         }
+      })
+
+      const { result, statusCode } = await server.inject({
+        method: 'POST',
+        url: routes.PROJECT_NAME,
+        payload: { projectName: 'test' }
+      })
+
+      expect(result).toEqual(expect.stringContaining(`Enter the project name`))
+
+      const { document } = new JSDOM(result).window
+
+      expect(
+        document.querySelector('.govuk-error-message').textContent.trim()
+      ).toBe('Error: Enter the project name')
+
+      expect(document.querySelector('h2').textContent.trim()).toBe(
+        'There is a problem'
+      )
+
+      expect(document.querySelector('.govuk-error-summary')).toBeTruthy()
+
+      expect(statusCode).toBe(statusCodes.ok)
+    })
+
+    test('Should pass erorr to global catchAll behaviour if it is not a validation error', async () => {
+      const apiPostMock = jest.spyOn(Wreck, 'post')
+      apiPostMock.mockRejectedValueOnce({
+        res: { statusCode: 500 },
+        data: {}
+      })
+
+      const { result } = await server.inject({
+        method: 'POST',
+        url: routes.PROJECT_NAME,
+        payload: { projectName: 'test' }
+      })
+
+      expect(result).toContain('Something went wrong')
+
+      const { document } = new JSDOM(result).window
+
+      expect(document.querySelector('h1').textContent.trim()).toBe('500')
+    })
+
+    test('Should correctly validate on empty data', () => {
+      const request = {
+        payload: { projectName: '' }
       }
-    })
 
-    const { result, statusCode } = await server.inject({
-      method: 'POST',
-      url: routes.PROJECT_NAME,
-      payload: { projectName: 'test' }
-    })
-
-    expect(result).toEqual(expect.stringContaining(`Enter the project name`))
-
-    const { document } = new JSDOM(result).window
-
-    expect(
-      document.querySelector('.govuk-error-message').textContent.trim()
-    ).toBe('Error: Enter the project name')
-
-    expect(document.querySelector('h2').textContent.trim()).toBe(
-      'There is a problem'
-    )
-
-    expect(document.querySelector('.govuk-error-summary')).toBeTruthy()
-
-    expect(statusCode).toBe(statusCodes.ok)
-  })
-
-  test('Should pass erorr to global catchAll behaviour if it is not a validation error', async () => {
-    const apiPostMock = jest.spyOn(Wreck, 'post')
-    apiPostMock.mockRejectedValueOnce({
-      res: { statusCode: 500 },
-      data: {}
-    })
-
-    const { result } = await server.inject({
-      method: 'POST',
-      url: routes.PROJECT_NAME,
-      payload: { projectName: 'test' }
-    })
-
-    expect(result).toContain('Something went wrong')
-
-    const { document } = new JSDOM(result).window
-
-    expect(document.querySelector('h1').textContent.trim()).toBe('500')
-  })
-
-  test('Should correctly validate on empty data', () => {
-    const request = {
-      payload: { projectName: '' }
-    }
-
-    const h = {
-      view: jest.fn().mockReturnValue({
-        takeover: jest.fn()
-      })
-    }
-
-    const err = {
-      details: [
-        {
-          path: ['projectName'],
-          message: 'TEST',
-          type: 'string.empty'
-        }
-      ]
-    }
-
-    projectNameSubmitController.options.validate.failAction(request, h, err)
-
-    expect(h.view).toHaveBeenCalledWith(PROJECT_NAME_VIEW_ROUTE, {
-      heading: 'Project Name',
-      pageTitle: 'Project name',
-      payload: { projectName: '' },
-      errorSummary: [
-        {
-          href: '#projectName',
-          text: 'TEST',
-          field: ['projectName']
-        }
-      ],
-      errors: {
-        projectName: {
-          field: ['projectName'],
-          href: '#projectName',
-          text: 'TEST'
-        }
+      const h = {
+        view: jest.fn().mockReturnValue({
+          takeover: jest.fn()
+        })
       }
-    })
 
-    expect(h.view().takeover).toHaveBeenCalled()
-  })
+      const err = {
+        details: [
+          {
+            path: ['projectName'],
+            message: 'TEST',
+            type: 'string.empty'
+          }
+        ]
+      }
 
-  test('Should correctly handle an incorrectly formed error object', () => {
-    const request = {
-      payload: { projectName: '' }
-    }
+      projectNameSubmitController.options.validate.failAction(request, h, err)
 
-    const h = {
-      view: jest.fn().mockReturnValue({
-        takeover: jest.fn()
+      expect(h.view).toHaveBeenCalledWith(PROJECT_NAME_VIEW_ROUTE, {
+        heading: 'Project Name',
+        pageTitle: 'Project name',
+        payload: { projectName: '' },
+        errorSummary: [
+          {
+            href: '#projectName',
+            text: 'TEST',
+            field: ['projectName']
+          }
+        ],
+        errors: {
+          projectName: {
+            field: ['projectName'],
+            href: '#projectName',
+            text: 'TEST'
+          }
+        }
       })
-    }
 
-    const err = {
-      details: null
-    }
-
-    projectNameSubmitController.options.validate.failAction(request, h, err)
-
-    expect(h.view).toHaveBeenCalledWith(PROJECT_NAME_VIEW_ROUTE, {
-      heading: 'Project Name',
-      pageTitle: 'Project name',
-      payload: { projectName: '' }
+      expect(h.view().takeover).toHaveBeenCalled()
     })
 
-    expect(h.view().takeover).toHaveBeenCalled()
-  })
+    test('Should correctly handle an incorrectly formed error object', () => {
+      const request = {
+        payload: { projectName: '' }
+      }
 
-  test('Should correctly validate on empty data and handle a scenario where error details are missing', () => {
-    const request = {
-      payload: { projectName: '' }
-    }
+      const h = {
+        view: jest.fn().mockReturnValue({
+          takeover: jest.fn()
+        })
+      }
 
-    const h = {
-      view: jest.fn().mockReturnValue({
-        takeover: jest.fn()
+      const err = {
+        details: null
+      }
+
+      projectNameSubmitController.options.validate.failAction(request, h, err)
+
+      expect(h.view).toHaveBeenCalledWith(PROJECT_NAME_VIEW_ROUTE, {
+        heading: 'Project Name',
+        pageTitle: 'Project name',
+        payload: { projectName: '' }
       })
-    }
 
-    projectNameSubmitController.options.validate.failAction(request, h, {})
-
-    expect(h.view).toHaveBeenCalledWith(PROJECT_NAME_VIEW_ROUTE, {
-      heading: 'Project Name',
-      pageTitle: 'Project name',
-      payload: { projectName: '' }
+      expect(h.view().takeover).toHaveBeenCalled()
     })
 
-    expect(h.view().takeover).toHaveBeenCalled()
-  })
+    test('Should correctly validate on empty data and handle a scenario where error details are missing', () => {
+      const request = {
+        payload: { projectName: '' }
+      }
 
-  test('Should show error messages without calling the back end when payload data is empty', async () => {
-    const apiPostMock = jest.spyOn(Wreck, 'post')
+      const h = {
+        view: jest.fn().mockReturnValue({
+          takeover: jest.fn()
+        })
+      }
 
-    const { result } = await server.inject({
-      method: 'POST',
-      url: routes.PROJECT_NAME,
-      payload: { projectName: '' }
+      projectNameSubmitController.options.validate.failAction(request, h, {})
+
+      expect(h.view).toHaveBeenCalledWith(PROJECT_NAME_VIEW_ROUTE, {
+        heading: 'Project Name',
+        pageTitle: 'Project name',
+        payload: { projectName: '' }
+      })
+
+      expect(h.view().takeover).toHaveBeenCalled()
     })
 
-    expect(apiPostMock).not.toHaveBeenCalled()
+    test('Should show error messages without calling the back end when payload data is empty', async () => {
+      const apiPostMock = jest.spyOn(Wreck, 'post')
 
-    const { document } = new JSDOM(result).window
+      const { result } = await server.inject({
+        method: 'POST',
+        url: routes.PROJECT_NAME,
+        payload: { projectName: '' }
+      })
 
-    expect(document.querySelector('.govuk-error-summary')).toBeTruthy()
-  })
+      expect(apiPostMock).not.toHaveBeenCalled()
 
-  test('Should correctly set the cache when submitting a project name', async () => {
-    const h = {
-      redirect: jest.fn().mockReturnValue({
-        takeover: jest.fn()
-      }),
-      view: jest.fn()
-    }
+      const { document } = new JSDOM(result).window
 
-    const mockRequest = { payload: { projectName: 'Project name' } }
+      expect(document.querySelector('.govuk-error-summary')).toBeTruthy()
+    })
 
-    await projectNameSubmitController.handler(
-      { payload: { projectName: 'Project name' } },
-      h
-    )
-    expect(cacheUtils.setExemptionCache).toHaveBeenCalledWith(mockRequest, {
-      projectName: 'Project name'
+    test('Should correctly set the cache when submitting a project name', async () => {
+      const h = {
+        redirect: jest.fn().mockReturnValue({
+          takeover: jest.fn()
+        }),
+        view: jest.fn()
+      }
+
+      const mockRequest = { payload: { projectName: 'Project name' } }
+
+      await projectNameSubmitController.handler(
+        { payload: { projectName: 'Project name' } },
+        h
+      )
+      expect(cacheUtils.setExemptionCache).toHaveBeenCalledWith(mockRequest, {
+        projectName: 'Project name'
+      })
     })
   })
 })

--- a/src/server/exemption/public-register/controller.test.js
+++ b/src/server/exemption/public-register/controller.test.js
@@ -15,7 +15,7 @@ import { routes } from '~/src/server/common/constants/routes.js'
 
 jest.mock('~/src/server/common/helpers/session-cache/utils.js')
 
-describe('#publicRegisterController', () => {
+describe('#publicRegister', () => {
   /** @type {Server} */
   let server
   let getExemptionCacheSpy
@@ -49,356 +49,372 @@ describe('#publicRegisterController', () => {
     await server.stop({ timeout: 0 })
   })
 
-  test('Should provide expected response and correctly pre populate data', async () => {
-    const { result, statusCode } = await server.inject({
-      method: 'GET',
-      url: routes.PUBLIC_REGISTER
+  describe('#publicRegisterController', () => {
+    test('Should provide expected response and correctly pre populate data', async () => {
+      const { result, statusCode } = await server.inject({
+        method: 'GET',
+        url: routes.PUBLIC_REGISTER
+      })
+
+      expect(result).toEqual(
+        expect.stringContaining(
+          `Public register | ${config.get('serviceName')}`
+        )
+      )
+
+      const { document } = new JSDOM(result).window
+
+      expect(document.querySelector('h1').textContent.trim()).toBe(
+        'Public register'
+      )
+
+      expect(
+        document.querySelector('.govuk-caption-l').textContent.trim()
+      ).toBe(mockExemption.projectName)
+
+      expect(document.querySelector('#consent').value).toBe(
+        mockExemption.publicRegister.consent
+      )
+
+      expect(
+        document
+          .querySelector('.govuk-back-link[href="/exemption/task-list"')
+          .textContent.trim()
+      ).toBe('Back')
+
+      expect(
+        document
+          .querySelector('.govuk-link[href="/exemption/task-list"')
+          .textContent.trim()
+      ).toBe('Cancel')
+
+      expect(statusCode).toBe(statusCodes.ok)
     })
 
-    expect(result).toEqual(
-      expect.stringContaining(`Public register | ${config.get('serviceName')}`)
-    )
+    test('Should provide expected response and correctly not pre populate data if it is not present', async () => {
+      getExemptionCacheSpy.mockReturnValueOnce({})
 
-    const { document } = new JSDOM(result).window
+      const { result, statusCode } = await server.inject({
+        method: 'GET',
+        url: routes.PUBLIC_REGISTER
+      })
 
-    expect(document.querySelector('h1').textContent.trim()).toBe(
-      'Public register'
-    )
+      expect(result).toEqual(
+        expect.stringContaining(
+          `Public register | ${config.get('serviceName')}`
+        )
+      )
 
-    expect(document.querySelector('.govuk-caption-l').textContent.trim()).toBe(
-      mockExemption.projectName
-    )
+      const { document } = new JSDOM(result).window
 
-    expect(document.querySelector('#consent').value).toBe(
-      mockExemption.publicRegister.consent
-    )
+      expect(document.querySelector('#consent').value).toBe('yes')
+      expect(document.querySelector('#consent:checked')).toBeFalsy()
+      expect(document.querySelector('#consent-2').value).toBe('no')
 
-    expect(
-      document
-        .querySelector('.govuk-back-link[href="/exemption/task-list"')
-        .textContent.trim()
-    ).toBe('Back')
-
-    expect(
-      document
-        .querySelector('.govuk-link[href="/exemption/task-list"')
-        .textContent.trim()
-    ).toBe('Cancel')
-
-    expect(statusCode).toBe(statusCodes.ok)
-  })
-
-  test('Should provide expected response and correctly not pre populate data if it is not present', async () => {
-    getExemptionCacheSpy.mockReturnValueOnce({})
-
-    const { result, statusCode } = await server.inject({
-      method: 'GET',
-      url: routes.PUBLIC_REGISTER
+      expect(statusCode).toBe(statusCodes.ok)
     })
 
-    expect(result).toEqual(
-      expect.stringContaining(`Public register | ${config.get('serviceName')}`)
-    )
+    test('publicRegisterController handler should render with correct context', () => {
+      const h = { view: jest.fn() }
 
-    const { document } = new JSDOM(result).window
+      publicRegisterController.handler({}, h)
 
-    expect(document.querySelector('#consent').value).toBe('yes')
-    expect(document.querySelector('#consent:checked')).toBeFalsy()
-    expect(document.querySelector('#consent-2').value).toBe('no')
-
-    expect(statusCode).toBe(statusCodes.ok)
-  })
-
-  test('Should correctly redirect to the next page on success', async () => {
-    const { statusCode, headers } = await server.inject({
-      method: 'POST',
-      url: routes.PUBLIC_REGISTER,
-      payload: { consent: 'yes', reason: 'Test reason' }
-    })
-
-    expect(Wreck.patch).toHaveBeenCalledWith(
-      `${config.get('backend').apiUrl}/exemption/public-register`,
-      {
+      expect(h.view).toHaveBeenCalledWith(PUBLIC_REGISTER_VIEW_ROUTE, {
+        pageTitle: 'Public register',
+        heading: 'Public register',
+        projectName: mockPublicRegisterState.projectName,
         payload: {
-          id: mockExemption.id,
-          consent: 'yes',
-          reason: 'Test reason'
-        },
-        json: true
-      }
-    )
+          ...mockPublicRegisterState.publicRegister
+        }
+      })
 
-    expect(statusCode).toBe(302)
+      getExemptionCacheSpy.mockResolvedValueOnce(null)
 
-    expect(headers.location).toBe('/exemption/task-list')
-  })
+      publicRegisterController.handler({}, h)
 
-  test('publicRegisterController handler should render with correct context', () => {
-    const h = { view: jest.fn() }
-
-    publicRegisterController.handler({}, h)
-
-    expect(h.view).toHaveBeenCalledWith(PUBLIC_REGISTER_VIEW_ROUTE, {
-      pageTitle: 'Public register',
-      heading: 'Public register',
-      projectName: mockPublicRegisterState.projectName,
-      payload: {
-        ...mockPublicRegisterState.publicRegister
-      }
-    })
-
-    getExemptionCacheSpy.mockResolvedValueOnce(null)
-
-    publicRegisterController.handler({}, h)
-
-    expect(h.view).toHaveBeenNthCalledWith(2, PUBLIC_REGISTER_VIEW_ROUTE, {
-      pageTitle: 'Public register',
-      heading: 'Public register',
-      projectName: undefined,
-      payload: undefined
+      expect(h.view).toHaveBeenNthCalledWith(2, PUBLIC_REGISTER_VIEW_ROUTE, {
+        pageTitle: 'Public register',
+        heading: 'Public register',
+        projectName: undefined,
+        payload: undefined
+      })
     })
   })
 
-  test('Should show error messages with invalid data', async () => {
-    const apiPostMock = jest.spyOn(Wreck, 'patch')
-    apiPostMock.mockRejectedValueOnce({
-      res: { statusCode: 200 },
-      data: {
-        payload: {
-          validation: {
-            source: 'payload',
-            keys: ['consent'],
-            details: [
-              {
-                field: 'consent',
-                message: 'PUBLIC_REGISTER_CONSENT_REQUIRED',
-                type: 'string.empty'
-              }
-            ]
+  describe('#publicRegisterSubmitController', () => {
+    test('Should correctly redirect to the next page on success', async () => {
+      const { statusCode, headers } = await server.inject({
+        method: 'POST',
+        url: routes.PUBLIC_REGISTER,
+        payload: { consent: 'yes', reason: 'Test reason' }
+      })
+
+      expect(Wreck.patch).toHaveBeenCalledWith(
+        `${config.get('backend').apiUrl}/exemption/public-register`,
+        {
+          payload: {
+            id: mockExemption.id,
+            consent: 'yes',
+            reason: 'Test reason'
+          },
+          json: true
+        }
+      )
+
+      expect(statusCode).toBe(302)
+
+      expect(headers.location).toBe('/exemption/task-list')
+    })
+
+    test('Should show error messages with invalid data', async () => {
+      const apiPostMock = jest.spyOn(Wreck, 'patch')
+      apiPostMock.mockRejectedValueOnce({
+        res: { statusCode: 200 },
+        data: {
+          payload: {
+            validation: {
+              source: 'payload',
+              keys: ['consent'],
+              details: [
+                {
+                  field: 'consent',
+                  message: 'PUBLIC_REGISTER_CONSENT_REQUIRED',
+                  type: 'string.empty'
+                }
+              ]
+            }
           }
         }
+      })
+
+      const { result, statusCode } = await server.inject({
+        method: 'POST',
+        url: routes.PUBLIC_REGISTER,
+        payload: { consent: 'no' }
+      })
+
+      expect(result).toEqual(
+        expect.stringContaining(errorMessages.PUBLIC_REGISTER_CONSENT_REQUIRED)
+      )
+
+      const { document } = new JSDOM(result).window
+
+      expect(
+        document.querySelector('.govuk-error-message').textContent.trim()
+      ).toBe(`Error: ${errorMessages.PUBLIC_REGISTER_CONSENT_REQUIRED}`)
+
+      expect(document.querySelector('h2').textContent.trim()).toBe(
+        'There is a problem'
+      )
+
+      expect(document.querySelector('.govuk-error-summary')).toBeTruthy()
+
+      expect(statusCode).toBe(statusCodes.ok)
+    })
+
+    test('Should pass error to global catchAll behaviour if it contains no validation data', async () => {
+      const apiPostMock = jest.spyOn(Wreck, 'patch')
+      apiPostMock.mockRejectedValueOnce({
+        res: { statusCode: 500 },
+        data: {}
+      })
+
+      const { result } = await server.inject({
+        method: 'POST',
+        url: routes.PUBLIC_REGISTER,
+        payload: { consent: 'no' }
+      })
+
+      expect(result).toContain('Something went wrong')
+
+      const { document } = new JSDOM(result).window
+
+      expect(document.querySelector('h1').textContent.trim()).toBe('500')
+    })
+
+    test('Should correctly validate on empty data', () => {
+      const request = {
+        payload: { consent: '' }
       }
-    })
 
-    const { result, statusCode } = await server.inject({
-      method: 'POST',
-      url: routes.PUBLIC_REGISTER,
-      payload: { consent: 'no' }
-    })
-
-    expect(result).toEqual(
-      expect.stringContaining(errorMessages.PUBLIC_REGISTER_CONSENT_REQUIRED)
-    )
-
-    const { document } = new JSDOM(result).window
-
-    expect(
-      document.querySelector('.govuk-error-message').textContent.trim()
-    ).toBe(`Error: ${errorMessages.PUBLIC_REGISTER_CONSENT_REQUIRED}`)
-
-    expect(document.querySelector('h2').textContent.trim()).toBe(
-      'There is a problem'
-    )
-
-    expect(document.querySelector('.govuk-error-summary')).toBeTruthy()
-
-    expect(statusCode).toBe(statusCodes.ok)
-  })
-
-  test('Should pass error to global catchAll behaviour if it contains no validation data', async () => {
-    const apiPostMock = jest.spyOn(Wreck, 'patch')
-    apiPostMock.mockRejectedValueOnce({
-      res: { statusCode: 500 },
-      data: {}
-    })
-
-    const { result } = await server.inject({
-      method: 'POST',
-      url: routes.PUBLIC_REGISTER,
-      payload: { consent: 'no' }
-    })
-
-    expect(result).toContain('Something went wrong')
-
-    const { document } = new JSDOM(result).window
-
-    expect(document.querySelector('h1').textContent.trim()).toBe('500')
-  })
-
-  test('Should correctly validate on empty data', () => {
-    const request = {
-      payload: { consent: '' }
-    }
-
-    const h = {
-      view: jest.fn().mockReturnValue({
-        takeover: jest.fn()
-      })
-    }
-
-    const err = {
-      details: [
-        {
-          path: ['consent'],
-          message: 'TEST',
-          type: 'string.empty'
-        }
-      ]
-    }
-
-    publicRegisterSubmitController.options.validate.failAction(request, h, err)
-
-    expect(h.view).toHaveBeenCalledWith(PUBLIC_REGISTER_VIEW_ROUTE, {
-      heading: 'Public register',
-      pageTitle: 'Public register',
-      projectName: 'Test Project',
-      payload: { consent: '' },
-      errorSummary: [
-        {
-          href: '#consent',
-          text: 'TEST',
-          field: ['consent']
-        }
-      ],
-      errors: {
-        consent: {
-          field: ['consent'],
-          href: '#consent',
-          text: 'TEST'
-        }
+      const h = {
+        view: jest.fn().mockReturnValue({
+          takeover: jest.fn()
+        })
       }
-    })
 
-    expect(h.view().takeover).toHaveBeenCalled()
-  })
+      const err = {
+        details: [
+          {
+            path: ['consent'],
+            message: 'TEST',
+            type: 'string.empty'
+          }
+        ]
+      }
 
-  test('Should correctly handle an incorrectly formed error object', () => {
-    const request = {
-      payload: { consent: '' }
-    }
+      publicRegisterSubmitController.options.validate.failAction(
+        request,
+        h,
+        err
+      )
 
-    const h = {
-      view: jest.fn().mockReturnValue({
-        takeover: jest.fn()
+      expect(h.view).toHaveBeenCalledWith(PUBLIC_REGISTER_VIEW_ROUTE, {
+        pageTitle: 'Public register',
+        heading: 'Public register',
+        projectName: mockExemption.projectName,
+        payload: { consent: '' },
+        errorSummary: [
+          {
+            href: '#consent',
+            text: 'TEST',
+            field: ['consent']
+          }
+        ],
+        errors: {
+          consent: {
+            field: ['consent'],
+            href: '#consent',
+            text: 'TEST'
+          }
+        }
       })
-    }
 
-    const err = {
-      details: null
-    }
-
-    publicRegisterSubmitController.options.validate.failAction(request, h, err)
-
-    expect(h.view).toHaveBeenCalledWith(PUBLIC_REGISTER_VIEW_ROUTE, {
-      heading: 'Public register',
-      pageTitle: 'Public register',
-      projectName: 'Test Project',
-      payload: { consent: '' }
+      expect(h.view().takeover).toHaveBeenCalled()
     })
 
-    expect(h.view().takeover).toHaveBeenCalled()
-  })
+    test('Should correctly handle an incorrectly formed error object', () => {
+      const request = {
+        payload: { consent: '' }
+      }
 
-  test('Should correctly validate on empty data and handle a scenario where error details are missing', () => {
-    const request = {
-      payload: { consent: '' }
-    }
+      const h = {
+        view: jest.fn().mockReturnValue({
+          takeover: jest.fn()
+        })
+      }
 
-    const h = {
-      view: jest.fn().mockReturnValue({
-        takeover: jest.fn()
+      const err = {
+        details: null
+      }
+
+      publicRegisterSubmitController.options.validate.failAction(
+        request,
+        h,
+        err
+      )
+
+      expect(h.view).toHaveBeenCalledWith(PUBLIC_REGISTER_VIEW_ROUTE, {
+        heading: 'Public register',
+        pageTitle: 'Public register',
+        projectName: 'Test Project',
+        payload: { consent: '' }
       })
-    }
 
-    publicRegisterSubmitController.options.validate.failAction(request, h, {})
-
-    expect(h.view).toHaveBeenCalledWith(PUBLIC_REGISTER_VIEW_ROUTE, {
-      heading: 'Public register',
-      pageTitle: 'Public register',
-      projectName: 'Test Project',
-      payload: { consent: '' }
+      expect(h.view().takeover).toHaveBeenCalled()
     })
 
-    expect(h.view().takeover).toHaveBeenCalled()
-  })
+    test('Should correctly validate on empty data and handle a scenario where error details are missing', () => {
+      const request = {
+        payload: { consent: '' }
+      }
 
-  test('Should correctly validate on invalid data', () => {
-    const request = {
-      payload: { consent: 'invalid' }
-    }
+      const h = {
+        view: jest.fn().mockReturnValue({
+          takeover: jest.fn()
+        })
+      }
 
-    const h = {
-      view: jest.fn().mockReturnValue({
-        takeover: jest.fn()
+      publicRegisterSubmitController.options.validate.failAction(request, h, {})
+
+      expect(h.view).toHaveBeenCalledWith(PUBLIC_REGISTER_VIEW_ROUTE, {
+        heading: 'Public register',
+        pageTitle: 'Public register',
+        projectName: 'Test Project',
+        payload: { consent: '' }
       })
-    }
 
-    publicRegisterSubmitController.options.validate.failAction(request, h, {})
-
-    expect(h.view).toHaveBeenCalledWith(PUBLIC_REGISTER_VIEW_ROUTE, {
-      heading: 'Public register',
-      pageTitle: 'Public register',
-      projectName: 'Test Project',
-      payload: { consent: 'invalid' }
+      expect(h.view().takeover).toHaveBeenCalled()
     })
 
-    expect(h.view().takeover).toHaveBeenCalled()
-  })
+    test('Should correctly validate on invalid data', () => {
+      const request = {
+        payload: { consent: 'invalid' }
+      }
 
-  test('Should show error messages without calling the back end when payload data is empty', async () => {
-    const apiPostMock = jest.spyOn(Wreck, 'post')
+      const h = {
+        view: jest.fn().mockReturnValue({
+          takeover: jest.fn()
+        })
+      }
 
-    const { result } = await server.inject({
-      method: 'POST',
-      url: routes.PUBLIC_REGISTER,
-      payload: { consent: '' }
+      publicRegisterSubmitController.options.validate.failAction(request, h, {})
+
+      expect(h.view).toHaveBeenCalledWith(PUBLIC_REGISTER_VIEW_ROUTE, {
+        heading: 'Public register',
+        pageTitle: 'Public register',
+        projectName: 'Test Project',
+        payload: { consent: 'invalid' }
+      })
+
+      expect(h.view().takeover).toHaveBeenCalled()
     })
 
-    expect(apiPostMock).not.toHaveBeenCalled()
+    test('Should show error messages without calling the back end when payload data is empty', async () => {
+      const apiPostMock = jest.spyOn(Wreck, 'post')
 
-    const { document } = new JSDOM(result).window
+      const { result } = await server.inject({
+        method: 'POST',
+        url: routes.PUBLIC_REGISTER,
+        payload: { consent: '' }
+      })
 
-    expect(document.querySelector('.govuk-error-summary')).toBeTruthy()
-  })
+      expect(apiPostMock).not.toHaveBeenCalled()
 
-  test('Should show error for reason being empty when consent is set to yes', async () => {
-    const apiPostMock = jest.spyOn(Wreck, 'post')
+      const { document } = new JSDOM(result).window
 
-    const { result } = await server.inject({
-      method: 'POST',
-      url: routes.PUBLIC_REGISTER,
-      payload: { consent: 'yes' }
+      expect(document.querySelector('.govuk-error-summary')).toBeTruthy()
     })
 
-    expect(apiPostMock).not.toHaveBeenCalled()
+    test('Should show error for reason being empty when consent is set to yes', async () => {
+      const apiPostMock = jest.spyOn(Wreck, 'post')
 
-    const { document } = new JSDOM(result).window
+      const { result } = await server.inject({
+        method: 'POST',
+        url: routes.PUBLIC_REGISTER,
+        payload: { consent: 'yes' }
+      })
 
-    expect(result).toEqual(
-      expect.stringContaining(errorMessages.PUBLIC_REGISTER_REASON_REQUIRED)
-    )
+      expect(apiPostMock).not.toHaveBeenCalled()
 
-    expect(document.querySelector('.govuk-error-summary')).toBeTruthy()
-  })
+      const { document } = new JSDOM(result).window
 
-  test('Should correctly set the cache when submitting public register', async () => {
-    const h = {
-      redirect: jest.fn().mockReturnValue({
-        takeover: jest.fn()
-      }),
-      view: jest.fn()
-    }
+      expect(result).toEqual(
+        expect.stringContaining(errorMessages.PUBLIC_REGISTER_REASON_REQUIRED)
+      )
 
-    const mockRequest = { payload: { consent: 'yes', reason: 'Test reason' } }
+      expect(document.querySelector('.govuk-error-summary')).toBeTruthy()
+    })
 
-    await publicRegisterSubmitController.handler(
-      { payload: { consent: 'yes', reason: 'Test reason' } },
-      h
-    )
-    expect(cacheUtils.setExemptionCache).toHaveBeenCalledWith(
-      mockRequest,
-      mockExemption
-    )
+    test('Should correctly set the cache when submitting public register', async () => {
+      const h = {
+        redirect: jest.fn().mockReturnValue({
+          takeover: jest.fn()
+        }),
+        view: jest.fn()
+      }
+
+      const mockRequest = { payload: { consent: 'yes', reason: 'Test reason' } }
+
+      await publicRegisterSubmitController.handler(
+        { payload: { consent: 'yes', reason: 'Test reason' } },
+        h
+      )
+      expect(cacheUtils.setExemptionCache).toHaveBeenCalledWith(
+        mockRequest,
+        mockExemption
+      )
+    })
   })
 })
 

--- a/src/server/exemption/site-details/coordinate-system/controller.test.js
+++ b/src/server/exemption/site-details/coordinate-system/controller.test.js
@@ -34,245 +34,249 @@ describe('#coordinateSystem', () => {
     await server.stop({ timeout: 0 })
   })
 
-  test('coordinateSystemController handler should render with correct context with no existing data', () => {
-    getExemptionCacheSpy.mockReturnValueOnce({})
-    const h = { view: jest.fn() }
+  describe('#coordinateSystemController', () => {
+    test('coordinateSystemController handler should render with correct context with no existing data', () => {
+      getExemptionCacheSpy.mockReturnValueOnce({})
+      const h = { view: jest.fn() }
 
-    coordinateSystemController.handler({}, h)
+      coordinateSystemController.handler({}, h)
 
-    expect(h.view).toHaveBeenCalledWith(COORDINATE_SYSTEM_VIEW_ROUTE, {
-      pageTitle: 'Which coordinate system do you want to use?',
-      heading: 'Which coordinate system do you want to use?',
-      backLink: routes.COORDINATES_ENTRY_CHOICE,
-      payload: { coordinateSystem: undefined },
-      projectName: undefined
+      expect(h.view).toHaveBeenCalledWith(COORDINATE_SYSTEM_VIEW_ROUTE, {
+        pageTitle: 'Which coordinate system do you want to use?',
+        heading: 'Which coordinate system do you want to use?',
+        backLink: routes.COORDINATES_ENTRY_CHOICE,
+        payload: { coordinateSystem: undefined },
+        projectName: undefined
+      })
+    })
+
+    test('coordinateSystemController handler should render with correct context', () => {
+      const h = { view: jest.fn() }
+
+      coordinateSystemController.handler({}, h)
+
+      expect(h.view).toHaveBeenCalledWith(COORDINATE_SYSTEM_VIEW_ROUTE, {
+        pageTitle: 'Which coordinate system do you want to use?',
+        heading: 'Which coordinate system do you want to use?',
+        backLink: routes.COORDINATES_ENTRY_CHOICE,
+        payload: { coordinateSystem: 'osgb36' },
+        projectName: 'Test Project'
+      })
+    })
+
+    test('coordinateSystemController handler should render with correct context with existing cache data', () => {
+      getExemptionCacheSpy.mockReturnValueOnce({
+        projectName: mockExemption.projectName,
+        siteDetails: {
+          coordinateSystem: 'wgs84'
+        }
+      })
+
+      const h = { view: jest.fn() }
+
+      coordinateSystemController.handler({}, h)
+
+      expect(h.view).toHaveBeenCalledWith(COORDINATE_SYSTEM_VIEW_ROUTE, {
+        pageTitle: 'Which coordinate system do you want to use?',
+        heading: 'Which coordinate system do you want to use?',
+        backLink: routes.COORDINATES_ENTRY_CHOICE,
+        payload: { coordinateSystem: 'wgs84' },
+        projectName: 'Test Project'
+      })
+    })
+
+    test('Should provide expected response and correctly pre populate data', async () => {
+      const { result, statusCode } = await server.inject({
+        method: 'GET',
+        url: routes.COORDINATE_SYSTEM_CHOICE
+      })
+
+      expect(result).toEqual(
+        expect.stringContaining(
+          `Which coordinate system do you want to use? | ${config.get('serviceName')}`
+        )
+      )
+
+      const { document } = new JSDOM(result).window
+
+      expect(document.querySelector('h1').textContent.trim()).toContain(
+        'Which coordinate system do you want to use?'
+      )
+      expect(document.querySelector('h1').innerHTML.trim()).toContain(
+        '<span class="govuk-caption-l">Test Project</span>'
+      )
+
+      expect(
+        document.querySelector('.govuk-caption-l').textContent.trim()
+      ).toBe(mockExemption.projectName)
+
+      expect(document.querySelector('#coordinateSystem').value).toBe('wgs84')
+      expect(document.querySelector('#coordinateSystem-2').value).toBe('osgb36')
+
+      const hint = document.querySelector('.govuk-hint')
+      expect(hint.hasAttribute('open')).toBe(false)
+      expect(hint.innerHTML).toContain(
+        '<h2 class="govuk-heading-s">WGS84 (World Geodetic System 1984)</h2>'
+      )
+      expect(hint.innerHTML).toContain(
+        '<h2 class="govuk-heading-s">OSGB36 (National Grid)</h2>'
+      )
+
+      const hintSummary = document.querySelector('.govuk-details__summary-text')
+      expect(hintSummary.textContent.trim()).toBe(
+        'Help with the coordinate systems'
+      )
+
+      expect(
+        document
+          .querySelector(
+            '.govuk-back-link[href="/exemption/how-do-you-want-to-enter-the-coordinates"'
+          )
+          .textContent.trim()
+      ).toBe('Back')
+
+      expect(
+        document
+          .querySelector('.govuk-link[href="/exemption/task-list"')
+          .textContent.trim()
+      ).toBe('Cancel')
+
+      expect(statusCode).toBe(statusCodes.ok)
     })
   })
 
-  test('coordinateSystemController handler should render with correct context', () => {
-    const h = { view: jest.fn() }
+  describe('#coordinateSystemSubmitController', () => {
+    test('Should correctly format error data', () => {
+      const request = {
+        payload: { coordinateSystem: 'invalid' }
+      }
 
-    coordinateSystemController.handler({}, h)
+      const h = {
+        view: jest.fn().mockReturnValue({
+          takeover: jest.fn()
+        })
+      }
 
-    expect(h.view).toHaveBeenCalledWith(COORDINATE_SYSTEM_VIEW_ROUTE, {
-      pageTitle: 'Which coordinate system do you want to use?',
-      heading: 'Which coordinate system do you want to use?',
-      backLink: routes.COORDINATES_ENTRY_CHOICE,
-      payload: { coordinateSystem: 'osgb36' },
-      projectName: 'Test Project'
+      const err = {
+        details: [
+          {
+            path: ['coordinateSystem'],
+            message: 'TEST',
+            type: 'any.only'
+          }
+        ]
+      }
+
+      coordinateSystemSubmitController.options.validate.failAction(
+        request,
+        h,
+        err
+      )
+
+      expect(h.view).toHaveBeenCalledWith(COORDINATE_SYSTEM_VIEW_ROUTE, {
+        pageTitle: 'Which coordinate system do you want to use?',
+        heading: 'Which coordinate system do you want to use?',
+        projectName: 'Test Project',
+        backLink: routes.COORDINATES_ENTRY_CHOICE,
+        payload: { coordinateSystem: 'invalid' },
+        errorSummary: [
+          {
+            href: '#coordinateSystem',
+            text: 'TEST',
+            field: ['coordinateSystem']
+          }
+        ],
+        errors: {
+          coordinateSystem: {
+            field: ['coordinateSystem'],
+            href: '#coordinateSystem',
+            text: 'TEST'
+          }
+        }
+      })
+
+      expect(h.view().takeover).toHaveBeenCalled()
     })
-  })
 
-  test('coordinateSystemController handler should render with correct context with existing cache data', () => {
-    getExemptionCacheSpy.mockReturnValueOnce({
-      projectName: mockExemption.projectName,
-      siteDetails: {
+    test('Should still render page if no error details are provided', () => {
+      const request = {
+        payload: { coordinateSystem: 'invalid' }
+      }
+
+      const h = {
+        view: jest.fn().mockReturnValue({
+          takeover: jest.fn()
+        })
+      }
+
+      const err = {}
+
+      coordinateSystemSubmitController.options.validate.failAction(
+        request,
+        h,
+        err
+      )
+
+      expect(h.view).toHaveBeenCalledWith(COORDINATE_SYSTEM_VIEW_ROUTE, {
+        pageTitle: 'Which coordinate system do you want to use?',
+        heading: 'Which coordinate system do you want to use?',
+        projectName: 'Test Project',
+        backLink: routes.COORDINATES_ENTRY_CHOICE,
+        payload: { coordinateSystem: 'invalid' }
+      })
+
+      expect(h.view().takeover).toHaveBeenCalled()
+    })
+
+    test('Should correctly validate on valid data', () => {
+      const request = {
         coordinateSystem: 'wgs84'
       }
+
+      const payloadValidator =
+        coordinateSystemSubmitController.options.validate.payload
+
+      const result = payloadValidator.validate(request)
+
+      expect(result.error).toBeUndefined()
     })
 
-    const h = { view: jest.fn() }
+    test('Should correctly validate on empty data', () => {
+      const request = {}
 
-    coordinateSystemController.handler({}, h)
+      const payloadValidator =
+        coordinateSystemSubmitController.options.validate.payload
 
-    expect(h.view).toHaveBeenCalledWith(COORDINATE_SYSTEM_VIEW_ROUTE, {
-      pageTitle: 'Which coordinate system do you want to use?',
-      heading: 'Which coordinate system do you want to use?',
-      backLink: routes.COORDINATES_ENTRY_CHOICE,
-      payload: { coordinateSystem: 'wgs84' },
-      projectName: 'Test Project'
-    })
-  })
+      const result = payloadValidator.validate(request)
 
-  test('Should provide expected response and correctly pre populate data', async () => {
-    const { result, statusCode } = await server.inject({
-      method: 'GET',
-      url: routes.COORDINATE_SYSTEM_CHOICE
+      expect(result.error.message).toBe('COORDINATE_SYSTEM_REQUIRED')
     })
 
-    expect(result).toEqual(
-      expect.stringContaining(
-        `Which coordinate system do you want to use? | ${config.get('serviceName')}`
-      )
-    )
+    test('Should correctly validate on invalid data', () => {
+      const request = { coordinateSystem: 'invalid' }
 
-    const { document } = new JSDOM(result).window
+      const payloadValidator =
+        coordinateSystemSubmitController.options.validate.payload
 
-    expect(document.querySelector('h1').textContent.trim()).toContain(
-      'Which coordinate system do you want to use?'
-    )
-    expect(document.querySelector('h1').innerHTML.trim()).toContain(
-      '<span class="govuk-caption-l">Test Project</span>'
-    )
+      const result = payloadValidator.validate(request)
 
-    expect(document.querySelector('.govuk-caption-l').textContent.trim()).toBe(
-      mockExemption.projectName
-    )
+      expect(result.error.message).toBe('COORDINATE_SYSTEM_REQUIRED')
+    })
 
-    expect(document.querySelector('#coordinateSystem').value).toBe('wgs84')
-    expect(document.querySelector('#coordinateSystem-2').value).toBe('osgb36')
-
-    const hint = document.querySelector('.govuk-hint')
-    expect(hint.hasAttribute('open')).toBe(false)
-    expect(hint.innerHTML).toContain(
-      '<h2 class="govuk-heading-s">WGS84 (World Geodetic System 1984)</h2>'
-    )
-    expect(hint.innerHTML).toContain(
-      '<h2 class="govuk-heading-s">OSGB36 (National Grid)</h2>'
-    )
-
-    const hintSummary = document.querySelector('.govuk-details__summary-text')
-    expect(hintSummary.textContent.trim()).toBe(
-      'Help with the coordinate systems'
-    )
-
-    expect(
-      document
-        .querySelector(
-          '.govuk-back-link[href="/exemption/how-do-you-want-to-enter-the-coordinates"'
-        )
-        .textContent.trim()
-    ).toBe('Back')
-
-    expect(
-      document
-        .querySelector('.govuk-link[href="/exemption/task-list"')
-        .textContent.trim()
-    ).toBe('Cancel')
-
-    expect(statusCode).toBe(statusCodes.ok)
-  })
-
-  test('Should correctly format error data', () => {
-    const request = {
-      payload: { coordinateSystem: 'invalid' }
-    }
-
-    const h = {
-      view: jest.fn().mockReturnValue({
-        takeover: jest.fn()
-      })
-    }
-
-    const err = {
-      details: [
-        {
-          path: ['coordinateSystem'],
-          message: 'TEST',
-          type: 'any.only'
-        }
-      ]
-    }
-
-    coordinateSystemSubmitController.options.validate.failAction(
-      request,
-      h,
-      err
-    )
-
-    expect(h.view).toHaveBeenCalledWith(COORDINATE_SYSTEM_VIEW_ROUTE, {
-      pageTitle: 'Which coordinate system do you want to use?',
-      heading: 'Which coordinate system do you want to use?',
-      projectName: 'Test Project',
-      backLink: routes.COORDINATES_ENTRY_CHOICE,
-      payload: { coordinateSystem: 'invalid' },
-      errorSummary: [
-        {
-          href: '#coordinateSystem',
-          text: 'TEST',
-          field: ['coordinateSystem']
-        }
-      ],
-      errors: {
-        coordinateSystem: {
-          field: ['coordinateSystem'],
-          href: '#coordinateSystem',
-          text: 'TEST'
-        }
+    test('Should correctly set the cache when submitting', async () => {
+      const h = {
+        view: jest.fn()
       }
+
+      const mockRequest = { payload: { coordinateSystem: 'wgs84' } }
+
+      await coordinateSystemSubmitController.handler(mockRequest, h)
+
+      expect(cacheUtils.updateExemptionSiteDetails).toHaveBeenCalledWith(
+        mockRequest,
+        'coordinateSystem',
+        'wgs84'
+      )
     })
-
-    expect(h.view().takeover).toHaveBeenCalled()
-  })
-
-  test('Should still render page if no error details are provided', () => {
-    const request = {
-      payload: { coordinateSystem: 'invalid' }
-    }
-
-    const h = {
-      view: jest.fn().mockReturnValue({
-        takeover: jest.fn()
-      })
-    }
-
-    const err = {}
-
-    coordinateSystemSubmitController.options.validate.failAction(
-      request,
-      h,
-      err
-    )
-
-    expect(h.view).toHaveBeenCalledWith(COORDINATE_SYSTEM_VIEW_ROUTE, {
-      pageTitle: 'Which coordinate system do you want to use?',
-      heading: 'Which coordinate system do you want to use?',
-      projectName: 'Test Project',
-      backLink: routes.COORDINATES_ENTRY_CHOICE,
-      payload: { coordinateSystem: 'invalid' }
-    })
-
-    expect(h.view().takeover).toHaveBeenCalled()
-  })
-
-  test('Should correctly validate on valid data', () => {
-    const request = {
-      coordinateSystem: 'wgs84'
-    }
-
-    const payloadValidator =
-      coordinateSystemSubmitController.options.validate.payload
-
-    const result = payloadValidator.validate(request)
-
-    expect(result.error).toBeUndefined()
-  })
-
-  test('Should correctly validate on empty data', () => {
-    const request = {}
-
-    const payloadValidator =
-      coordinateSystemSubmitController.options.validate.payload
-
-    const result = payloadValidator.validate(request)
-
-    expect(result.error.message).toBe('COORDINATE_SYSTEM_REQUIRED')
-  })
-
-  test('Should correctly validate on invalid data', () => {
-    const request = { coordinateSystem: 'invalid' }
-
-    const payloadValidator =
-      coordinateSystemSubmitController.options.validate.payload
-
-    const result = payloadValidator.validate(request)
-
-    expect(result.error.message).toBe('COORDINATE_SYSTEM_REQUIRED')
-  })
-
-  test('Should correctly set the cache when submitting', async () => {
-    const h = {
-      view: jest.fn()
-    }
-
-    const mockRequest = { payload: { coordinateSystem: 'wgs84' } }
-
-    await coordinateSystemSubmitController.handler(mockRequest, h)
-
-    expect(cacheUtils.updateExemptionSiteDetails).toHaveBeenCalledWith(
-      mockRequest,
-      'coordinateSystem',
-      'wgs84'
-    )
   })
 })

--- a/src/server/exemption/site-details/coordinates-type/controller.test.js
+++ b/src/server/exemption/site-details/coordinates-type/controller.test.js
@@ -13,7 +13,7 @@ import { routes } from '~/src/server/common/constants/routes.js'
 
 jest.mock('~/src/server/common/helpers/session-cache/utils.js')
 
-describe('#coordinatesTypeController', () => {
+describe('#coordinatesType', () => {
   /** @type {Server} */
   let server
   let getExemptionCacheSpy
@@ -34,246 +34,274 @@ describe('#coordinatesTypeController', () => {
     await server.stop({ timeout: 0 })
   })
 
-  test('coordinatesTypeController handler should render with correct context', () => {
-    const h = { view: jest.fn() }
+  describe('#coordinatesTypeController', () => {
+    test('coordinatesTypeController handler should render with correct context', () => {
+      const h = { view: jest.fn() }
 
-    coordinatesTypeController.handler({}, h)
+      coordinatesTypeController.handler({}, h)
 
-    expect(h.view).toHaveBeenCalledWith(PROVIDE_COORDINATES_CHOICE_VIEW_ROUTE, {
-      pageTitle: 'How do you want to provide the site location?',
-      heading: 'How do you want to provide the site location?',
-      payload: { coordinatesType: 'coordinates' },
-      projectName: 'Test Project'
-    })
-  })
-
-  test('coordinatesTypeController handler should render with correct context with no existing cache data', () => {
-    getExemptionCacheSpy.mockReturnValueOnce({
-      projectName: mockExemption.projectName
-    })
-
-    const h = { view: jest.fn() }
-
-    coordinatesTypeController.handler({}, h)
-
-    expect(h.view).toHaveBeenCalledWith(PROVIDE_COORDINATES_CHOICE_VIEW_ROUTE, {
-      pageTitle: 'How do you want to provide the site location?',
-      heading: 'How do you want to provide the site location?',
-      payload: { coordinatesType: undefined },
-      projectName: 'Test Project'
-    })
-  })
-
-  test('Should provide expected response and correctly pre populate data', async () => {
-    const { result, statusCode } = await server.inject({
-      method: 'GET',
-      url: routes.COORDINATES_TYPE_CHOICE
-    })
-
-    expect(result).toEqual(
-      expect.stringContaining(
-        `How do you want to provide the site location? | ${config.get('serviceName')}`
+      expect(h.view).toHaveBeenCalledWith(
+        PROVIDE_COORDINATES_CHOICE_VIEW_ROUTE,
+        {
+          pageTitle: 'How do you want to provide the site location?',
+          heading: 'How do you want to provide the site location?',
+          payload: { coordinatesType: 'coordinates' },
+          projectName: 'Test Project'
+        }
       )
-    )
+    })
 
-    const { document } = new JSDOM(result).window
+    test('coordinatesTypeController handler should render with correct context with no existing cache data', () => {
+      getExemptionCacheSpy.mockReturnValueOnce({
+        projectName: mockExemption.projectName
+      })
 
-    expect(document.querySelector('h1').textContent.trim()).toContain(
-      'How do you want to provide the site location?'
-    )
-    expect(document.querySelector('h1').innerHTML.trim()).toContain(
-      '<span class="govuk-caption-l">Test Project</span>'
-    )
+      const h = { view: jest.fn() }
 
-    expect(document.querySelector('.govuk-caption-l').textContent.trim()).toBe(
-      mockExemption.projectName
-    )
+      coordinatesTypeController.handler({}, h)
 
-    expect(document.querySelector('#coordinatesType').value).toBe('file')
+      expect(h.view).toHaveBeenCalledWith(
+        PROVIDE_COORDINATES_CHOICE_VIEW_ROUTE,
+        {
+          pageTitle: 'How do you want to provide the site location?',
+          heading: 'How do you want to provide the site location?',
+          payload: { coordinatesType: undefined },
+          projectName: 'Test Project'
+        }
+      )
+    })
 
-    expect(document.querySelector('#coordinatesType-2').value).toBe(
-      'coordinates'
-    )
+    test('Should provide expected response and correctly pre populate data', async () => {
+      const { result, statusCode } = await server.inject({
+        method: 'GET',
+        url: routes.COORDINATES_TYPE_CHOICE
+      })
 
-    expect(document.querySelector('#coordinatesType-2').checked).toBe(true)
+      expect(result).toEqual(
+        expect.stringContaining(
+          `How do you want to provide the site location? | ${config.get('serviceName')}`
+        )
+      )
 
-    expect(
-      document
-        .querySelector('.govuk-back-link[href="/exemption/task-list"')
-        .textContent.trim()
-    ).toBe('Back')
+      const { document } = new JSDOM(result).window
 
-    expect(
-      document
-        .querySelector('.govuk-link[href="/exemption/task-list"')
-        .textContent.trim()
-    ).toBe('Cancel')
+      expect(document.querySelector('h1').textContent.trim()).toContain(
+        'How do you want to provide the site location?'
+      )
+      expect(document.querySelector('h1').innerHTML.trim()).toContain(
+        '<span class="govuk-caption-l">Test Project</span>'
+      )
 
-    expect(statusCode).toBe(statusCodes.ok)
+      expect(
+        document.querySelector('.govuk-caption-l').textContent.trim()
+      ).toBe(mockExemption.projectName)
+
+      expect(document.querySelector('#coordinatesType').value).toBe('file')
+
+      expect(document.querySelector('#coordinatesType-2').value).toBe(
+        'coordinates'
+      )
+
+      expect(document.querySelector('#coordinatesType-2').checked).toBe(true)
+
+      expect(
+        document
+          .querySelector('.govuk-back-link[href="/exemption/task-list"')
+          .textContent.trim()
+      ).toBe('Back')
+
+      expect(
+        document
+          .querySelector('.govuk-link[href="/exemption/task-list"')
+          .textContent.trim()
+      ).toBe('Cancel')
+
+      expect(statusCode).toBe(statusCodes.ok)
+    })
   })
 
-  test('Should correctly format error data', () => {
-    const request = {
-      payload: { coordinatesType: 'invalid' }
-    }
-
-    const h = {
-      view: jest.fn().mockReturnValue({
-        takeover: jest.fn()
-      })
-    }
-
-    const err = {
-      details: [
-        {
-          path: ['coordinatesType'],
-          message: 'TEST',
-          type: 'any.only'
-        }
-      ]
-    }
-
-    coordinatesTypeSubmitController.options.validate.failAction(request, h, err)
-
-    expect(h.view).toHaveBeenCalledWith(PROVIDE_COORDINATES_CHOICE_VIEW_ROUTE, {
-      pageTitle: 'How do you want to provide the site location?',
-      heading: 'How do you want to provide the site location?',
-      projectName: 'Test Project',
-      payload: { coordinatesType: 'invalid' },
-      errorSummary: [
-        {
-          href: '#coordinatesType',
-          text: 'TEST',
-          field: ['coordinatesType']
-        }
-      ],
-      errors: {
-        coordinatesType: {
-          field: ['coordinatesType'],
-          href: '#coordinatesType',
-          text: 'TEST'
-        }
+  describe('#coordinatesTypeSubmitController', () => {
+    test('Should correctly format error data', () => {
+      const request = {
+        payload: { coordinatesType: 'invalid' }
       }
+
+      const h = {
+        view: jest.fn().mockReturnValue({
+          takeover: jest.fn()
+        })
+      }
+
+      const err = {
+        details: [
+          {
+            path: ['coordinatesType'],
+            message: 'TEST',
+            type: 'any.only'
+          }
+        ]
+      }
+
+      coordinatesTypeSubmitController.options.validate.failAction(
+        request,
+        h,
+        err
+      )
+
+      expect(h.view).toHaveBeenCalledWith(
+        PROVIDE_COORDINATES_CHOICE_VIEW_ROUTE,
+        {
+          pageTitle: 'How do you want to provide the site location?',
+          heading: 'How do you want to provide the site location?',
+          projectName: 'Test Project',
+          payload: { coordinatesType: 'invalid' },
+          errorSummary: [
+            {
+              href: '#coordinatesType',
+              text: 'TEST',
+              field: ['coordinatesType']
+            }
+          ],
+          errors: {
+            coordinatesType: {
+              field: ['coordinatesType'],
+              href: '#coordinatesType',
+              text: 'TEST'
+            }
+          }
+        }
+      )
+
+      expect(h.view().takeover).toHaveBeenCalled()
     })
 
-    expect(h.view().takeover).toHaveBeenCalled()
-  })
+    test('Should correctly output page with no error data in object', () => {
+      const request = {
+        payload: { coordinatesType: 'invalid' }
+      }
 
-  test('Should correctly output page with no error data in object', () => {
-    const request = {
-      payload: { coordinatesType: 'invalid' }
-    }
+      const h = {
+        view: jest.fn().mockReturnValue({
+          takeover: jest.fn()
+        })
+      }
 
-    const h = {
-      view: jest.fn().mockReturnValue({
-        takeover: jest.fn()
-      })
-    }
+      coordinatesTypeSubmitController.options.validate.failAction(
+        request,
+        h,
+        {}
+      )
 
-    coordinatesTypeSubmitController.options.validate.failAction(request, h, {})
+      expect(h.view).toHaveBeenCalledWith(
+        PROVIDE_COORDINATES_CHOICE_VIEW_ROUTE,
+        {
+          pageTitle: 'How do you want to provide the site location?',
+          heading: 'How do you want to provide the site location?',
+          projectName: 'Test Project',
+          payload: { coordinatesType: 'invalid' }
+        }
+      )
 
-    expect(h.view).toHaveBeenCalledWith(PROVIDE_COORDINATES_CHOICE_VIEW_ROUTE, {
-      pageTitle: 'How do you want to provide the site location?',
-      heading: 'How do you want to provide the site location?',
-      projectName: 'Test Project',
-      payload: { coordinatesType: 'invalid' }
+      expect(h.view().takeover).toHaveBeenCalled()
     })
 
-    expect(h.view().takeover).toHaveBeenCalled()
-  })
+    test('Should correctly validate on valid data', () => {
+      const request = {
+        coordinatesType: 'file'
+      }
 
-  test('Should correctly validate on valid data', () => {
-    const request = {
-      coordinatesType: 'file'
-    }
+      const payloadValidator =
+        coordinatesTypeSubmitController.options.validate.payload
 
-    const payloadValidator =
-      coordinatesTypeSubmitController.options.validate.payload
+      const result = payloadValidator.validate(request)
 
-    const result = payloadValidator.validate(request)
-
-    expect(result.error).toBeUndefined()
-  })
-
-  test('Should correctly validate on empty data', () => {
-    const request = {}
-
-    const payloadValidator =
-      coordinatesTypeSubmitController.options.validate.payload
-
-    const result = payloadValidator.validate(request)
-
-    expect(result.error.message).toBe('PROVIDE_COORDINATES_CHOICE_REQUIRED')
-  })
-
-  test('Should correctly validate on invalid data', () => {
-    const request = { coordinatesType: 'invalid' }
-
-    const payloadValidator =
-      coordinatesTypeSubmitController.options.validate.payload
-
-    const result = payloadValidator.validate(request)
-
-    expect(result.error.message).toBe('PROVIDE_COORDINATES_CHOICE_REQUIRED')
-  })
-
-  test('Should correctly remain on the same page when file option is selected', async () => {
-    const h = {
-      view: jest.fn(),
-      redirect: jest.fn().mockReturnValue({
-        takeover: jest.fn()
-      })
-    }
-
-    await coordinatesTypeSubmitController.handler(
-      { payload: { coordinatesType: 'file' } },
-      h
-    )
-
-    expect(h.view).toHaveBeenCalledWith(PROVIDE_COORDINATES_CHOICE_VIEW_ROUTE, {
-      pageTitle: 'How do you want to provide the site location?',
-      heading: 'How do you want to provide the site location?',
-      payload: { coordinatesType: 'file' },
-      projectName: mockExemption.projectName
+      expect(result.error).toBeUndefined()
     })
-    expect(h.redirect).not.toHaveBeenCalled()
-  })
 
-  test('Should correctly redirect to coordinates entry page when coordinates option is selected', async () => {
-    const h = {
-      view: jest.fn(),
-      redirect: jest.fn().mockReturnValue({
-        takeover: jest.fn()
-      })
-    }
+    test('Should correctly validate on empty data', () => {
+      const request = {}
 
-    await coordinatesTypeSubmitController.handler(
-      { payload: { coordinatesType: 'coordinates' } },
-      h
-    )
+      const payloadValidator =
+        coordinatesTypeSubmitController.options.validate.payload
 
-    expect(h.redirect).toHaveBeenCalledWith(routes.COORDINATES_ENTRY_CHOICE)
-    expect(h.redirect().takeover).toHaveBeenCalled()
-    expect(h.view).not.toHaveBeenCalled()
-  })
+      const result = payloadValidator.validate(request)
 
-  test('Should correctly set the cache when submitting', async () => {
-    const h = {
-      redirect: jest.fn().mockReturnValue({
-        takeover: jest.fn()
-      }),
-      view: jest.fn()
-    }
+      expect(result.error.message).toBe('PROVIDE_COORDINATES_CHOICE_REQUIRED')
+    })
 
-    const mockRequest = { payload: { coordinatesType: 'file' } }
+    test('Should correctly validate on invalid data', () => {
+      const request = { coordinatesType: 'invalid' }
 
-    await coordinatesTypeSubmitController.handler(mockRequest, h)
+      const payloadValidator =
+        coordinatesTypeSubmitController.options.validate.payload
 
-    expect(cacheUtils.updateExemptionSiteDetails).toHaveBeenCalledWith(
-      mockRequest,
-      'coordinatesType',
-      'file'
-    )
+      const result = payloadValidator.validate(request)
+
+      expect(result.error.message).toBe('PROVIDE_COORDINATES_CHOICE_REQUIRED')
+    })
+
+    test('Should correctly remain on the same page when file option is selected', async () => {
+      const h = {
+        view: jest.fn(),
+        redirect: jest.fn().mockReturnValue({
+          takeover: jest.fn()
+        })
+      }
+
+      await coordinatesTypeSubmitController.handler(
+        { payload: { coordinatesType: 'file' } },
+        h
+      )
+
+      expect(h.view).toHaveBeenCalledWith(
+        PROVIDE_COORDINATES_CHOICE_VIEW_ROUTE,
+        {
+          pageTitle: 'How do you want to provide the site location?',
+          heading: 'How do you want to provide the site location?',
+          payload: { coordinatesType: 'file' },
+          projectName: mockExemption.projectName
+        }
+      )
+      expect(h.redirect).not.toHaveBeenCalled()
+    })
+
+    test('Should correctly redirect to coordinates entry page when coordinates option is selected', async () => {
+      const h = {
+        view: jest.fn(),
+        redirect: jest.fn().mockReturnValue({
+          takeover: jest.fn()
+        })
+      }
+
+      await coordinatesTypeSubmitController.handler(
+        { payload: { coordinatesType: 'coordinates' } },
+        h
+      )
+
+      expect(h.view).not.toHaveBeenCalled()
+
+      expect(h.redirect).toHaveBeenCalledWith(routes.COORDINATES_ENTRY_CHOICE)
+      expect(h.redirect().takeover).toHaveBeenCalled()
+    })
+
+    test('Should correctly set the cache when submitting', async () => {
+      const h = {
+        redirect: jest.fn().mockReturnValue({
+          takeover: jest.fn()
+        }),
+        view: jest.fn()
+      }
+
+      const mockRequest = { payload: { coordinatesType: 'file' } }
+
+      await coordinatesTypeSubmitController.handler(mockRequest, h)
+
+      expect(cacheUtils.updateExemptionSiteDetails).toHaveBeenCalledWith(
+        mockRequest,
+        'coordinatesType',
+        'file'
+      )
+    })
   })
 })
 


### PR DESCRIPTION
Add describe blocks that differentiate between Submit and GET controllers for better test readability.