### PR TITLE
Feature/ml 69 choose file type to upload

### DIFF
--- a/src/server/common/constants/routes.js
+++ b/src/server/common/constants/routes.js
@@ -10,5 +10,6 @@ export const routes = {
   PUBLIC_REGISTER: '/exemption/public-register',
   TASK_LIST: '/exemption/task-list',
   ACTIVITY_DESCRIPTION: '/exemption/activity-description',
-  WIDTH_OF_SITE: '/exemption/width-of-site'
+  WIDTH_OF_SITE: '/exemption/width-of-site',
+  CHOOSE_FILE_UPLOAD_TYPE: '/exemption/choose-file-type-to-upload'
 }

--- a/src/server/exemption/index.js
+++ b/src/server/exemption/index.js
@@ -4,6 +4,7 @@ import { taskListRoutes } from '~/src/server/exemption/task-list/index.js'
 import { siteDetailsRoutes } from '~/src/server/exemption/site-details/index.js'
 import { activityDescriptionRoutes } from './activity-description/index.js'
 import { routes } from '~/src/server/common/constants/routes.js'
+import { chooseFileTypeRoutes } from './site-details/choose-file-type/index.js'
 
 /**
  * Sets up the routes used in the exemption home page.
@@ -23,6 +24,7 @@ export const exemption = {
         ...taskListRoutes,
         ...siteDetailsRoutes,
         ...activityDescriptionRoutes,
+        ...chooseFileTypeRoutes,
         {
           method: 'GET',
           path: '/exemption',

--- a/src/server/exemption/index.test.js
+++ b/src/server/exemption/index.test.js
@@ -88,6 +88,14 @@ describe('exemption route', () => {
       }),
       expect.objectContaining({
         method: 'GET',
+        path: '/exemption/choose-file-type-to-upload'
+      }),
+      expect.objectContaining({
+        method: 'POST',
+        path: '/exemption/choose-file-type-to-upload'
+      }),
+      expect.objectContaining({
+        method: 'GET',
         path: '/exemption'
       })
     ])

--- a/src/server/exemption/site-details/choose-file-type/controller.js
+++ b/src/server/exemption/site-details/choose-file-type/controller.js
@@ -98,13 +98,11 @@ export const chooseFileTypeSubmitController = {
       payload.fileUploadType
     )
 
-    return h
-      .view(CHOOSE_FILE_UPLOAD_TYPE_VIEW_ROUTE, {
-        ...pageSettings,
-        projectName: exemption.projectName,
-        payload,
-        backLink: routes.COORDINATES_TYPE_CHOICE
-      })
-      .code(200)
+    return h.view(CHOOSE_FILE_UPLOAD_TYPE_VIEW_ROUTE, {
+      ...pageSettings,
+      projectName: exemption.projectName,
+      payload,
+      backLink: routes.COORDINATES_TYPE_CHOICE
+    })
   }
 }

--- a/src/server/exemption/site-details/choose-file-type/controller.js
+++ b/src/server/exemption/site-details/choose-file-type/controller.js
@@ -1,0 +1,110 @@
+import joi from 'joi'
+
+import {
+  getExemptionCache,
+  updateExemptionSiteDetails
+} from '~/src/server/common/helpers/session-cache/utils.js'
+import { routes } from '~/src/server/common/constants/routes.js'
+import {
+  errorDescriptionByFieldName,
+  mapErrorsForDisplay
+} from '~/src/server/common/helpers/errors.js'
+
+const pageSettings = {
+  pageTitle: 'Choose file type',
+  heading: 'Which type of file do you want to upload?'
+}
+
+export const CHOOSE_FILE_UPLOAD_TYPE_VIEW_ROUTE =
+  'exemption/site-details/choose-file-type/index'
+
+export const errorMessages = {
+  FILE_TYPE_ENTRY_REQUIRED: 'Select which type of file you want to upload'
+}
+
+/**
+ * A GDS styled project name page controller.
+ * @satisfies {Partial<ServerRoute>}
+ */
+export const chooseFileTypeController = {
+  handler(request, h) {
+    const exemption = getExemptionCache(request)
+
+    return h.view(CHOOSE_FILE_UPLOAD_TYPE_VIEW_ROUTE, {
+      ...pageSettings,
+      payload: { fileUploadType: exemption.fileUploadType || '' },
+      projectName: exemption.projectName,
+      backLink: routes.COORDINATES_TYPE_CHOICE
+    })
+  }
+}
+
+/**
+ * A GDS styled page controller for the POST route in the coordinates type page.
+ * @satisfies {Partial<ServerRoute>}
+ */
+export const chooseFileTypeSubmitController = {
+  options: {
+    validate: {
+      payload: joi.object({
+        fileUploadType: joi
+          .string()
+          .valid('shapefile', 'kml')
+          .required()
+          .messages({
+            'any.only': 'FILE_TYPE_ENTRY_REQUIRED',
+            'string.empty': 'FILE_TYPE_ENTRY_REQUIRED',
+            'any.required': 'FILE_TYPE_ENTRY_REQUIRED'
+          })
+      }),
+      failAction: (request, h, err) => {
+        const { payload } = request
+        const { projectName } = getExemptionCache(request)
+
+        if (!err.details) {
+          return h
+            .view(CHOOSE_FILE_UPLOAD_TYPE_VIEW_ROUTE, {
+              ...pageSettings,
+              payload,
+              projectName,
+              backLink: routes.COORDINATES_TYPE_CHOICE
+            })
+            .takeover()
+        }
+
+        const errorSummary = mapErrorsForDisplay(err.details, errorMessages)
+        const errors = errorDescriptionByFieldName(errorSummary)
+
+        return h
+          .view(CHOOSE_FILE_UPLOAD_TYPE_VIEW_ROUTE, {
+            ...pageSettings,
+            payload,
+            projectName,
+            backLink: routes.COORDINATES_TYPE_CHOICE,
+            errors,
+            errorSummary
+          })
+          .takeover()
+      }
+    }
+  },
+  handler(request, h) {
+    const { payload } = request
+    const exemption = getExemptionCache(request)
+
+    updateExemptionSiteDetails(
+      request,
+      'fileUploadType',
+      payload.fileUploadType
+    )
+
+    return h
+      .view(CHOOSE_FILE_UPLOAD_TYPE_VIEW_ROUTE, {
+        ...pageSettings,
+        projectName: exemption.projectName,
+        payload,
+        backLink: routes.COORDINATES_TYPE_CHOICE
+      })
+      .code(200)
+  }
+}

--- a/src/server/exemption/site-details/choose-file-type/controller.test.js
+++ b/src/server/exemption/site-details/choose-file-type/controller.test.js
@@ -1,0 +1,284 @@
+import { createServer } from '~/src/server/index.js'
+import { statusCodes } from '~/src/server/common/constants/status-codes.js'
+import { routes } from '~/src/server/common/constants/routes.js'
+import { config } from '~/src/config/config.js'
+import { JSDOM } from 'jsdom'
+import {
+  chooseFileTypeController,
+  chooseFileTypeSubmitController,
+  CHOOSE_FILE_UPLOAD_TYPE_VIEW_ROUTE,
+  errorMessages
+} from '~/src/server/exemption/site-details/choose-file-type/controller.js'
+import * as cacheUtils from '~/src/server/common/helpers/session-cache/utils.js'
+
+jest.mock('~/src/server/common/helpers/session-cache/utils.js')
+
+describe('#chooseFileType', () => {
+  /** @type {Server} */
+  let server
+  let getExemptionCacheSpy
+
+  const mockExemptionState = {
+    projectName: 'Test Project',
+    fileUploadType: 'shapefile'
+  }
+
+  beforeAll(async () => {
+    server = await createServer()
+    await server.initialize()
+  })
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    getExemptionCacheSpy = jest
+      .spyOn(cacheUtils, 'getExemptionCache')
+      .mockReturnValue(mockExemptionState)
+  })
+
+  afterAll(async () => {
+    await server.stop({ timeout: 0 })
+  })
+
+  describe('#chooseFileTypeController', () => {
+    test('Should provide expected response and correctly pre populate data', async () => {
+      const { result, statusCode } = await server.inject({
+        method: 'GET',
+        url: routes.CHOOSE_FILE_UPLOAD_TYPE
+      })
+
+      expect(result).toEqual(
+        expect.stringContaining(
+          `Choose file type | ${config.get('serviceName')}`
+        )
+      )
+
+      const { document } = new JSDOM(result).window
+
+      expect(
+        document.querySelector(
+          'input[name="fileUploadType"][value="shapefile"]:checked'
+        )
+      ).toBeTruthy()
+      expect(statusCode).toBe(statusCodes.ok)
+    })
+
+    test('Should provide expected response and correctly not pre-populate data if it is not present', async () => {
+      getExemptionCacheSpy.mockReturnValueOnce({})
+
+      const { result, statusCode } = await server.inject({
+        method: 'GET',
+        url: routes.CHOOSE_FILE_UPLOAD_TYPE
+      })
+
+      expect(result).toEqual(
+        expect.stringContaining(
+          `Choose file type | ${config.get('serviceName')}`
+        )
+      )
+
+      const { document } = new JSDOM(result).window
+      expect(
+        document.querySelector('input[name="fileUploadType"]:checked')
+      ).toBeFalsy()
+      expect(statusCode).toBe(statusCodes.ok)
+    })
+
+    test('chooseFileTypeController handler should render view with correct page title, heading, and pre-populated data from cache', () => {
+      const h = { view: jest.fn() }
+
+      chooseFileTypeController.handler({}, h)
+
+      expect(h.view).toHaveBeenCalledWith(CHOOSE_FILE_UPLOAD_TYPE_VIEW_ROUTE, {
+        pageTitle: 'Choose file type',
+        heading: 'Which type of file do you want to upload?',
+        payload: { fileUploadType: mockExemptionState.fileUploadType },
+        projectName: mockExemptionState.projectName,
+        backLink: routes.COORDINATES_TYPE_CHOICE
+      })
+
+      getExemptionCacheSpy.mockReturnValueOnce({}) // exmpty excemption cache object
+
+      chooseFileTypeController.handler({}, h)
+
+      expect(h.view).toHaveBeenNthCalledWith(
+        2,
+        CHOOSE_FILE_UPLOAD_TYPE_VIEW_ROUTE,
+        {
+          pageTitle: 'Choose file type',
+          heading: 'Which type of file do you want to upload?',
+          payload: { fileUploadType: '' },
+          projectName: undefined, // nothing in the cache
+          backLink: routes.COORDINATES_TYPE_CHOICE
+        }
+      )
+    })
+
+    test('Should render details and summary elements', async () => {
+      const { result, statusCode } = await server.inject({
+        method: 'GET',
+        url: routes.CHOOSE_FILE_UPLOAD_TYPE
+      })
+
+      const { document } = new JSDOM(result).window
+
+      // Check for details element
+      const detailsElement = document.querySelector('.govuk-details')
+      expect(detailsElement).toBeTruthy()
+
+      // Check for summary element and its text
+      const summaryElement = document.querySelector('.govuk-details__summary')
+      expect(summaryElement).toBeTruthy()
+      expect(summaryElement.textContent.trim()).toBe('Help with file types')
+
+      // Check for Shapefile heading
+      const shapefileHeading = document.querySelector('.govuk-details h2')
+      expect(shapefileHeading).toBeTruthy()
+      expect(shapefileHeading.textContent.trim()).toBe('Shapefile')
+
+      // Check for Shapefile description
+      const shapefileDescription = document.querySelector('.govuk-details p')
+      expect(shapefileDescription).toBeTruthy()
+      expect(shapefileDescription.textContent.trim()).toMatch(
+        /^A shapefile is a collection of files that store map data\./
+      )
+
+      // Check for KML heading
+      const kmlHeading = document.querySelectorAll('.govuk-details h2')[1]
+      expect(kmlHeading).toBeTruthy()
+      expect(kmlHeading.textContent.trim()).toBe('KML')
+
+      // Check for KML description
+      const kmlDescription = document.querySelectorAll('.govuk-details p')[1]
+      expect(kmlDescription).toBeTruthy()
+      expect(kmlDescription.textContent.trim()).toMatch(
+        /^A KML file \(Keyhole Markup Language\) is used to store map data\./
+      )
+
+      expect(statusCode).toBe(statusCodes.ok)
+    })
+  })
+
+  describe('#chooseFileTypeSubmitController', () => {
+    test('Should show error messages with invalid data', async () => {
+      const { result, statusCode } = await server.inject({
+        method: 'POST',
+        url: routes.CHOOSE_FILE_UPLOAD_TYPE,
+        payload: { fileUploadType: '' }
+      })
+
+      const { document } = new JSDOM(result).window
+
+      expect(document.querySelector('.govuk-error-summary')).toBeTruthy()
+      expect(
+        document.querySelector('.govuk-error-summary__list').textContent
+      ).toContain(errorMessages.FILE_TYPE_ENTRY_REQUIRED)
+
+      expect(statusCode).toBe(statusCodes.ok)
+    })
+
+    test('Should correctly validate on empty data', () => {
+      const request = {
+        payload: { fileUploadType: '' }
+      }
+
+      const h = {
+        view: jest.fn().mockReturnValue({
+          takeover: jest.fn()
+        })
+      }
+
+      const err = {
+        details: [
+          {
+            path: ['fileUploadType'],
+            message: 'FILE_TYPE_ENTRY_REQUIRED',
+            type: 'string.empty'
+          }
+        ]
+      }
+
+      chooseFileTypeSubmitController.options.validate.failAction(
+        request,
+        h,
+        err
+      )
+
+      expect(h.view).toHaveBeenCalledWith(CHOOSE_FILE_UPLOAD_TYPE_VIEW_ROUTE, {
+        pageTitle: 'Choose file type',
+        heading: 'Which type of file do you want to upload?',
+        projectName: mockExemptionState.projectName,
+        payload: { fileUploadType: '' },
+        backLink: routes.COORDINATES_TYPE_CHOICE,
+        errorSummary: [
+          {
+            href: '#fileUploadType',
+            text: errorMessages.FILE_TYPE_ENTRY_REQUIRED,
+            field: ['fileUploadType']
+          }
+        ],
+        errors: {
+          fileUploadType: {
+            field: ['fileUploadType'],
+            href: '#fileUploadType',
+            text: errorMessages.FILE_TYPE_ENTRY_REQUIRED
+          }
+        }
+      })
+
+      expect(h.view().takeover).toHaveBeenCalled()
+    })
+
+    test('Should correctly handle an incorrectly formed error object', () => {
+      const request = {
+        payload: { fileUploadType: '' }
+      }
+
+      const h = {
+        view: jest.fn().mockReturnValue({
+          takeover: jest.fn()
+        })
+      }
+
+      const err = {
+        details: null
+      }
+
+      chooseFileTypeSubmitController.options.validate.failAction(
+        request,
+        h,
+        err
+      )
+
+      expect(h.view).toHaveBeenCalledWith(CHOOSE_FILE_UPLOAD_TYPE_VIEW_ROUTE, {
+        pageTitle: 'Choose file type',
+        heading: 'Which type of file do you want to upload?',
+        projectName: mockExemptionState.projectName,
+        payload: { fileUploadType: '' },
+        backLink: routes.COORDINATES_TYPE_CHOICE
+      })
+
+      expect(h.view().takeover).toHaveBeenCalled()
+    })
+
+    test('Should successfully update exemption cache and return 200 status code', async () => {
+      const updateExemptionSiteDetailsSpy = jest.spyOn(
+        cacheUtils,
+        'updateExemptionSiteDetails'
+      )
+
+      const { statusCode } = await server.inject({
+        method: 'POST',
+        url: routes.CHOOSE_FILE_UPLOAD_TYPE,
+        payload: { fileUploadType: 'shapefile' }
+      })
+
+      expect(updateExemptionSiteDetailsSpy).toHaveBeenCalledWith(
+        expect.anything(),
+        'fileUploadType',
+        'shapefile'
+      )
+
+      expect(statusCode).toBe(statusCodes.ok)
+    })
+  })
+})

--- a/src/server/exemption/site-details/choose-file-type/controller.test.js
+++ b/src/server/exemption/site-details/choose-file-type/controller.test.js
@@ -121,33 +121,27 @@ describe('#chooseFileType', () => {
 
       const { document } = new JSDOM(result).window
 
-      // Check for details element
       const detailsElement = document.querySelector('.govuk-details')
       expect(detailsElement).toBeTruthy()
 
-      // Check for summary element and its text
       const summaryElement = document.querySelector('.govuk-details__summary')
       expect(summaryElement).toBeTruthy()
       expect(summaryElement.textContent.trim()).toBe('Help with file types')
 
-      // Check for Shapefile heading
       const shapefileHeading = document.querySelector('.govuk-details h2')
       expect(shapefileHeading).toBeTruthy()
       expect(shapefileHeading.textContent.trim()).toBe('Shapefile')
 
-      // Check for Shapefile description
       const shapefileDescription = document.querySelector('.govuk-details p')
       expect(shapefileDescription).toBeTruthy()
       expect(shapefileDescription.textContent.trim()).toMatch(
         /^A shapefile is a collection of files that store map data\./
       )
 
-      // Check for KML heading
       const kmlHeading = document.querySelectorAll('.govuk-details h2')[1]
       expect(kmlHeading).toBeTruthy()
       expect(kmlHeading.textContent.trim()).toBe('KML')
 
-      // Check for KML description
       const kmlDescription = document.querySelectorAll('.govuk-details p')[1]
       expect(kmlDescription).toBeTruthy()
       expect(kmlDescription.textContent.trim()).toMatch(

--- a/src/server/exemption/site-details/choose-file-type/index.js
+++ b/src/server/exemption/site-details/choose-file-type/index.js
@@ -1,0 +1,30 @@
+import {
+  chooseFileTypeController,
+  chooseFileTypeSubmitController
+} from '~/src/server/exemption/site-details/choose-file-type/controller.js'
+import { routes } from '~/src/server/common/constants/routes.js'
+
+/**
+ * @satisfies {ServerRegisterPluginObject<void>}
+ */
+export const chooseFileTypeRoutes = [
+  {
+    method: 'GET',
+    path: routes.CHOOSE_FILE_UPLOAD_TYPE,
+    ...chooseFileTypeController
+  },
+  {
+    method: 'POST',
+    path: routes.CHOOSE_FILE_UPLOAD_TYPE,
+    options: {
+      plugins: {
+        crumb: true
+      }
+    },
+    ...chooseFileTypeSubmitController
+  }
+]
+
+/**
+ * @import { ServerRegisterPluginObject } from '@hapi/hapi'
+ */

--- a/src/server/exemption/site-details/choose-file-type/index.njk
+++ b/src/server/exemption/site-details/choose-file-type/index.njk
@@ -1,0 +1,62 @@
+{% extends 'layouts/page.njk' %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "radio-page/macro.njk" import appRadioPage %}
+{% from "govuk/components/details/macro.njk" import govukDetails %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: backLink
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+  {% set helperHtml %}
+  <h2 class="govuk-heading-s">Shapefile</h2>
+  <p>A shapefile is a collection of files that store map data. It defines locations, shapes, 
+         and other details like names or numbers. Shapefiles are commonly used in geographic 
+         information system (GIS) software.</p>
+
+  <h2 class="govuk-heading-s">KML</h2>
+  <p>
+        A KML file (Keyhole Markup Language) is used to store map data. It tells mapping programs
+        like Google Earth where to place points, lines, shapes, and other features on a map. KML 
+        files are written in XML (Extensible Markup Language), a format that organises data so 
+        computers can read it.
+      </p>
+  {% endset %}
+
+  {% set helperText %}
+  {{ govukDetails({ 
+      html:helperHtml, 
+      summaryText: "Help with file types" 
+  }) }}
+  {% endset %}
+
+    {{ appRadioPage({
+            name: "fileUploadType",
+            errorSummary: errorSummary,
+            errors: errors,
+            heading: "Which type of file do you want to upload?",
+            isPageHeading: true,
+            value: payload.fileUploadType,
+            errorMessage: errors['fileUploadType'],
+            projectName: projectName,
+            hint: { html: helperText },
+            items: [
+                {
+                value: "shapefile",
+                text: "Shapefile"
+                },
+                {
+                value: "kml",
+                text: "KML"
+                }
+            ],
+            csrfToken: csrfToken,
+            cancelLink: "/exemption/task-list?cancel=site-details"
+            })
+        }}
+
+{% endblock %}

--- a/src/server/exemption/site-details/choose-file-type/index.njk
+++ b/src/server/exemption/site-details/choose-file-type/index.njk
@@ -23,8 +23,7 @@
         A KML file (Keyhole Markup Language) is used to store map data. It tells mapping programs
         like Google Earth where to place points, lines, shapes, and other features on a map. KML 
         files are written in XML (Extensible Markup Language), a format that organises data so 
-        computers can read it.
-      </p>
+        computers can read it.</p>
   {% endset %}
 
   {% set helperText %}

--- a/src/server/exemption/site-details/coordinates-type/controller.js
+++ b/src/server/exemption/site-details/coordinates-type/controller.js
@@ -95,8 +95,6 @@ export const coordinatesTypeSubmitController = {
   handler(request, h) {
     const { payload } = request
 
-    const exemption = getExemptionCache(request)
-
     updateExemptionSiteDetails(
       request,
       'coordinatesType',
@@ -105,14 +103,10 @@ export const coordinatesTypeSubmitController = {
 
     if (payload.coordinatesType === 'coordinates') {
       return h.redirect(routes.COORDINATES_ENTRY_CHOICE).takeover()
+    } else {
+      // the 'file' case is at this point in the code flow is the only
+      // reachable option, as the validator explicitly lists all available valid choices.
+      return h.redirect(routes.CHOOSE_FILE_UPLOAD_TYPE).takeover()
     }
-
-    return h.view(PROVIDE_COORDINATES_CHOICE_VIEW_ROUTE, {
-      ...provideCoordinatesSettings,
-      projectName: exemption.projectName,
-      payload: {
-        coordinatesType: payload.coordinatesType
-      }
-    })
   }
 }

--- a/src/server/exemption/site-details/coordinates-type/controller.test.js
+++ b/src/server/exemption/site-details/coordinates-type/controller.test.js
@@ -243,7 +243,7 @@ describe('#coordinatesType', () => {
       expect(result.error.message).toBe('PROVIDE_COORDINATES_CHOICE_REQUIRED')
     })
 
-    test('Should correctly remain on the same page when file option is selected', async () => {
+    test('Should correctly redirect when file option is selected', async () => {
       const h = {
         view: jest.fn(),
         redirect: jest.fn().mockReturnValue({
@@ -256,16 +256,8 @@ describe('#coordinatesType', () => {
         h
       )
 
-      expect(h.view).toHaveBeenCalledWith(
-        PROVIDE_COORDINATES_CHOICE_VIEW_ROUTE,
-        {
-          pageTitle: 'How do you want to provide the site location?',
-          heading: 'How do you want to provide the site location?',
-          payload: { coordinatesType: 'file' },
-          projectName: mockExemption.projectName
-        }
-      )
-      expect(h.redirect).not.toHaveBeenCalled()
+      expect(h.view).not.toHaveBeenCalled()
+      expect(h.redirect).toHaveBeenCalledWith(routes.CHOOSE_FILE_UPLOAD_TYPE)
     })
 
     test('Should correctly redirect to coordinates entry page when coordinates option is selected', async () => {


### PR DESCRIPTION
Jira reference: https://eaflood.atlassian.net/browse/ML-69
Add a new page to allow the user to choose the file type for upload when requesting an exception.
![Screenshot 2025-06-13 at 16 24 24](https://github.com/user-attachments/assets/2719fd95-889c-49b6-a1cf-36f4d655d12a)


