### PR TITLE
ML-18: Clear cache for siteDetails when cancel button is selected

### DIFF
--- a/src/server/common/components/cancel-button/cancel-button.test.js
+++ b/src/server/common/components/cancel-button/cancel-button.test.js
@@ -1,0 +1,24 @@
+import { renderComponent } from '~/src/server/test-helpers/component-helpers.js'
+
+describe('cancelButton Component', () => {
+  /** @type {CheerioAPI} */
+  let $cancelButton
+
+  test('Should render cancel button correctly with default text', () => {
+    $cancelButton = renderComponent('cancel-button', {
+      cancelLink: '/test-link'
+    })
+
+    expect($cancelButton('a')).toHaveLength(1)
+    expect($cancelButton('a').text().trim()).toBe('Cancel')
+    expect($cancelButton('a').attr('href')).toBe('/test-link')
+    expect($cancelButton('a').hasClass('govuk-link')).toBe(true)
+    expect($cancelButton('a').hasClass('govuk-link--no-visited-state')).toBe(
+      true
+    )
+  })
+})
+
+/**
+ * @import { CheerioAPI } from 'cheerio'
+ */

--- a/src/server/common/components/cancel-button/macro.njk
+++ b/src/server/common/components/cancel-button/macro.njk
@@ -1,0 +1,3 @@
+{% macro appCancelButton(params) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/src/server/common/components/cancel-button/template.njk
+++ b/src/server/common/components/cancel-button/template.njk
@@ -1,0 +1,2 @@
+
+<a class="govuk-link govuk-link--no-visited-state" href="{{params.cancelLink}}">Cancel</a>

--- a/src/server/common/components/radio-page/template.njk
+++ b/src/server/common/components/radio-page/template.njk
@@ -37,9 +37,9 @@
                 value: params.value,
                 fieldset: {
                     legend: {
-                    html: headingWithCaption,
-                    isPageHeading: true,
-                    classes: "govuk-fieldset__legend govuk-fieldset__legend--l govuk-!-margin-bottom-6"
+                        html: headingWithCaption,
+                        isPageHeading: true,
+                        classes: "govuk-fieldset__legend govuk-fieldset__legend--l govuk-!-margin-bottom-6"
                     }
                 } if params.isPageHeading,
                 hint: params.hint,
@@ -53,9 +53,9 @@
                 classes: "govuk-button--primary"
                 }) }}
 
-                  {{ appCancelButton({
-                    cancelLink: params.cancelLink
-                  }) }}
+                {{ appCancelButton({
+                cancelLink: params.cancelLink
+                }) }}
             </div>
 
         </form>

--- a/src/server/common/components/radio-page/template.njk
+++ b/src/server/common/components/radio-page/template.njk
@@ -1,6 +1,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "cancel-button/macro.njk" import appCancelButton %}
 
 {% set headingWithCaption %}
     {% if params.projectName %}
@@ -52,7 +53,9 @@
                 classes: "govuk-button--primary"
                 }) }}
 
-                <a class="govuk-link" href="/exemption/task-list">Cancel</a>
+                  {{ appCancelButton({
+                    cancelLink: params.cancelLink
+                  }) }}
             </div>
 
         </form>

--- a/src/server/common/helpers/session-cache/utils.js
+++ b/src/server/common/helpers/session-cache/utils.js
@@ -41,6 +41,8 @@ export const updateExemptionSiteDetails = (request, key, value) => {
  * @param { Request } request
  */
 export const resetExemptionSiteDetails = (request) => {
-  request.yar.clear(EXEMPTION_CACHE_KEY.siteDetails)
-  return { siteDetails: undefined }
+  const existingCache = getExemptionCache(request)
+  delete existingCache.siteDetails
+  request.yar.set(EXEMPTION_CACHE_KEY, existingCache)
+  return { siteDetails: null }
 }

--- a/src/server/common/helpers/session-cache/utils.js
+++ b/src/server/common/helpers/session-cache/utils.js
@@ -36,3 +36,11 @@ export const updateExemptionSiteDetails = (request, key, value) => {
 
   return { [key]: cacheValue }
 }
+
+/**
+ * @param { Request } request
+ */
+export const resetExemptionSiteDetails = (request) => {
+  request.yar.clear(EXEMPTION_CACHE_KEY.siteDetails)
+  return { siteDetails: undefined }
+}

--- a/src/server/common/helpers/session-cache/utils.test.js
+++ b/src/server/common/helpers/session-cache/utils.test.js
@@ -2,6 +2,7 @@ import {
   getExemptionCache,
   setExemptionCache,
   updateExemptionSiteDetails,
+  resetExemptionSiteDetails,
   EXEMPTION_CACHE_KEY
 } from '~/src/server/common/helpers/session-cache/utils.js'
 import { clone } from '@hapi/hoek'
@@ -164,6 +165,29 @@ describe('#utils', () => {
       })
 
       expect(result).toEqual({})
+    })
+  })
+
+  describe('resetExemptionSiteDetails', () => {
+    let mockRequest
+
+    beforeEach(() => {
+      jest.clearAllMocks()
+
+      mockRequest = {
+        yar: {
+          clear: jest.fn()
+        }
+      }
+    })
+
+    test('should clear the value in cache', () => {
+      const result = resetExemptionSiteDetails(mockRequest)
+
+      expect(mockRequest.yar.clear).toHaveBeenCalledWith(
+        EXEMPTION_CACHE_KEY.siteDetails
+      )
+      expect(result).toEqual({ siteDetails: undefined })
     })
   })
 })

--- a/src/server/common/helpers/session-cache/utils.test.js
+++ b/src/server/common/helpers/session-cache/utils.test.js
@@ -176,7 +176,8 @@ describe('#utils', () => {
 
       mockRequest = {
         yar: {
-          clear: jest.fn()
+          get: jest.fn(),
+          set: jest.fn()
         }
       }
     })
@@ -184,10 +185,8 @@ describe('#utils', () => {
     test('should clear the value in cache', () => {
       const result = resetExemptionSiteDetails(mockRequest)
 
-      expect(mockRequest.yar.clear).toHaveBeenCalledWith(
-        EXEMPTION_CACHE_KEY.siteDetails
-      )
-      expect(result).toEqual({ siteDetails: undefined })
+      expect(mockRequest.yar.set).toHaveBeenCalledWith(EXEMPTION_CACHE_KEY, {})
+      expect(result).toEqual({ siteDetails: null })
     })
   })
 })

--- a/src/server/exemption/public-register/index.njk
+++ b/src/server/exemption/public-register/index.njk
@@ -5,6 +5,7 @@
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "cancel-button/macro.njk" import appCancelButton %}
 
 {% block beforeContent %}
   {{ govukBackLink({
@@ -78,7 +79,9 @@
               classes: "govuk-button--primary"
             }) }}
 
-            <a class="govuk-link" href="/exemption/task-list">Cancel</a>
+            {{ appCancelButton({
+                cancelLink: '/exemption/task-list'
+            }) }}
           </div>
         </form>
 

--- a/src/server/exemption/site-details/coordinate-system/controller.test.js
+++ b/src/server/exemption/site-details/coordinate-system/controller.test.js
@@ -137,7 +137,9 @@ describe('#coordinateSystem', () => {
 
       expect(
         document
-          .querySelector('.govuk-link[href="/exemption/task-list"')
+          .querySelector(
+            '.govuk-link[href="/exemption/task-list?cancel=site-details"'
+          )
           .textContent.trim()
       ).toBe('Cancel')
 

--- a/src/server/exemption/site-details/coordinate-system/index.njk
+++ b/src/server/exemption/site-details/coordinate-system/index.njk
@@ -61,7 +61,8 @@
           }
         }
       ],
-      csrfToken: csrfToken
+      csrfToken: csrfToken,
+      cancelLink: "/exemption/task-list?cancel=site-details"
     })
   }}
 

--- a/src/server/exemption/site-details/coordinates-entry/controller.test.js
+++ b/src/server/exemption/site-details/coordinates-entry/controller.test.js
@@ -110,7 +110,9 @@ describe('#coordinatesEntry', () => {
 
       expect(
         document
-          .querySelector('.govuk-link[href="/exemption/task-list"')
+          .querySelector(
+            '.govuk-link[href="/exemption/task-list?cancel=site-details"'
+          )
           .textContent.trim()
       ).toBe('Cancel')
 

--- a/src/server/exemption/site-details/coordinates-entry/index.njk
+++ b/src/server/exemption/site-details/coordinates-entry/index.njk
@@ -36,7 +36,8 @@
           }
         }
       ],
-      csrfToken: csrfToken
+      csrfToken: csrfToken,
+      cancelLink: "/exemption/task-list?cancel=site-details"
     })
   }}
 

--- a/src/server/exemption/site-details/coordinates-type/controller.test.js
+++ b/src/server/exemption/site-details/coordinates-type/controller.test.js
@@ -112,7 +112,9 @@ describe('#coordinatesType', () => {
 
       expect(
         document
-          .querySelector('.govuk-link[href="/exemption/task-list"')
+          .querySelector(
+            '.govuk-link[href="/exemption/task-list?cancel=site-details"'
+          )
           .textContent.trim()
       ).toBe('Cancel')
 

--- a/src/server/exemption/site-details/coordinates-type/index.njk
+++ b/src/server/exemption/site-details/coordinates-type/index.njk
@@ -30,7 +30,8 @@
           text: "Enter the coordinates of the site manually"
         }
       ],
-      csrfToken: csrfToken
+      csrfToken: csrfToken,
+      cancelLink: "/exemption/task-list?cancel=site-details"
     })
   }}
 

--- a/src/server/exemption/task-list/controller.js
+++ b/src/server/exemption/task-list/controller.js
@@ -1,6 +1,10 @@
 import { config } from '~/src/config/config.js'
-import { getExemptionCache } from '~/src/server/common/helpers/session-cache/utils.js'
+import {
+  getExemptionCache,
+  resetExemptionSiteDetails
+} from '~/src/server/common/helpers/session-cache/utils.js'
 import { transformTaskList } from '~/src/server/exemption/task-list/utils.js'
+import { routes } from '~/src/server/common/constants/routes.js'
 
 import Wreck from '@hapi/wreck'
 import Boom from '@hapi/boom'
@@ -24,6 +28,16 @@ export const taskListController = {
 
     if (!id) {
       throw Boom.notFound(`Exemption not found`, { id })
+    }
+
+    const { query } = request
+
+    if (query?.cancel) {
+      if (query.cancel === 'site-details') {
+        resetExemptionSiteDetails(request)
+      }
+
+      return h.redirect(routes.TASK_LIST)
     }
 
     const { payload } = await Wreck.get(

--- a/src/server/exemption/task-list/controller.test.js
+++ b/src/server/exemption/task-list/controller.test.js
@@ -122,6 +122,38 @@ describe('#taskListController', () => {
     })
   })
 
+  test('taskListController handler should correctly handle request to clear cache and redirect', async () => {
+    const resetExemptionSiteDetailsSpy = jest.spyOn(
+      cacheUtils,
+      'resetExemptionSiteDetails'
+    )
+
+    const { statusCode, headers } = await server.inject({
+      method: 'GET',
+      url: `${routes.TASK_LIST}?cancel=site-details`
+    })
+
+    expect(resetExemptionSiteDetailsSpy).toHaveBeenCalled()
+    expect(statusCode).toBe(302)
+    expect(headers.location).toBe(routes.TASK_LIST)
+  })
+
+  test('taskListController should redirect when cancel query parameter is provided but does not match', async () => {
+    const resetExemptionSiteDetailsSpy = jest.spyOn(
+      cacheUtils,
+      'resetExemptionSiteDetails'
+    )
+
+    const { statusCode, headers } = await server.inject({
+      method: 'GET',
+      url: `${routes.TASK_LIST}?cancel=does-not-exist`
+    })
+
+    expect(resetExemptionSiteDetailsSpy).not.toHaveBeenCalled()
+    expect(statusCode).toBe(302)
+    expect(headers.location).toBe(routes.TASK_LIST)
+  })
+
   test('taskListController handler should throw a 404 if exemption is not found', async () => {
     const h = { view: jest.fn() }
 


### PR DESCRIPTION
- When clicking the cancel button, clear siteDetails from the cache. This happens using a query parameter.
- Cancel button is now a component