### PR TITLE
ML-10 v2 - Activity dates page

### DIFF
--- a/.cursor/rules/api-integration.mdc
+++ b/.cursor/rules/api-integration.mdc
@@ -1,0 +1,69 @@
+---
+description: 
+globs: 
+alwaysApply: true
+---
+---
+description: API Integration Standards
+globs: src/**/*.js
+---
+# API Integration Standards
+
+## Configuration
+- Use apiServer from config for base URL:
+```javascript
+import { config } from '~/src/config/config.js'
+const baseUrl = config.get('apiServer')
+```
+
+## Making API Calls
+- Use native fetch for HTTP requests (do not use Axios or other HTTP clients)
+- Always include error handling
+- Use JSON content type by default
+- Follow RESTful conventions
+- Use absolute imports with '~' alias
+
+### Standard Pattern
+
+```javascript
+import { config } from '~/src/config/config.js'
+import { statusCodes } from '~/src/server/common/constants/status-codes.js'
+async function makeApiCall(request) {
+try {
+const response = await fetch(${config.get('apiServer')}/api/v1/endpoint, {
+method: 'POST',
+headers: {
+'Content-Type': 'application/json'
+},
+body: JSON.stringify(data)
+})
+if (!response.ok) {
+throw new Error(API call failed with status: ${response.status})
+}
+return await response.json()
+} catch (error) {
+request.logger.error(error)
+throw error
+}
+}
+```
+
+
+## Error Handling
+- Check response.ok status
+- Log errors with request.logger
+- Use statusCodes constants for response codes
+- Return user-friendly error messages
+- Propagate errors up for handling
+
+## Response Processing 
+- Parse JSON responses
+- Validate response data structure
+- Handle empty responses appropriately
+- Use TypeScript-style JSDoc for type annotations
+
+## Security
+- Use HTTPS in production
+- Include authorization headers when required
+- Redact sensitive data in logs
+- Follow security best practices

--- a/.cursor/rules/gov-uk-standards.mdc
+++ b/.cursor/rules/gov-uk-standards.mdc
@@ -1,0 +1,69 @@
+---
+description: 
+globs: 
+alwaysApply: true
+---
+---
+description: GOV.UK Frontend
+globs: *.njk, *.js
+---
+# GOV UK Frontend
+
+## Tech Stack
+- Node.js + Hapi.js
+- govuk-frontend npm library
+- Nunjucks templates
+
+## Template Structure
+- Use layouts/page.njk as base template
+- Follow GDS template hierarchy
+- Required template blocks:
+  - pageTitle: Page title with " - Defra SDLC Governance Checklist" suffix
+  - content: Main content area
+- Use govuk-width-container for page layout
+- Use govuk-main-wrapper for main content
+- Use govuk-grid-row and govuk-grid-column-* for grid layouts
+
+## Template Inheritance
+- Always use search path style imports (e.g. {% extends "layouts/page.njk" %})
+- Never use relative paths in extends/include statements
+- Base template is at src/server/common/templates/layouts/page.njk
+- Feature templates should be in src/server/{feature}/views/
+- Common components in src/server/common/components/
+
+## Component Usage
+- Use GDS components with data-module="govuk-button" where needed
+- Follow GDS class naming:
+  - Headings: govuk-heading-xl, govuk-heading-l, etc.
+  - Body text: govuk-body
+  - Tables: govuk-table with appropriate child classes
+  - Buttons: govuk-button, govuk-button--warning for variants
+  - Forms: govuk-form-group, govuk-input, etc.
+  - Error handling: govuk-error-message, govuk-error-summary
+
+## Content Guidelines
+- Follow GDS content patterns
+- Use appropriate heading hierarchy
+- Ensure accessible content structure
+- Include proper ARIA roles and attributes
+- Use semantic HTML elements
+
+## Error Handling
+- Use consistent error templates
+- Display user-friendly error messages
+- Include status codes where appropriate
+- Provide clear next steps for users
+
+## Navigation
+- Use buildNavigation helper for consistent nav
+- Implement breadcrumbs where appropriate
+- Clear call-to-action buttons
+- Logical page flow
+
+## Nunjucks Filters
+- Custom filters located in src/config/nunjucks/filters/
+- Each filter should have its own file
+- Common filters:
+  - formatDate
+  - formatCurrency
+  - markdown (for content formatting)

--- a/.cursor/rules/javascript.mdc
+++ b/.cursor/rules/javascript.mdc
@@ -1,0 +1,102 @@
+---
+description: 
+globs: 
+alwaysApply: true
+---
+---
+description: Javascript in Defra
+globs: *.js
+---
+# JavaScript in Defra
+
+## Language
+- JavaScript
+- TypeScript (for type checking only)
+
+## Tech Stack
+- Node.js + Hapi.js (do NOT use Express)
+- govuk-frontend npm library
+- Nunjucks templates npm library
+- Webpack + Babel
+- Jest + ESLint + Prettier
+- SCSS + PostCSS + Stylelint
+
+## Code Standards
+- Use vanilla JavaScript (no TypeScript files)
+- Use JSDoc for type annotations
+- Use TypeScript for type checking only
+- Use ES Modules with named exports
+- Use absolute imports with '~' alias for internal project files
+- Use convict for configuration management
+- Use BEM-style naming with 'app-' prefix
+
+## Project Structure
+- /src/config/ - Configuration and setup
+  - /nunjucks/ - Template engine setup
+    - /filters/ - Custom Nunjucks filters
+    - /globals/ - Global template variables
+- /src/server/ - Server-side code
+  - /common/ - Shared components and utilities
+    - /templates/ - Base templates and layouts
+    - /components/ - Reusable view components
+  - /{feature}/ - Feature modules
+    - controller.js - Route handlers and business logic
+    - controller.test.js - Unit tests
+    - index.js - Route definitions
+    - /views/ - Feature-specific templates
+  - router.js - Main route aggregation
+  - index.js - Server setup and plugins
+
+## Controller Patterns
+- Export named functions
+- Use JSDoc to document parameters
+- Standard parameters: (request, h)
+- Consistent error handling:
+  - Try/catch blocks
+  - Error logging with request.logger
+  - User-friendly error responses
+- Use h.view for template rendering
+- Use h.redirect for navigation
+
+## API Integration
+- Use fetch for API calls
+- Base URL from config
+- JSON content type
+- Response status checking
+- Error propagation
+- Consistent error handling
+
+## Configuration
+- Use config module for settings
+- Environment-based configuration
+- Consistent config access pattern
+- Type-safe config values
+
+## Markdown Parsing
+- Use marked library for parsing markdown
+- Configure marked options to match GDS styling
+- Always sanitize markdown output
+- Common use cases:
+  - Standards content
+  - Documentation
+  - Help text
+
+## Testing
+- Write comprehensive Jest tests
+- Test functionality, not implementation
+  - End-to-end coverage
+  - API: test input/output
+  - UI: test behavior + use data-testid
+- Use describe blocks and beforeEach for setup
+- Mock external dependencies
+
+## Template Handling
+- Configure Nunjucks search paths in nunjucks.js:
+  - govuk-frontend templates
+  - project views directory
+  - common templates
+  - common components
+- Use h.view with template paths relative to search paths
+- Bind controller methods when used as route handlers
+- Follow template inheritance patterns from gov-uk-standards
+- Keep templates close to their feature modules

--- a/.cursor/rules/javascript.mdc
+++ b/.cursor/rules/javascript.mdc
@@ -29,6 +29,10 @@ globs: *.js
 - Use absolute imports with '~' alias for internal project files
 - Use convict for configuration management
 - Use BEM-style naming with 'app-' prefix
+- Use curly braces for control structures
+- Use comments for complex logic only
+- Use constants instead of magic strings and numbers
+- Use child functions when function complexity is greater than ten
 
 ## Project Structure
 - /src/config/ - Configuration and setup

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -68,7 +68,7 @@ module.exports = {
 
         // Check for mandatory file extensions
         // https://nodejs.org/api/esm.html#mandatory-file-extensions
-        'import/extensions': ['error', 'always', { ignorePackages: true }],
+        'import/extensions': ['error', 'always'],
 
         // Skip rules handled by TypeScript compiler
         'import/default': 'off',

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "cssnano": "^7.0.6",
         "cssnano-preset-default": "^7.0.6",
         "date-fns": "^4.1.0",
+        "dayjs": "^1.11.13",
         "global-agent": "^3.0.0",
         "govuk-frontend": "^5.10.2",
         "hapi-pino": "^12.1.0",
@@ -6527,6 +6528,12 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.0",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "cssnano": "^7.0.6",
     "cssnano-preset-default": "^7.0.6",
     "date-fns": "^4.1.0",
+    "dayjs": "^1.11.13",
     "global-agent": "^3.0.0",
     "govuk-frontend": "^5.10.2",
     "hapi-pino": "^12.1.0",

--- a/src/server/common/constants/joi.js
+++ b/src/server/common/constants/joi.js
@@ -7,5 +7,20 @@ export const JOI_ERRORS = {
   NUMBER_INTEGER: 'number.integer',
   STRING_EMPTY: 'string.empty',
   STRING_PATTERN_BASE: 'string.pattern.base',
-  ANY_REQUIRED: 'any.required'
+  ANY_REQUIRED: 'any.required',
+  // Activity date field errors
+  ACTIVITY_START_DATE_DAY: 'activity-start-date-day',
+  ACTIVITY_START_DATE_MONTH: 'activity-start-date-month',
+  ACTIVITY_START_DATE_YEAR: 'activity-start-date-year',
+  ACTIVITY_END_DATE_DAY: 'activity-end-date-day',
+  ACTIVITY_END_DATE_MONTH: 'activity-end-date-month',
+  ACTIVITY_END_DATE_YEAR: 'activity-end-date-year',
+  // Custom date validation errors
+  CUSTOM_START_DATE_MISSING: 'custom.startDate.missing',
+  CUSTOM_END_DATE_MISSING: 'custom.endDate.missing',
+  CUSTOM_START_DATE_INVALID: 'custom.startDate.invalid',
+  CUSTOM_END_DATE_INVALID: 'custom.endDate.invalid',
+  CUSTOM_START_DATE_TODAY_OR_FUTURE: 'custom.startDate.todayOrFuture',
+  CUSTOM_END_DATE_TODAY_OR_FUTURE: 'custom.endDate.todayOrFuture',
+  CUSTOM_END_DATE_BEFORE_START_DATE: 'custom.endDate.before.startDate'
 }

--- a/src/server/common/constants/routes.js
+++ b/src/server/common/constants/routes.js
@@ -10,5 +10,6 @@ export const routes = {
   PUBLIC_REGISTER: '/exemption/public-register',
   TASK_LIST: '/exemption/task-list',
   ACTIVITY_DESCRIPTION: '/exemption/activity-description',
+  ACTIVITY_DATES: '/exemption/activity-dates',
   WIDTH_OF_SITE: '/exemption/width-of-site'
 }

--- a/src/server/common/helpers/date-form-utils.js
+++ b/src/server/common/helpers/date-form-utils.js
@@ -292,7 +292,6 @@ export function addCustomValidationErrors(
         href: `#${dateFieldNames.DAY}`,
         text: errorMessages[errorKeys.INVALID]
       })
-      dateErrorAdded = true
     }
 
     // Date relationship error (e.g., end before start)

--- a/src/server/common/helpers/date-form-utils.js
+++ b/src/server/common/helpers/date-form-utils.js
@@ -1,0 +1,421 @@
+/**
+ * Generic Date Form Utilities
+ *
+ * This module provides reusable utilities for handling date forms with multiple
+ * date fields (day, month, year components). It's designed to work with any
+ * date field prefix and can handle multiple dates within the same form.
+ *
+ * USAGE EXAMPLE:
+ *
+ * 1. Define your date configurations:
+ * ```javascript
+ * const dateConfigs = [
+ *   {
+ *     prefix: 'birth-date',
+ *     fieldNames: createDateFieldNames('birth-date'),
+ *     errorMessageKey: 'birthDateErrorMessage',
+ *     errorKeys: {
+ *       MISSING: 'CUSTOM_BIRTH_DATE_MISSING',
+ *       INVALID: 'CUSTOM_BIRTH_DATE_INVALID',
+ *       TODAY_OR_FUTURE: 'CUSTOM_BIRTH_DATE_TODAY_OR_FUTURE',
+ *       DAY: 'BIRTH_DATE_DAY',
+ *       MONTH: 'BIRTH_DATE_MONTH',
+ *       YEAR: 'BIRTH_DATE_YEAR'
+ *     },
+ *     fieldErrorKeys: {
+ *       'birth-date-day': 'BIRTH_DATE_DAY',
+ *       'birth-date-month': 'BIRTH_DATE_MONTH',
+ *       'birth-date-year': 'BIRTH_DATE_YEAR'
+ *     },
+ *     errorMessages: {
+ *       'CUSTOM_BIRTH_DATE_MISSING': 'Enter your birth date',
+ *       'CUSTOM_BIRTH_DATE_INVALID': 'Birth date must be a real date',
+ *       // ... other error messages
+ *     }
+ *   }
+ * ]
+ * ```
+ *
+ * 2. Use in your controller:
+ * ```javascript
+ * import { handleDateValidationErrors, extractMultipleDateFields } from '~/src/server/common/helpers/date-form-utils.js'
+ *
+ * export function handlePost(request, h) {
+ *   // Extract date fields from payload
+ *   const dateFields = extractMultipleDateFields(request.payload, [
+ *     { key: 'birthDate', prefix: 'birth-date' }
+ *   ])
+ *
+ *   // Handle validation errors
+ *   const failAction = (request, h, err) => {
+ *     return handleDateValidationErrors({
+ *       request,
+ *       h,
+ *       err,
+ *       dateConfigs,
+ *       errorMessages,
+ *       createTemplateData: (payload) => ({ ...dateFields }),
+ *       viewRoute: 'your/view/route'
+ *     })
+ *   }
+ * }
+ * ```
+ *
+ * FEATURES:
+ * - Generic field name generation for any date prefix
+ * - Automatic error message priority handling
+ * - Support for multiple dates in the same form
+ * - Custom validation error handling (missing dates, invalid dates, etc.)
+ * - Template data extraction and preparation
+ * - Backwards compatibility with existing implementations
+ */
+
+import {
+  errorDescriptionByFieldName,
+  mapErrorsForDisplay
+} from '~/src/server/common/helpers/errors.js'
+import { extractDateComponents } from '~/src/server/common/helpers/date-utils.js'
+
+/**
+ * Creates field names for a date with given prefix
+ * @param {string} prefix - Field prefix (e.g., 'activity-start-date')
+ * @returns {object} Field names object
+ */
+export function createDateFieldNames(prefix) {
+  return {
+    DAY: `${prefix}-day`,
+    MONTH: `${prefix}-month`,
+    YEAR: `${prefix}-year`
+  }
+}
+
+/**
+ * Extracts date fields from payload for a specific date prefix
+ * @param {object} payload - Form payload
+ * @param {string} prefix - Date field prefix
+ * @returns {object} Date field values
+ */
+export function extractDateFieldsFromPayload(payload, prefix) {
+  const fieldNames = createDateFieldNames(prefix)
+  return {
+    day: payload[fieldNames.DAY] || '',
+    month: payload[fieldNames.MONTH] || '',
+    year: payload[fieldNames.YEAR] || ''
+  }
+}
+
+/**
+ * Extracts multiple date fields from payload
+ * @param {object} payload - Form payload
+ * @param {Array<{key: string, prefix: string}>} dateConfigs - Array of date configurations
+ * @returns {object} All date field values
+ */
+export function extractMultipleDateFields(payload, dateConfigs) {
+  const result = {}
+  dateConfigs.forEach(({ key, prefix }) => {
+    const dateFields = extractDateFieldsFromPayload(payload, prefix)
+    result[`${key}Day`] = dateFields.day
+    result[`${key}Month`] = dateFields.month
+    result[`${key}Year`] = dateFields.year
+  })
+  return result
+}
+
+/**
+ * Creates date field values from existing date data
+ * @param {string|null} dateValue - ISO date string or null
+ * @returns {object} Date field components
+ */
+export function createDateFieldsFromValue(dateValue) {
+  const components = extractDateComponents(dateValue)
+  return {
+    day: components.day,
+    month: components.month,
+    year: components.year
+  }
+}
+
+/**
+ * Creates error type mapping from JOI error details
+ * @param {Array} errorDetails - JOI error details array
+ * @returns {object} Error type mapping
+ */
+export function createErrorTypeMap(errorDetails) {
+  const errorTypeMap = {}
+  errorDetails.forEach((detail) => {
+    errorTypeMap[detail.type] = detail
+    // Also map by path for field-specific errors
+    if (detail.path && detail.path.length > 0) {
+      errorTypeMap[detail.path[0]] = detail
+    }
+    // Also map by message for custom error types
+    if (detail.message !== detail.type) {
+      errorTypeMap[detail.message] = detail
+    }
+  })
+  return errorTypeMap
+}
+
+/**
+ * Checks if all date components are missing for complete date validation
+ * @param {object} errors - Error descriptions by field name
+ * @param {string} prefix - Date field prefix
+ * @param {object} fieldErrorKeys - Field error key mapping
+ * @returns {boolean}
+ */
+export function isCompleteDateMissing(errors, prefix, fieldErrorKeys) {
+  const fieldNames = createDateFieldNames(prefix)
+  const dayError = fieldErrorKeys[fieldNames.DAY]
+  const monthError = fieldErrorKeys[fieldNames.MONTH]
+  const yearError = fieldErrorKeys[fieldNames.YEAR]
+
+  return errors[dayError] && errors[monthError] && errors[yearError]
+}
+
+/**
+ * Checks if there are any number.max errors for date fields that should be treated as invalid date errors
+ * @param {string} prefix - Date field prefix (e.g., 'activity-start-date')
+ * @param {object} errorTypeMap - Error type mapping
+ * @returns {boolean} True if there are number.max errors for date fields
+ */
+export function hasNumberMaxErrorsForDate(prefix, errorTypeMap) {
+  const fieldNames = createDateFieldNames(prefix)
+
+  // Check if any of the date field errors are caused by number.max validation
+  const dayError = errorTypeMap[fieldNames.DAY]
+  const monthError = errorTypeMap[fieldNames.MONTH]
+
+  return (
+    (dayError && dayError.type === 'number.max') ||
+    (monthError && monthError.type === 'number.max')
+  )
+}
+
+/**
+ * Generic error message resolver for date fields
+ * @param {object} config - Configuration object
+ * @param {string} config.prefix - Date field prefix
+ * @param {boolean} config.isDateMissing - Whether date is completely missing
+ * @param {object} config.errorTypeMap - Error type mapping
+ * @param {object} config.errors - Error descriptions by field name
+ * @param {object} config.errorKeys - Error key mapping for this date type
+ * @param {object} config.errorMessages - Error message mapping
+ * @returns {object|null} Error message object or null
+ */
+export function getDateErrorMessage({
+  prefix,
+  isDateMissing,
+  errorTypeMap,
+  errors,
+  errorKeys,
+  errorMessages
+}) {
+  // Check if we have number.max errors that should be treated as invalid date errors
+  const hasInvalidDateFieldErrors = hasNumberMaxErrorsForDate(
+    prefix,
+    errorTypeMap
+  )
+
+  const errorPriority = [
+    {
+      condition: isDateMissing,
+      key: errorKeys.MISSING
+    },
+    {
+      condition: errorTypeMap[errorKeys.INVALID] || hasInvalidDateFieldErrors,
+      key: errorKeys.INVALID
+    },
+    {
+      condition: errorTypeMap[errorKeys.TODAY_OR_FUTURE],
+      key: errorKeys.TODAY_OR_FUTURE
+    },
+    {
+      condition: errorTypeMap[errorKeys.BEFORE_OTHER_DATE],
+      key: errorKeys.BEFORE_OTHER_DATE
+    },
+    {
+      condition: errors[errorKeys.DAY] && !hasInvalidDateFieldErrors,
+      key: errorKeys.DAY
+    },
+    {
+      condition: errors[errorKeys.MONTH] && !hasInvalidDateFieldErrors,
+      key: errorKeys.MONTH
+    },
+    {
+      condition: errors[errorKeys.YEAR] && !hasInvalidDateFieldErrors,
+      key: errorKeys.YEAR
+    }
+  ].filter((error) => error.key) // Filter out undefined keys
+
+  const errorToShow = errorPriority.find((error) => error.condition)
+  return errorToShow ? { text: errorMessages[errorToShow.key] } : null
+}
+
+/**
+ * Adds custom validation errors to error summary for multiple dates
+ * @param {Array} errorSummary - Current error summary array
+ * @param {object} errorTypeMap - Error type mapping
+ * @param {Array} dateConfigs - Array of date configurations
+ */
+export function addCustomValidationErrors(
+  errorSummary,
+  errorTypeMap,
+  dateConfigs
+) {
+  dateConfigs.forEach(({ prefix, errorKeys, errorMessages }) => {
+    // Check for number.max errors that should be treated as invalid date errors
+    const hasInvalidFieldErrors = hasNumberMaxErrorsForDate(
+      prefix,
+      errorTypeMap
+    )
+    const dateFieldNames = createDateFieldNames(prefix)
+
+    let dateErrorAdded = false
+
+    // Check for today/future error first (higher priority)
+    if (errorKeys.TODAY_OR_FUTURE && errorTypeMap[errorKeys.TODAY_OR_FUTURE]) {
+      errorSummary.push({
+        href: `#${dateFieldNames.DAY}`,
+        text: errorMessages[errorKeys.TODAY_OR_FUTURE]
+      })
+      dateErrorAdded = true
+    }
+
+    // Add invalid date error if no today/future error was added AND we have either
+    // a custom invalid error OR number.max errors for date fields
+    if (
+      !dateErrorAdded &&
+      errorKeys.INVALID &&
+      (errorTypeMap[errorKeys.INVALID] || hasInvalidFieldErrors)
+    ) {
+      errorSummary.push({
+        href: `#${dateFieldNames.DAY}`,
+        text: errorMessages[errorKeys.INVALID]
+      })
+      dateErrorAdded = true
+    }
+
+    // Date relationship error (e.g., end before start)
+    if (
+      errorKeys.BEFORE_OTHER_DATE &&
+      errorTypeMap[errorKeys.BEFORE_OTHER_DATE]
+    ) {
+      errorSummary.push({
+        href: `#${dateFieldNames.DAY}`,
+        text: errorMessages[errorKeys.BEFORE_OTHER_DATE]
+      })
+    }
+  })
+}
+
+/**
+ * Handles missing complete date errors in summary
+ * @param {Array} errorSummary - Current error summary array
+ * @param {Array} missingDates - Array of missing date configurations
+ * @returns {Array} Modified error summary
+ */
+export function handleMissingDateErrors(errorSummary, missingDates) {
+  let modifiedSummary = [...errorSummary]
+
+  missingDates.forEach(({ prefix, errorKey, errorMessage, fieldNames }) => {
+    // Remove existing errors for this date
+    modifiedSummary = modifiedSummary.filter(
+      (error) => !error.href.includes(`#${prefix}`)
+    )
+
+    // Add the missing date error
+    const position = errorKey.includes('START') ? 'unshift' : 'push'
+    modifiedSummary[position]({
+      href: `#${fieldNames.DAY}`,
+      text: errorMessage
+    })
+  })
+
+  return modifiedSummary
+}
+
+/**
+ * Processes validation errors for date forms
+ * @param {object} config - Configuration object
+ * @param {object} config.request - Hapi request object
+ * @param {object} config.h - Hapi response toolkit
+ * @param {Error} config.err - Validation error
+ * @param {Array} config.dateConfigs - Array of date configurations
+ * @param {object} config.errorMessages - Error message mapping
+ * @param {Function} config.createTemplateData - Function to create template data
+ * @param {string} config.viewRoute - View route for rendering
+ * @returns {object} Response with error template
+ */
+export function handleDateValidationErrors({
+  request,
+  h,
+  err,
+  dateConfigs,
+  errorMessages,
+  createTemplateData,
+  viewRoute
+}) {
+  const { payload } = request
+
+  if (!err.details) {
+    return h.view(viewRoute, createTemplateData(payload)).takeover()
+  }
+
+  const errorSummary = mapErrorsForDisplay(err.details, errorMessages)
+  const errors = errorDescriptionByFieldName(errorSummary)
+  const errorTypeMap = createErrorTypeMap(err.details)
+
+  // Check for missing dates
+  const missingDates = []
+  dateConfigs.forEach((config) => {
+    const isDateMissing = isCompleteDateMissing(
+      errors,
+      config.prefix,
+      config.fieldErrorKeys
+    )
+    if (isDateMissing) {
+      missingDates.push({
+        prefix: config.prefix,
+        errorKey: config.errorKeys.MISSING,
+        errorMessage: errorMessages[config.errorKeys.MISSING],
+        fieldNames: config.fieldNames
+      })
+    }
+  })
+
+  let modifiedErrorSummary = errorSummary.filter(
+    (error) => error.href && error.href !== '#' && error.href !== '#undefined'
+  )
+
+  addCustomValidationErrors(modifiedErrorSummary, errorTypeMap, dateConfigs)
+  modifiedErrorSummary = handleMissingDateErrors(
+    modifiedErrorSummary,
+    missingDates
+  )
+
+  // Generate error messages for each date
+  const dateErrorMessages = {}
+  dateConfigs.forEach((config) => {
+    const isDateMissing = missingDates.some(
+      (missing) => missing.prefix === config.prefix
+    )
+    const errorMessage = getDateErrorMessage({
+      prefix: config.prefix,
+      isDateMissing,
+      errorTypeMap,
+      errors,
+      errorKeys: config.errorKeys,
+      errorMessages
+    })
+    dateErrorMessages[config.errorMessageKey] = errorMessage
+  })
+
+  return h
+    .view(viewRoute, {
+      ...createTemplateData(payload),
+      errors,
+      errorSummary: modifiedErrorSummary,
+      ...dateErrorMessages
+    })
+    .takeover()
+}

--- a/src/server/common/helpers/date-form-utils.test.js
+++ b/src/server/common/helpers/date-form-utils.test.js
@@ -1,0 +1,315 @@
+import {
+  createDateFieldNames,
+  extractDateFieldsFromPayload,
+  extractMultipleDateFields,
+  createDateFieldsFromValue,
+  createErrorTypeMap,
+  isCompleteDateMissing,
+  hasNumberMaxErrorsForDate,
+  getDateErrorMessage,
+  addCustomValidationErrors,
+  handleMissingDateErrors,
+  handleDateValidationErrors
+} from '~/src/server/common/helpers/date-form-utils.js'
+
+describe('Date Form Utils', () => {
+  describe('createDateFieldNames', () => {
+    test('should create field names for a given prefix', () => {
+      const result = createDateFieldNames('birth-date')
+      expect(result).toEqual({
+        DAY: 'birth-date-day',
+        MONTH: 'birth-date-month',
+        YEAR: 'birth-date-year'
+      })
+    })
+  })
+
+  describe('extractDateFieldsFromPayload', () => {
+    test('should extract date fields for a given prefix', () => {
+      const payload = {
+        'birth-date-day': '15',
+        'birth-date-month': '06',
+        'birth-date-year': '1990'
+      }
+
+      const result = extractDateFieldsFromPayload(payload, 'birth-date')
+      expect(result).toEqual({
+        day: '15',
+        month: '06',
+        year: '1990'
+      })
+    })
+
+    test('should return empty strings for missing fields', () => {
+      const payload = {}
+
+      const result = extractDateFieldsFromPayload(payload, 'birth-date')
+      expect(result).toEqual({
+        day: '',
+        month: '',
+        year: ''
+      })
+    })
+  })
+
+  describe('extractMultipleDateFields', () => {
+    test('should extract multiple date fields', () => {
+      const payload = {
+        'start-date-day': '01',
+        'start-date-month': '01',
+        'start-date-year': '2025',
+        'end-date-day': '31',
+        'end-date-month': '12',
+        'end-date-year': '2025'
+      }
+
+      const dateConfigs = [
+        { key: 'startDate', prefix: 'start-date' },
+        { key: 'endDate', prefix: 'end-date' }
+      ]
+
+      const result = extractMultipleDateFields(payload, dateConfigs)
+      expect(result).toEqual({
+        startDateDay: '01',
+        startDateMonth: '01',
+        startDateYear: '2025',
+        endDateDay: '31',
+        endDateMonth: '12',
+        endDateYear: '2025'
+      })
+    })
+  })
+
+  describe('createDateFieldsFromValue', () => {
+    test('should extract date components from ISO string', () => {
+      const result = createDateFieldsFromValue('2025-06-15T00:00:00.000Z')
+      expect(result).toEqual({
+        day: '15',
+        month: '6',
+        year: '2025'
+      })
+    })
+
+    test('should handle null date values', () => {
+      const result = createDateFieldsFromValue(null)
+      expect(result).toEqual({
+        day: '',
+        month: '',
+        year: ''
+      })
+    })
+  })
+
+  describe('createErrorTypeMap', () => {
+    test('should create error type mapping from details', () => {
+      const errorDetails = [
+        { type: 'number.max', path: ['test-field'], message: 'custom message' },
+        { type: 'any.required', path: ['other-field'], message: 'any.required' }
+      ]
+
+      const result = createErrorTypeMap(errorDetails)
+      expect(result).toEqual({
+        'number.max': errorDetails[0],
+        'test-field': errorDetails[0],
+        'custom message': errorDetails[0],
+        'any.required': errorDetails[1],
+        'other-field': errorDetails[1]
+      })
+    })
+  })
+
+  describe('isCompleteDateMissing', () => {
+    test('should return true when all date components are missing', () => {
+      const errors = {
+        'day-error': true,
+        'month-error': true,
+        'year-error': true
+      }
+      const fieldErrorKeys = {
+        'test-date-day': 'day-error',
+        'test-date-month': 'month-error',
+        'test-date-year': 'year-error'
+      }
+
+      const result = isCompleteDateMissing(errors, 'test-date', fieldErrorKeys)
+      expect(result).toBe(true)
+    })
+
+    test('should return false when some date components are present', () => {
+      const errors = {
+        'day-error': true,
+        'month-error': false,
+        'year-error': true
+      }
+      const fieldErrorKeys = {
+        'test-date-day': 'day-error',
+        'test-date-month': 'month-error',
+        'test-date-year': 'year-error'
+      }
+
+      const result = isCompleteDateMissing(errors, 'test-date', fieldErrorKeys)
+      expect(result).toBe(false)
+    })
+  })
+
+  describe('hasNumberMaxErrorsForDate', () => {
+    test('should return true when there are number.max errors for date fields', () => {
+      const errorTypeMap = {
+        'test-date-day': { type: 'number.max' },
+        'test-date-month': { type: 'any.required' }
+      }
+
+      const result = hasNumberMaxErrorsForDate('test-date', errorTypeMap)
+      expect(result).toBe(true)
+    })
+
+    test('should return false when there are no number.max errors', () => {
+      const errorTypeMap = {
+        'test-date-day': { type: 'any.required' },
+        'test-date-month': { type: 'any.required' }
+      }
+
+      const result = hasNumberMaxErrorsForDate('test-date', errorTypeMap)
+      expect(result).toBe(false)
+    })
+  })
+
+  describe('getDateErrorMessage', () => {
+    const mockErrorMessages = {
+      missing: 'Date is missing',
+      invalid: 'Date is invalid',
+      future: 'Date must be in future',
+      day: 'Day is required',
+      month: 'Month is required'
+    }
+
+    test('should return missing error message with highest priority', () => {
+      const config = {
+        prefix: 'test-date',
+        isDateMissing: true,
+        errorTypeMap: {},
+        errors: {},
+        errorKeys: {
+          MISSING: 'missing',
+          INVALID: 'invalid'
+        },
+        errorMessages: mockErrorMessages
+      }
+
+      const result = getDateErrorMessage(config)
+      expect(result).toEqual({ text: 'Date is missing' })
+    })
+
+    test('should return invalid error message when not missing but invalid', () => {
+      const config = {
+        prefix: 'test-date',
+        isDateMissing: false,
+        errorTypeMap: { invalid: true },
+        errors: {},
+        errorKeys: {
+          MISSING: 'missing',
+          INVALID: 'invalid'
+        },
+        errorMessages: mockErrorMessages
+      }
+
+      const result = getDateErrorMessage(config)
+      expect(result).toEqual({ text: 'Date is invalid' })
+    })
+
+    test('should return null when no errors match', () => {
+      const config = {
+        prefix: 'test-date',
+        isDateMissing: false,
+        errorTypeMap: {},
+        errors: {},
+        errorKeys: {
+          MISSING: 'missing'
+        },
+        errorMessages: mockErrorMessages
+      }
+
+      const result = getDateErrorMessage(config)
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('addCustomValidationErrors', () => {
+    test('should add custom validation errors to error summary', () => {
+      const errorSummary = []
+      const errorTypeMap = {
+        'invalid-error': true,
+        'future-error': true
+      }
+      const dateConfigs = [
+        {
+          prefix: 'test-date',
+          fieldNames: { DAY: 'test-date-day' },
+          errorKeys: {
+            INVALID: 'invalid-error',
+            TODAY_OR_FUTURE: 'future-error'
+          },
+          errorMessages: {
+            'invalid-error': 'Date is invalid',
+            'future-error': 'Date must be future'
+          }
+        }
+      ]
+
+      addCustomValidationErrors(errorSummary, errorTypeMap, dateConfigs)
+
+      expect(errorSummary).toHaveLength(1)
+      expect(errorSummary[0]).toEqual({
+        href: '#test-date-day',
+        text: 'Date must be future'
+      })
+    })
+  })
+
+  describe('handleMissingDateErrors', () => {
+    test('should handle missing date errors in summary', () => {
+      const errorSummary = [{ href: '#other-field', text: 'Other error' }]
+      const missingDates = [
+        {
+          prefix: 'test-date',
+          errorKey: 'MISSING_START',
+          errorMessage: 'Start date is missing',
+          fieldNames: { DAY: 'test-date-day' }
+        }
+      ]
+
+      const result = handleMissingDateErrors(errorSummary, missingDates)
+
+      expect(result).toHaveLength(2)
+      expect(result[0]).toEqual({
+        href: '#test-date-day',
+        text: 'Start date is missing'
+      })
+    })
+  })
+
+  describe('handleDateValidationErrors', () => {
+    test('should handle validation errors with no details', () => {
+      const mockRequest = { payload: {} }
+      const mockH = {
+        view: jest.fn().mockReturnValue({ takeover: jest.fn() })
+      }
+      const mockErr = {}
+      const mockCreateTemplateData = jest.fn().mockReturnValue({ test: 'data' })
+
+      const config = {
+        request: mockRequest,
+        h: mockH,
+        err: mockErr,
+        dateConfigs: [],
+        errorMessages: {},
+        createTemplateData: mockCreateTemplateData,
+        viewRoute: 'test/view'
+      }
+
+      handleDateValidationErrors(config)
+
+      expect(mockH.view).toHaveBeenCalledWith('test/view', { test: 'data' })
+    })
+  })
+})

--- a/src/server/common/helpers/date-utils.js
+++ b/src/server/common/helpers/date-utils.js
@@ -1,0 +1,129 @@
+/**
+ * Day.js-based date utility functions for handling date operations across the application
+ */
+import dayjs from 'dayjs'
+import utc from 'dayjs/plugin/utc'
+import customParseFormat from 'dayjs/plugin/customParseFormat'
+import isSameOrAfter from 'dayjs/plugin/isSameOrAfter'
+import isSameOrBefore from 'dayjs/plugin/isSameOrBefore'
+
+// Extend dayjs with plugins
+dayjs.extend(utc)
+dayjs.extend(customParseFormat)
+dayjs.extend(isSameOrAfter)
+dayjs.extend(isSameOrBefore)
+
+/**
+ * Creates a date from individual components and returns ISO string
+ * @param {string|number} year
+ * @param {string|number} month
+ * @param {string|number} day
+ * @returns {string|null}
+ */
+export function createDateISO(year, month, day) {
+  // Handle undefined or null values
+  if (year == null || month == null || day == null) {
+    return null
+  }
+
+  const date = dayjs.utc(
+    `${year}-${month.toString().padStart(2, '0')}-${day.toString().padStart(2, '0')}`,
+    'YYYY-MM-DD',
+    true // strict parsing
+  )
+
+  return date.isValid() ? date.toISOString() : null
+}
+
+/**
+ * Extracts date components from ISO date string
+ * @param {string} isoDate - ISO date string
+ * @returns {object} Date components
+ */
+export function extractDateComponents(isoDate) {
+  if (!isoDate) {
+    return { day: '', month: '', year: '' }
+  }
+
+  const date = dayjs.utc(isoDate)
+  return {
+    day: date.date().toString(),
+    month: (date.month() + 1).toString(), // dayjs months are 0-indexed
+    year: date.year().toString()
+  }
+}
+
+/**
+ * Formats a date object to a human-readable string
+ * @param {Date|string} date - Date object or ISO string
+ * @param {string} format - Day.js format string (default: 'D MMMM YYYY')
+ * @returns {string} Formatted date string
+ */
+export function formatDate(date, format = 'D MMMM YYYY') {
+  const dayjsDate = typeof date === 'string' ? dayjs.utc(date) : dayjs.utc(date)
+  return dayjsDate.format(format)
+}
+
+/**
+ * Validates if date components form a valid date
+ * @param {number} year
+ * @param {number} month
+ * @param {number} day
+ * @returns {boolean}
+ */
+export function isValidDateComponents(year, month, day) {
+  const date = dayjs.utc(`${year}-${month}-${day}`, 'YYYY-M-D', true)
+  return date.isValid()
+}
+
+/**
+ * Checks if a date is today or in the future
+ * @param {Date|string} date - Date to check
+ * @returns {boolean}
+ */
+export function isTodayOrFuture(date) {
+  const inputDate = typeof date === 'string' ? dayjs.utc(date) : dayjs.utc(date)
+  const today = dayjs.utc().startOf('day')
+
+  return inputDate.isSameOrAfter(today, 'day')
+}
+
+/**
+ * Compares two dates and returns -1, 0, or 1
+ * @param {Date|string} date1
+ * @param {Date|string} date2
+ * @returns {number} -1 if date1 < date2, 0 if equal, 1 if date1 > date2
+ */
+export function compareDates(date1, date2) {
+  const d1 = typeof date1 === 'string' ? dayjs.utc(date1) : dayjs.utc(date1)
+  const d2 = typeof date2 === 'string' ? dayjs.utc(date2) : dayjs.utc(date2)
+
+  if (d1.isBefore(d2)) return -1
+  if (d1.isAfter(d2)) return 1
+  return 0
+}
+
+/**
+ * Checks if end date is before start date
+ * @param {string} startDate - ISO date string
+ * @param {string} endDate - ISO date string
+ * @returns {boolean}
+ */
+export function isEndDateBeforeStartDate(startDate, endDate) {
+  const start = dayjs.utc(startDate)
+  const end = dayjs.utc(endDate)
+
+  return end.isBefore(start, 'day')
+}
+
+/**
+ * Creates a Day.js date from components with validation
+ * @param {number} year
+ * @param {number} month
+ * @param {number} day
+ * @returns {dayjs.Dayjs|null} Day.js object or null if invalid
+ */
+export function createDayjsDate(year, month, day) {
+  const date = dayjs.utc(`${year}-${month}-${day}`, 'YYYY-M-D', true)
+  return date.isValid() ? date : null
+}

--- a/src/server/common/helpers/date-utils.js
+++ b/src/server/common/helpers/date-utils.js
@@ -13,6 +13,10 @@ dayjs.extend(customParseFormat)
 dayjs.extend(isSameOrAfter)
 dayjs.extend(isSameOrBefore)
 
+// Date format constants
+const DATE_FORMAT_ISO = 'YYYY-MM-DD'
+const DATE_FORMAT_FLEXIBLE = 'YYYY-M-D'
+
 /**
  * Creates a date from individual components and returns ISO string
  * @param {string|number} year
@@ -28,7 +32,7 @@ export function createDateISO(year, month, day) {
 
   const date = dayjs.utc(
     `${year}-${month.toString().padStart(2, '0')}-${day.toString().padStart(2, '0')}`,
-    'YYYY-MM-DD',
+    DATE_FORMAT_ISO,
     true // strict parsing
   )
 
@@ -60,8 +64,7 @@ export function extractDateComponents(isoDate) {
  * @returns {string} Formatted date string
  */
 export function formatDate(date, format = 'D MMMM YYYY') {
-  const dayjsDate = typeof date === 'string' ? dayjs.utc(date) : dayjs.utc(date)
-  return dayjsDate.format(format)
+  return dayjs.utc(date).format(format)
 }
 
 /**
@@ -72,7 +75,7 @@ export function formatDate(date, format = 'D MMMM YYYY') {
  * @returns {boolean}
  */
 export function isValidDateComponents(year, month, day) {
-  const date = dayjs.utc(`${year}-${month}-${day}`, 'YYYY-M-D', true)
+  const date = dayjs.utc(`${year}-${month}-${day}`, DATE_FORMAT_FLEXIBLE, true)
   return date.isValid()
 }
 
@@ -82,7 +85,7 @@ export function isValidDateComponents(year, month, day) {
  * @returns {boolean}
  */
 export function isTodayOrFuture(date) {
-  const inputDate = typeof date === 'string' ? dayjs.utc(date) : dayjs.utc(date)
+  const inputDate = dayjs.utc(date)
   const today = dayjs.utc().startOf('day')
 
   return inputDate.isSameOrAfter(today, 'day')
@@ -95,11 +98,15 @@ export function isTodayOrFuture(date) {
  * @returns {number} -1 if date1 < date2, 0 if equal, 1 if date1 > date2
  */
 export function compareDates(date1, date2) {
-  const d1 = typeof date1 === 'string' ? dayjs.utc(date1) : dayjs.utc(date1)
-  const d2 = typeof date2 === 'string' ? dayjs.utc(date2) : dayjs.utc(date2)
+  const d1 = dayjs.utc(date1)
+  const d2 = dayjs.utc(date2)
 
-  if (d1.isBefore(d2)) return -1
-  if (d1.isAfter(d2)) return 1
+  if (d1.isBefore(d2)) {
+    return -1
+  }
+  if (d1.isAfter(d2)) {
+    return 1
+  }
   return 0
 }
 
@@ -124,6 +131,6 @@ export function isEndDateBeforeStartDate(startDate, endDate) {
  * @returns {dayjs.Dayjs|null} Day.js object or null if invalid
  */
 export function createDayjsDate(year, month, day) {
-  const date = dayjs.utc(`${year}-${month}-${day}`, 'YYYY-M-D', true)
+  const date = dayjs.utc(`${year}-${month}-${day}`, DATE_FORMAT_FLEXIBLE, true)
   return date.isValid() ? date : null
 }

--- a/src/server/common/helpers/date-utils.js
+++ b/src/server/common/helpers/date-utils.js
@@ -2,10 +2,10 @@
  * Day.js-based date utility functions for handling date operations across the application
  */
 import dayjs from 'dayjs'
-import utc from 'dayjs/plugin/utc'
-import customParseFormat from 'dayjs/plugin/customParseFormat'
-import isSameOrAfter from 'dayjs/plugin/isSameOrAfter'
-import isSameOrBefore from 'dayjs/plugin/isSameOrBefore'
+import utc from 'dayjs/plugin/utc.js'
+import customParseFormat from 'dayjs/plugin/customParseFormat.js'
+import isSameOrAfter from 'dayjs/plugin/isSameOrAfter.js'
+import isSameOrBefore from 'dayjs/plugin/isSameOrBefore.js'
 
 // Extend dayjs with plugins
 dayjs.extend(utc)

--- a/src/server/common/helpers/date-utils.test.js
+++ b/src/server/common/helpers/date-utils.test.js
@@ -1,0 +1,274 @@
+import {
+  createDateISO,
+  extractDateComponents,
+  formatDate,
+  isValidDateComponents,
+  isTodayOrFuture,
+  compareDates,
+  isEndDateBeforeStartDate,
+  createDayjsDate
+} from './date-utils.js'
+
+describe('date-utils', () => {
+  describe('createDateISO', () => {
+    test('creates ISO string from valid date components', () => {
+      const result = createDateISO(2025, 6, 15)
+      expect(result).toBe('2025-06-15T00:00:00.000Z')
+    })
+
+    test('handles string inputs', () => {
+      const result = createDateISO('2025', '6', '15')
+      expect(result).toBe('2025-06-15T00:00:00.000Z')
+    })
+
+    test('returns null for invalid year', () => {
+      const result = createDateISO('invalid', 6, 15)
+      expect(result).toBeNull()
+    })
+
+    test('returns null for invalid month', () => {
+      const result = createDateISO(2025, 'invalid', 15)
+      expect(result).toBeNull()
+    })
+
+    test('returns null for invalid day', () => {
+      const result = createDateISO(2025, 6, 'invalid')
+      expect(result).toBeNull()
+    })
+
+    test('returns null for impossible date (strict parsing)', () => {
+      const result = createDateISO(2025, 2, 29) // Not a leap year
+      expect(result).toBeNull()
+    })
+
+    test('handles valid leap year date', () => {
+      const result = createDateISO(2024, 2, 29) // Leap year
+      expect(result).toBe('2024-02-29T00:00:00.000Z')
+    })
+
+    test('returns null for null values', () => {
+      expect(createDateISO(null, 6, 15)).toBeNull()
+      expect(createDateISO(2025, null, 15)).toBeNull()
+      expect(createDateISO(2025, 6, null)).toBeNull()
+    })
+
+    test('returns null for undefined values', () => {
+      expect(createDateISO(undefined, 6, 15)).toBeNull()
+      expect(createDateISO(2025, undefined, 15)).toBeNull()
+      expect(createDateISO(2025, 6, undefined)).toBeNull()
+    })
+  })
+
+  describe('extractDateComponents', () => {
+    test('extracts components from ISO date string', () => {
+      const result = extractDateComponents('2025-06-15T00:00:00.000Z')
+      expect(result).toEqual({
+        day: '15',
+        month: '6',
+        year: '2025'
+      })
+    })
+
+    test('returns empty strings for null input', () => {
+      const result = extractDateComponents(null)
+      expect(result).toEqual({
+        day: '',
+        month: '',
+        year: ''
+      })
+    })
+
+    test('returns empty strings for undefined input', () => {
+      const result = extractDateComponents(undefined)
+      expect(result).toEqual({
+        day: '',
+        month: '',
+        year: ''
+      })
+    })
+
+    test('returns empty strings for empty string input', () => {
+      const result = extractDateComponents('')
+      expect(result).toEqual({
+        day: '',
+        month: '',
+        year: ''
+      })
+    })
+  })
+
+  describe('formatDate', () => {
+    test('formats date object with default format', () => {
+      const date = new Date('2025-06-15T00:00:00.000Z')
+      const result = formatDate(date)
+      expect(result).toBe('15 June 2025')
+    })
+
+    test('formats ISO string with default format', () => {
+      const result = formatDate('2025-06-15T00:00:00.000Z')
+      expect(result).toBe('15 June 2025')
+    })
+
+    test('formats date with custom Day.js format', () => {
+      const date = new Date('2025-06-15T00:00:00.000Z')
+      const result = formatDate(date, 'DD MMM YY')
+      expect(result).toBe('15 Jun 25')
+    })
+
+    test('formats date with different Day.js format patterns', () => {
+      const date = new Date('2025-06-15T00:00:00.000Z')
+      expect(formatDate(date, 'YYYY-MM-DD')).toBe('2025-06-15')
+      expect(formatDate(date, 'dddd, MMMM D, YYYY')).toBe(
+        'Sunday, June 15, 2025'
+      )
+    })
+  })
+
+  describe('isValidDateComponents', () => {
+    test('returns true for valid date components', () => {
+      const result = isValidDateComponents(2025, 6, 15)
+      expect(result).toBe(true)
+    })
+
+    test('returns false for invalid day (leap year)', () => {
+      const result = isValidDateComponents(2024, 2, 30)
+      expect(result).toBe(false)
+    })
+
+    test('returns false for invalid day (non-leap year)', () => {
+      const result = isValidDateComponents(2025, 2, 29)
+      expect(result).toBe(false)
+    })
+
+    test('returns false for invalid month', () => {
+      const result = isValidDateComponents(2025, 13, 15)
+      expect(result).toBe(false)
+    })
+
+    test('returns true for valid leap year date', () => {
+      const result = isValidDateComponents(2024, 2, 29)
+      expect(result).toBe(true)
+    })
+  })
+
+  describe('isTodayOrFuture', () => {
+    beforeEach(() => {
+      jest.useFakeTimers()
+      jest.setSystemTime(new Date('2025-06-15T12:00:00.000Z'))
+    })
+
+    afterEach(() => {
+      jest.useRealTimers()
+    })
+
+    test('returns true for future date', () => {
+      const futureDate = new Date('2025-06-16T00:00:00.000Z')
+      const result = isTodayOrFuture(futureDate)
+      expect(result).toBe(true)
+    })
+
+    test('returns true for today', () => {
+      const todayDate = new Date('2025-06-15T00:00:00.000Z')
+      const result = isTodayOrFuture(todayDate)
+      expect(result).toBe(true)
+    })
+
+    test('returns false for past date', () => {
+      const pastDate = new Date('2025-06-14T00:00:00.000Z')
+      const result = isTodayOrFuture(pastDate)
+      expect(result).toBe(false)
+    })
+
+    test('handles ISO string input', () => {
+      const result = isTodayOrFuture('2025-06-16T00:00:00.000Z')
+      expect(result).toBe(true)
+    })
+  })
+
+  describe('compareDates', () => {
+    test('returns -1 when first date is earlier', () => {
+      const date1 = new Date('2025-06-14T00:00:00.000Z')
+      const date2 = new Date('2025-06-15T00:00:00.000Z')
+      const result = compareDates(date1, date2)
+      expect(result).toBe(-1)
+    })
+
+    test('returns 1 when first date is later', () => {
+      const date1 = new Date('2025-06-16T00:00:00.000Z')
+      const date2 = new Date('2025-06-15T00:00:00.000Z')
+      const result = compareDates(date1, date2)
+      expect(result).toBe(1)
+    })
+
+    test('returns 0 when dates are equal', () => {
+      const date1 = new Date('2025-06-15T00:00:00.000Z')
+      const date2 = new Date('2025-06-15T00:00:00.000Z')
+      const result = compareDates(date1, date2)
+      expect(result).toBe(0)
+    })
+
+    test('handles ISO string inputs', () => {
+      const result = compareDates(
+        '2025-06-14T00:00:00.000Z',
+        '2025-06-15T00:00:00.000Z'
+      )
+      expect(result).toBe(-1)
+    })
+
+    test('handles mixed Date and string inputs', () => {
+      const date1 = new Date('2025-06-14T00:00:00.000Z')
+      const result = compareDates(date1, '2025-06-15T00:00:00.000Z')
+      expect(result).toBe(-1)
+    })
+  })
+
+  describe('isEndDateBeforeStartDate', () => {
+    test('returns true when end date is before start date', () => {
+      const startDate = '2025-06-15T00:00:00.000Z'
+      const endDate = '2025-06-14T00:00:00.000Z'
+      const result = isEndDateBeforeStartDate(startDate, endDate)
+      expect(result).toBe(true)
+    })
+
+    test('returns false when end date is after start date', () => {
+      const startDate = '2025-06-15T00:00:00.000Z'
+      const endDate = '2025-06-16T00:00:00.000Z'
+      const result = isEndDateBeforeStartDate(startDate, endDate)
+      expect(result).toBe(false)
+    })
+
+    test('returns false when dates are the same', () => {
+      const startDate = '2025-06-15T00:00:00.000Z'
+      const endDate = '2025-06-15T00:00:00.000Z'
+      const result = isEndDateBeforeStartDate(startDate, endDate)
+      expect(result).toBe(false)
+    })
+  })
+
+  describe('createDayjsDate', () => {
+    test('creates valid Day.js date from components', () => {
+      const result = createDayjsDate(2025, 6, 15)
+      expect(result).not.toBeNull()
+      expect(result.isValid()).toBe(true)
+      expect(result.year()).toBe(2025)
+      expect(result.month() + 1).toBe(6) // dayjs months are 0-indexed
+      expect(result.date()).toBe(15)
+    })
+
+    test('returns null for invalid date components', () => {
+      const result = createDayjsDate(2025, 13, 15)
+      expect(result).toBeNull()
+    })
+
+    test('returns null for invalid leap year date', () => {
+      const result = createDayjsDate(2025, 2, 29)
+      expect(result).toBeNull()
+    })
+
+    test('creates valid date for leap year', () => {
+      const result = createDayjsDate(2024, 2, 29)
+      expect(result).not.toBeNull()
+      expect(result.isValid()).toBe(true)
+    })
+  })
+})

--- a/src/server/common/schemas/date.js
+++ b/src/server/common/schemas/date.js
@@ -1,7 +1,7 @@
 import joi from 'joi'
 import dayjs from 'dayjs'
-import utc from 'dayjs/plugin/utc'
-import customParseFormat from 'dayjs/plugin/customParseFormat'
+import utc from 'dayjs/plugin/utc.js'
+import customParseFormat from 'dayjs/plugin/customParseFormat.js'
 import { JOI_ERRORS } from '~/src/server/common/constants/joi.js'
 
 dayjs.extend(utc)

--- a/src/server/common/schemas/date.js
+++ b/src/server/common/schemas/date.js
@@ -1,7 +1,13 @@
 import joi from 'joi'
+import dayjs from 'dayjs'
+import utc from 'dayjs/plugin/utc'
+import customParseFormat from 'dayjs/plugin/customParseFormat'
 import { JOI_ERRORS } from '~/src/server/common/constants/joi.js'
 
-const MIN_YEAR = new Date().getFullYear()
+dayjs.extend(utc)
+dayjs.extend(customParseFormat)
+
+const MIN_YEAR = dayjs().year()
 const MAX_YEAR_OFFSET = 75
 const MAX_YEAR = MIN_YEAR + MAX_YEAR_OFFSET
 
@@ -62,21 +68,36 @@ export const individualDate = ({
 })
 
 /**
- * Validates if a date object matches its components
- * @param {object} params - Parameters object
- * @param {Date} params.date - Date object to validate
- * @param {number} params.day - Day component
- * @param {number} params.month - Month component
- * @param {number} params.year - Year component
- * @returns {boolean} True if date matches components
+ * Validates if date components form a valid Day.js date
+ * @param {number} year - Year component
+ * @param {number} month - Month component (1-12)
+ * @param {number} day - Day component (1-31)
+ * @returns {boolean} True if date is valid
  */
-const isValidDate = ({ date, day, month, year }) =>
-  date.getUTCFullYear() === year &&
-  date.getUTCMonth() === month - 1 &&
-  date.getUTCDate() === day
+const isValidDate = (year, month, day) => {
+  // Create the date with strict parsing
+  const date = dayjs.utc(
+    `${year}-${month.toString().padStart(2, '0')}-${day.toString().padStart(2, '0')}`,
+    'YYYY-MM-DD',
+    true
+  )
+
+  // Check if Day.js created a valid date AND the components match exactly
+  // This prevents Day.js from "correcting" invalid dates like Feb 30th -> Mar 2nd
+  if (!date.isValid()) {
+    return false
+  }
+
+  // Verify the parsed date components match the input exactly
+  return (
+    date.year() === year &&
+    date.month() + 1 === month && // Day.js months are 0-indexed
+    date.date() === day
+  )
+}
 
 /**
- * Activity dates schema for start and end date validation
+ * Activity dates schema for start and end date validation using Day.js
  */
 export const activityDatesSchema = joi
   .object({
@@ -103,47 +124,40 @@ export const activityDatesSchema = joi
       'activity-end-date-year': endYear
     } = value
 
-    const startDate = new Date(Date.UTC(startYear, startMonth - 1, startDay))
-    const endDate = new Date(Date.UTC(endYear, endMonth - 1, endDay))
-    const today = new Date()
-    today.setHours(0, 0, 0, 0)
-
-    // Validate start date is a real date
-    if (
-      !isValidDate({
-        date: startDate,
-        day: startDay,
-        month: startMonth,
-        year: startYear
-      })
-    ) {
+    // Validate start date components form a valid date
+    if (!isValidDate(startYear, startMonth, startDay)) {
       return helpers.error('custom.startDate.invalid')
     }
 
-    // Validate end date is a real date
-    if (
-      !isValidDate({
-        date: endDate,
-        day: endDay,
-        month: endMonth,
-        year: endYear
-      })
-    ) {
+    // Validate end date components form a valid date
+    if (!isValidDate(endYear, endMonth, endDay)) {
       return helpers.error('custom.endDate.invalid')
     }
 
-    // Check end date future validation before date order (for consistency with existing behavior)
-    if (endDate < today) {
-      return helpers.error('custom.endDate.todayOrFuture')
-    }
+    // Create Day.js dates for comparison (we know they're valid now)
+    const startDate = dayjs.utc(
+      `${startYear}-${startMonth.toString().padStart(2, '0')}-${startDay.toString().padStart(2, '0')}`,
+      'YYYY-MM-DD'
+    )
+    const endDate = dayjs.utc(
+      `${endYear}-${endMonth.toString().padStart(2, '0')}-${endDay.toString().padStart(2, '0')}`,
+      'YYYY-MM-DD'
+    )
+    const today = dayjs.utc().startOf('day')
 
-    // Validate date order
-    if (endDate < startDate) {
+    // Check date order first - if end date is before start date, show that error
+    // regardless of whether dates are in the past
+    if (endDate.isBefore(startDate, 'day')) {
       return helpers.error('custom.endDate.before.startDate')
     }
 
+    // Then check future date validation for end date
+    if (endDate.isBefore(today, 'day')) {
+      return helpers.error('custom.endDate.todayOrFuture')
+    }
+
     // Check start date future validation last
-    if (startDate < today) {
+    if (startDate.isBefore(today, 'day')) {
       return helpers.error('custom.startDate.todayOrFuture')
     }
 

--- a/src/server/common/schemas/date.js
+++ b/src/server/common/schemas/date.js
@@ -42,6 +42,122 @@ function isDateTodayOrFuture(date) {
   return date >= today
 }
 
+/**
+ * Validates if date component values are valid numbers
+ * @param {number} day
+ * @param {number} month
+ * @param {number} year
+ * @returns {boolean}
+ */
+function areComponentsValidNumbers(day, month, year) {
+  return !isNaN(day) && !isNaN(month) && !isNaN(year)
+}
+
+/**
+ * Validates if date component values are within valid ranges
+ * @param {number} day
+ * @param {number} month
+ * @param {number} year
+ * @returns {boolean}
+ */
+function areComponentsInValidRange(day, month, year) {
+  return (
+    day >= 1 &&
+    day <= MAX_DAYS_IN_MONTH &&
+    month >= 1 &&
+    month <= MAX_MONTHS_IN_YEAR &&
+    year >= MIN_YEAR &&
+    year <= MAX_YEAR
+  )
+}
+
+/**
+ * Extracts and parses date components from form value
+ * @param {Object} value - Form data object
+ * @returns {Object} Parsed date components
+ */
+function extractDateComponents(value) {
+  return {
+    startDay: parseInt(value['activity-start-date-day'], 10),
+    startMonth: parseInt(value['activity-start-date-month'], 10),
+    startYear: parseInt(value['activity-start-date-year'], 10),
+    endDay: parseInt(value['activity-end-date-day'], 10),
+    endMonth: parseInt(value['activity-end-date-month'], 10),
+    endYear: parseInt(value['activity-end-date-year'], 10)
+  }
+}
+
+/**
+ * Validates start date components and returns error if invalid
+ * @param {number} startDay
+ * @param {number} startMonth
+ * @param {number} startYear
+ * @param {Object} helpers - Joi helpers object
+ * @returns {Object|null} Error object or null if valid
+ */
+function validateStartDateComponents(startDay, startMonth, startYear, helpers) {
+  if (!areComponentsValidNumbers(startDay, startMonth, startYear)) {
+    return helpers.error(JOI_ERRORS.CUSTOM_START_DATE_INVALID)
+  }
+
+  if (!areComponentsInValidRange(startDay, startMonth, startYear)) {
+    return helpers.error(JOI_ERRORS.CUSTOM_START_DATE_INVALID)
+  }
+
+  return null
+}
+
+/**
+ * Validates end date components and returns error if invalid
+ * @param {number} endDay
+ * @param {number} endMonth
+ * @param {number} endYear
+ * @param {Object} helpers - Joi helpers object
+ * @returns {Object|null} Error object or null if valid
+ */
+function validateEndDateComponents(endDay, endMonth, endYear, helpers) {
+  if (!areComponentsValidNumbers(endDay, endMonth, endYear)) {
+    return helpers.error(JOI_ERRORS.CUSTOM_END_DATE_INVALID)
+  }
+
+  if (!areComponentsInValidRange(endDay, endMonth, endYear)) {
+    return helpers.error(JOI_ERRORS.CUSTOM_END_DATE_INVALID)
+  }
+
+  return null
+}
+
+/**
+ * Validates date objects and relationships
+ * @param {Date} startDate
+ * @param {Date} endDate
+ * @param {Object} helpers - Joi helpers object
+ * @returns {Object|null} Error object or null if valid
+ */
+function validateDateRelationships(startDate, endDate, helpers) {
+  if (!startDate) {
+    return helpers.error(JOI_ERRORS.CUSTOM_START_DATE_INVALID)
+  }
+
+  if (!endDate) {
+    return helpers.error(JOI_ERRORS.CUSTOM_END_DATE_INVALID)
+  }
+
+  if (endDate < startDate) {
+    return helpers.error(JOI_ERRORS.CUSTOM_END_DATE_BEFORE_START_DATE)
+  }
+
+  if (!isDateTodayOrFuture(startDate)) {
+    return helpers.error(JOI_ERRORS.CUSTOM_START_DATE_TODAY_OR_FUTURE)
+  }
+
+  if (!isDateTodayOrFuture(endDate)) {
+    return helpers.error(JOI_ERRORS.CUSTOM_END_DATE_TODAY_OR_FUTURE)
+  }
+
+  return null
+}
+
 export const activityDatesSchema = joi
   .object({
     'activity-start-date-day': joi
@@ -96,67 +212,34 @@ export const activityDatesSchema = joi
       })
   })
   .custom((value, helpers) => {
-    const startDay = parseInt(value['activity-start-date-day'], 10)
-    const startMonth = parseInt(value['activity-start-date-month'], 10)
-    const startYear = parseInt(value['activity-start-date-year'], 10)
+    const { startDay, startMonth, startYear, endDay, endMonth, endYear } =
+      extractDateComponents(value)
 
-    const endDay = parseInt(value['activity-end-date-day'], 10)
-    const endMonth = parseInt(value['activity-end-date-month'], 10)
-    const endYear = parseInt(value['activity-end-date-year'], 10)
+    const startDateError = validateStartDateComponents(
+      startDay,
+      startMonth,
+      startYear,
+      helpers
+    )
+    if (startDateError) return startDateError
 
-    if (isNaN(startDay) || isNaN(startMonth) || isNaN(startYear)) {
-      return helpers.error(JOI_ERRORS.CUSTOM_START_DATE_INVALID)
-    }
-
-    if (isNaN(endDay) || isNaN(endMonth) || isNaN(endYear)) {
-      return helpers.error(JOI_ERRORS.CUSTOM_END_DATE_INVALID)
-    }
-
-    if (
-      startDay < 1 ||
-      startDay > MAX_DAYS_IN_MONTH ||
-      startMonth < 1 ||
-      startMonth > MAX_MONTHS_IN_YEAR ||
-      startYear < MIN_YEAR ||
-      startYear > MAX_YEAR
-    ) {
-      return helpers.error(JOI_ERRORS.CUSTOM_START_DATE_INVALID)
-    }
-
-    if (
-      endDay < 1 ||
-      endDay > MAX_DAYS_IN_MONTH ||
-      endMonth < 1 ||
-      endMonth > MAX_MONTHS_IN_YEAR ||
-      endYear < MIN_YEAR ||
-      endYear > MAX_YEAR
-    ) {
-      return helpers.error(JOI_ERRORS.CUSTOM_END_DATE_INVALID)
-    }
+    const endDateError = validateEndDateComponents(
+      endDay,
+      endMonth,
+      endYear,
+      helpers
+    )
+    if (endDateError) return endDateError
 
     const startDate = createDateFromComponents(startYear, startMonth, startDay)
-    if (!startDate) {
-      return helpers.error(JOI_ERRORS.CUSTOM_START_DATE_INVALID)
-    }
-
     const endDate = createDateFromComponents(endYear, endMonth, endDay)
-    if (!endDate) {
-      return helpers.error(JOI_ERRORS.CUSTOM_END_DATE_INVALID)
-    }
 
-    // REORDER: Check date relationships BEFORE checking if dates are in the future
-    // This ensures more specific error messages are shown first
-    if (endDate < startDate) {
-      return helpers.error(JOI_ERRORS.CUSTOM_END_DATE_BEFORE_START_DATE)
-    }
-
-    if (!isDateTodayOrFuture(startDate)) {
-      return helpers.error(JOI_ERRORS.CUSTOM_START_DATE_TODAY_OR_FUTURE)
-    }
-
-    if (!isDateTodayOrFuture(endDate)) {
-      return helpers.error(JOI_ERRORS.CUSTOM_END_DATE_TODAY_OR_FUTURE)
-    }
+    const relationshipError = validateDateRelationships(
+      startDate,
+      endDate,
+      helpers
+    )
+    if (relationshipError) return relationshipError
 
     return value
   })

--- a/src/server/common/schemas/date.js
+++ b/src/server/common/schemas/date.js
@@ -1,0 +1,173 @@
+import joi from 'joi'
+import { JOI_ERRORS } from '~/src/server/common/constants/joi.js'
+
+const CURRENT_YEAR = new Date().getFullYear()
+const MIN_YEAR = CURRENT_YEAR - 10 // Allow 10 years in the past for reasonable range validation
+const MAX_YEAR = CURRENT_YEAR + 75
+const MAX_DAYS_IN_MONTH = 31
+const MAX_MONTHS_IN_YEAR = 12
+
+/**
+ * Creates a date from individual day, month, year components
+ * @param {number} year
+ * @param {number} month (1-12)
+ * @param {number} day
+ * @returns {Date|null}
+ */
+function createDateFromComponents(year, month, day) {
+  if (isNaN(year) || isNaN(month) || isNaN(day)) {
+    return null
+  }
+
+  const date = new Date(Date.UTC(year, month - 1, day))
+  if (
+    date.getUTCFullYear() !== year ||
+    date.getUTCMonth() !== month - 1 ||
+    date.getUTCDate() !== day
+  ) {
+    return null
+  }
+
+  return date
+}
+
+/**
+ * Checks if a date is today or in the future
+ * @param {Date} date
+ * @returns {boolean}
+ */
+function isDateTodayOrFuture(date) {
+  const today = new Date()
+  today.setHours(0, 0, 0, 0)
+  return date >= today
+}
+
+export const activityDatesSchema = joi
+  .object({
+    'activity-start-date-day': joi
+      .string()
+      .pattern(/^\d+$/)
+      .required()
+      .messages({
+        'any.required': JOI_ERRORS.ACTIVITY_START_DATE_DAY,
+        'string.empty': JOI_ERRORS.ACTIVITY_START_DATE_DAY,
+        'string.pattern.base': JOI_ERRORS.ACTIVITY_START_DATE_DAY
+      }),
+    'activity-start-date-month': joi
+      .string()
+      .pattern(/^\d+$/)
+      .required()
+      .messages({
+        'any.required': JOI_ERRORS.ACTIVITY_START_DATE_MONTH,
+        'string.empty': JOI_ERRORS.ACTIVITY_START_DATE_MONTH,
+        'string.pattern.base': JOI_ERRORS.ACTIVITY_START_DATE_MONTH
+      }),
+    'activity-start-date-year': joi
+      .string()
+      .pattern(/^\d+$/)
+      .required()
+      .messages({
+        'any.required': JOI_ERRORS.ACTIVITY_START_DATE_YEAR,
+        'string.empty': JOI_ERRORS.ACTIVITY_START_DATE_YEAR,
+        'string.pattern.base': JOI_ERRORS.ACTIVITY_START_DATE_YEAR
+      }),
+    'activity-end-date-day': joi.string().pattern(/^\d+$/).required().messages({
+      'any.required': JOI_ERRORS.ACTIVITY_END_DATE_DAY,
+      'string.empty': JOI_ERRORS.ACTIVITY_END_DATE_DAY,
+      'string.pattern.base': JOI_ERRORS.ACTIVITY_END_DATE_DAY
+    }),
+    'activity-end-date-month': joi
+      .string()
+      .pattern(/^\d+$/)
+      .required()
+      .messages({
+        'any.required': JOI_ERRORS.ACTIVITY_END_DATE_MONTH,
+        'string.empty': JOI_ERRORS.ACTIVITY_END_DATE_MONTH,
+        'string.pattern.base': JOI_ERRORS.ACTIVITY_END_DATE_MONTH
+      }),
+    'activity-end-date-year': joi
+      .string()
+      .pattern(/^\d+$/)
+      .required()
+      .messages({
+        'any.required': JOI_ERRORS.ACTIVITY_END_DATE_YEAR,
+        'string.empty': JOI_ERRORS.ACTIVITY_END_DATE_YEAR,
+        'string.pattern.base': JOI_ERRORS.ACTIVITY_END_DATE_YEAR
+      })
+  })
+  .custom((value, helpers) => {
+    const startDay = parseInt(value['activity-start-date-day'], 10)
+    const startMonth = parseInt(value['activity-start-date-month'], 10)
+    const startYear = parseInt(value['activity-start-date-year'], 10)
+
+    const endDay = parseInt(value['activity-end-date-day'], 10)
+    const endMonth = parseInt(value['activity-end-date-month'], 10)
+    const endYear = parseInt(value['activity-end-date-year'], 10)
+
+    if (isNaN(startDay) || isNaN(startMonth) || isNaN(startYear)) {
+      return helpers.error(JOI_ERRORS.CUSTOM_START_DATE_INVALID)
+    }
+
+    if (isNaN(endDay) || isNaN(endMonth) || isNaN(endYear)) {
+      return helpers.error(JOI_ERRORS.CUSTOM_END_DATE_INVALID)
+    }
+
+    if (
+      startDay < 1 ||
+      startDay > MAX_DAYS_IN_MONTH ||
+      startMonth < 1 ||
+      startMonth > MAX_MONTHS_IN_YEAR ||
+      startYear < MIN_YEAR ||
+      startYear > MAX_YEAR
+    ) {
+      return helpers.error(JOI_ERRORS.CUSTOM_START_DATE_INVALID)
+    }
+
+    if (
+      endDay < 1 ||
+      endDay > MAX_DAYS_IN_MONTH ||
+      endMonth < 1 ||
+      endMonth > MAX_MONTHS_IN_YEAR ||
+      endYear < MIN_YEAR ||
+      endYear > MAX_YEAR
+    ) {
+      return helpers.error(JOI_ERRORS.CUSTOM_END_DATE_INVALID)
+    }
+
+    const startDate = createDateFromComponents(startYear, startMonth, startDay)
+    if (!startDate) {
+      return helpers.error(JOI_ERRORS.CUSTOM_START_DATE_INVALID)
+    }
+
+    const endDate = createDateFromComponents(endYear, endMonth, endDay)
+    if (!endDate) {
+      return helpers.error(JOI_ERRORS.CUSTOM_END_DATE_INVALID)
+    }
+
+    // REORDER: Check date relationships BEFORE checking if dates are in the future
+    // This ensures more specific error messages are shown first
+    if (endDate < startDate) {
+      return helpers.error(JOI_ERRORS.CUSTOM_END_DATE_BEFORE_START_DATE)
+    }
+
+    if (!isDateTodayOrFuture(startDate)) {
+      return helpers.error(JOI_ERRORS.CUSTOM_START_DATE_TODAY_OR_FUTURE)
+    }
+
+    if (!isDateTodayOrFuture(endDate)) {
+      return helpers.error(JOI_ERRORS.CUSTOM_END_DATE_TODAY_OR_FUTURE)
+    }
+
+    return value
+  })
+  .messages({
+    [JOI_ERRORS.CUSTOM_START_DATE_INVALID]:
+      JOI_ERRORS.CUSTOM_START_DATE_INVALID,
+    [JOI_ERRORS.CUSTOM_END_DATE_INVALID]: JOI_ERRORS.CUSTOM_END_DATE_INVALID,
+    [JOI_ERRORS.CUSTOM_START_DATE_TODAY_OR_FUTURE]:
+      JOI_ERRORS.CUSTOM_START_DATE_TODAY_OR_FUTURE,
+    [JOI_ERRORS.CUSTOM_END_DATE_TODAY_OR_FUTURE]:
+      JOI_ERRORS.CUSTOM_END_DATE_TODAY_OR_FUTURE,
+    [JOI_ERRORS.CUSTOM_END_DATE_BEFORE_START_DATE]:
+      JOI_ERRORS.CUSTOM_END_DATE_BEFORE_START_DATE
+  })

--- a/src/server/common/schemas/date.js
+++ b/src/server/common/schemas/date.js
@@ -1,258 +1,175 @@
 import joi from 'joi'
 import { JOI_ERRORS } from '~/src/server/common/constants/joi.js'
 
-const CURRENT_YEAR = new Date().getFullYear()
-const YEARS_IN_PAST_ALLOWED = 10 // Allow 10 years in the past for reasonable range validation
-const YEARS_IN_FUTURE_ALLOWED = 75 // Allow 75 years in the future for long-term planning
-const MIN_YEAR = CURRENT_YEAR - YEARS_IN_PAST_ALLOWED
-const MAX_YEAR = CURRENT_YEAR + YEARS_IN_FUTURE_ALLOWED
+const MIN_YEAR = new Date().getFullYear()
+const MAX_YEAR_OFFSET = 75
+const MAX_YEAR = MIN_YEAR + MAX_YEAR_OFFSET
+
 const MAX_DAYS_IN_MONTH = 31
 const MAX_MONTHS_IN_YEAR = 12
 
 /**
- * Creates a date from individual day, month, year components
- * @param {number} year
- * @param {number} month (1-12)
- * @param {number} day
- * @returns {Date|null}
+ * Creates individual date field validation schema
+ * @param {object} config - Configuration object
+ * @param {string} config.prefix - Field prefix (e.g., 'activity-start-date')
+ * @param {number} config.minYear - Minimum allowed year (default: current year)
+ * @param {number} config.maxYear - Maximum allowed year (default: current year + 75)
+ * @param {string} config.minYearError - Error message for minimum year validation
+ * @returns {object} Joi schema object for day, month, year fields
  */
-function createDateFromComponents(year, month, day) {
-  if (isNaN(year) || isNaN(month) || isNaN(day)) {
-    return null
-  }
-
-  const date = new Date(Date.UTC(year, month - 1, day))
-  if (
-    date.getUTCFullYear() !== year ||
-    date.getUTCMonth() !== month - 1 ||
-    date.getUTCDate() !== day
-  ) {
-    return null
-  }
-
-  return date
-}
+export const individualDate = ({
+  prefix,
+  minYear = MIN_YEAR,
+  maxYear = MAX_YEAR,
+  minYearError
+}) => ({
+  [`${prefix}-day`]: joi
+    .number()
+    .integer()
+    .min(1)
+    .max(MAX_DAYS_IN_MONTH)
+    .required()
+    .messages({
+      'any.required': `${prefix}-day`,
+      'number.base': `${prefix}-day`,
+      'number.min': `${prefix}-day`,
+      'number.max': `${prefix}-day`
+    }),
+  [`${prefix}-month`]: joi
+    .number()
+    .integer()
+    .min(1)
+    .max(MAX_MONTHS_IN_YEAR)
+    .required()
+    .messages({
+      'any.required': `${prefix}-month`,
+      'number.base': `${prefix}-month`,
+      'number.min': `${prefix}-month`,
+      'number.max': `${prefix}-month`
+    }),
+  [`${prefix}-year`]: joi
+    .number()
+    .integer()
+    .min(minYear)
+    .max(maxYear)
+    .required()
+    .messages({
+      'any.required': `${prefix}-year`,
+      'number.base': `${prefix}-year`,
+      'number.min': minYearError || `${prefix}-year`,
+      'number.max': `${prefix}-year`
+    })
+})
 
 /**
- * Checks if a date is today or in the future
- * @param {Date} date
- * @returns {boolean}
+ * Validates if a date object matches its components
+ * @param {object} params - Parameters object
+ * @param {Date} params.date - Date object to validate
+ * @param {number} params.day - Day component
+ * @param {number} params.month - Month component
+ * @param {number} params.year - Year component
+ * @returns {boolean} True if date matches components
  */
-function isDateTodayOrFuture(date) {
-  const today = new Date()
-  today.setHours(0, 0, 0, 0)
-  return date >= today
-}
+const isValidDate = ({ date, day, month, year }) =>
+  date.getUTCFullYear() === year &&
+  date.getUTCMonth() === month - 1 &&
+  date.getUTCDate() === day
 
 /**
- * Validates if date component values are valid numbers
- * @param {number} day
- * @param {number} month
- * @param {number} year
- * @returns {boolean}
+ * Activity dates schema for start and end date validation
  */
-function areComponentsValidNumbers(day, month, year) {
-  return !isNaN(day) && !isNaN(month) && !isNaN(year)
-}
-
-/**
- * Validates if date component values are within valid ranges
- * @param {number} day
- * @param {number} month
- * @param {number} year
- * @returns {boolean}
- */
-function areComponentsInValidRange(day, month, year) {
-  return (
-    day >= 1 &&
-    day <= MAX_DAYS_IN_MONTH &&
-    month >= 1 &&
-    month <= MAX_MONTHS_IN_YEAR &&
-    year >= MIN_YEAR &&
-    year <= MAX_YEAR
-  )
-}
-
-/**
- * Extracts and parses date components from form value
- * @param {Object} value - Form data object
- * @returns {Object} Parsed date components
- */
-function extractDateComponents(value) {
-  return {
-    startDay: parseInt(value['activity-start-date-day'], 10),
-    startMonth: parseInt(value['activity-start-date-month'], 10),
-    startYear: parseInt(value['activity-start-date-year'], 10),
-    endDay: parseInt(value['activity-end-date-day'], 10),
-    endMonth: parseInt(value['activity-end-date-month'], 10),
-    endYear: parseInt(value['activity-end-date-year'], 10)
-  }
-}
-
-/**
- * Validates start date components and returns error if invalid
- * @param {number} startDay
- * @param {number} startMonth
- * @param {number} startYear
- * @param {Object} helpers - Joi helpers object
- * @returns {Object|null} Error object or null if valid
- */
-function validateStartDateComponents(startDay, startMonth, startYear, helpers) {
-  if (!areComponentsValidNumbers(startDay, startMonth, startYear)) {
-    return helpers.error(JOI_ERRORS.CUSTOM_START_DATE_INVALID)
-  }
-
-  if (!areComponentsInValidRange(startDay, startMonth, startYear)) {
-    return helpers.error(JOI_ERRORS.CUSTOM_START_DATE_INVALID)
-  }
-
-  return null
-}
-
-/**
- * Validates end date components and returns error if invalid
- * @param {number} endDay
- * @param {number} endMonth
- * @param {number} endYear
- * @param {Object} helpers - Joi helpers object
- * @returns {Object|null} Error object or null if valid
- */
-function validateEndDateComponents(endDay, endMonth, endYear, helpers) {
-  if (!areComponentsValidNumbers(endDay, endMonth, endYear)) {
-    return helpers.error(JOI_ERRORS.CUSTOM_END_DATE_INVALID)
-  }
-
-  if (!areComponentsInValidRange(endDay, endMonth, endYear)) {
-    return helpers.error(JOI_ERRORS.CUSTOM_END_DATE_INVALID)
-  }
-
-  return null
-}
-
-/**
- * Validates date objects and relationships
- * @param {Date} startDate
- * @param {Date} endDate
- * @param {Object} helpers - Joi helpers object
- * @returns {Object|null} Error object or null if valid
- */
-function validateDateRelationships(startDate, endDate, helpers) {
-  if (!startDate) {
-    return helpers.error(JOI_ERRORS.CUSTOM_START_DATE_INVALID)
-  }
-
-  if (!endDate) {
-    return helpers.error(JOI_ERRORS.CUSTOM_END_DATE_INVALID)
-  }
-
-  if (endDate < startDate) {
-    return helpers.error(JOI_ERRORS.CUSTOM_END_DATE_BEFORE_START_DATE)
-  }
-
-  if (!isDateTodayOrFuture(startDate)) {
-    return helpers.error(JOI_ERRORS.CUSTOM_START_DATE_TODAY_OR_FUTURE)
-  }
-
-  if (!isDateTodayOrFuture(endDate)) {
-    return helpers.error(JOI_ERRORS.CUSTOM_END_DATE_TODAY_OR_FUTURE)
-  }
-
-  return null
-}
-
 export const activityDatesSchema = joi
   .object({
-    'activity-start-date-day': joi
-      .string()
-      .pattern(/^\d+$/)
-      .required()
-      .messages({
-        'any.required': JOI_ERRORS.ACTIVITY_START_DATE_DAY,
-        'string.empty': JOI_ERRORS.ACTIVITY_START_DATE_DAY,
-        'string.pattern.base': JOI_ERRORS.ACTIVITY_START_DATE_DAY
-      }),
-    'activity-start-date-month': joi
-      .string()
-      .pattern(/^\d+$/)
-      .required()
-      .messages({
-        'any.required': JOI_ERRORS.ACTIVITY_START_DATE_MONTH,
-        'string.empty': JOI_ERRORS.ACTIVITY_START_DATE_MONTH,
-        'string.pattern.base': JOI_ERRORS.ACTIVITY_START_DATE_MONTH
-      }),
-    'activity-start-date-year': joi
-      .string()
-      .pattern(/^\d+$/)
-      .required()
-      .messages({
-        'any.required': JOI_ERRORS.ACTIVITY_START_DATE_YEAR,
-        'string.empty': JOI_ERRORS.ACTIVITY_START_DATE_YEAR,
-        'string.pattern.base': JOI_ERRORS.ACTIVITY_START_DATE_YEAR
-      }),
-    'activity-end-date-day': joi.string().pattern(/^\d+$/).required().messages({
-      'any.required': JOI_ERRORS.ACTIVITY_END_DATE_DAY,
-      'string.empty': JOI_ERRORS.ACTIVITY_END_DATE_DAY,
-      'string.pattern.base': JOI_ERRORS.ACTIVITY_END_DATE_DAY
+    ...individualDate({
+      prefix: 'activity-start-date',
+      minYear: MIN_YEAR,
+      maxYear: MAX_YEAR,
+      minYearError: JOI_ERRORS.CUSTOM_START_DATE_TODAY_OR_FUTURE
     }),
-    'activity-end-date-month': joi
-      .string()
-      .pattern(/^\d+$/)
-      .required()
-      .messages({
-        'any.required': JOI_ERRORS.ACTIVITY_END_DATE_MONTH,
-        'string.empty': JOI_ERRORS.ACTIVITY_END_DATE_MONTH,
-        'string.pattern.base': JOI_ERRORS.ACTIVITY_END_DATE_MONTH
-      }),
-    'activity-end-date-year': joi
-      .string()
-      .pattern(/^\d+$/)
-      .required()
-      .messages({
-        'any.required': JOI_ERRORS.ACTIVITY_END_DATE_YEAR,
-        'string.empty': JOI_ERRORS.ACTIVITY_END_DATE_YEAR,
-        'string.pattern.base': JOI_ERRORS.ACTIVITY_END_DATE_YEAR
-      })
+    ...individualDate({
+      prefix: 'activity-end-date',
+      minYear: MIN_YEAR,
+      maxYear: MAX_YEAR,
+      minYearError: JOI_ERRORS.CUSTOM_END_DATE_TODAY_OR_FUTURE
+    })
   })
   .custom((value, helpers) => {
-    const { startDay, startMonth, startYear, endDay, endMonth, endYear } =
-      extractDateComponents(value)
+    const {
+      'activity-start-date-day': startDay,
+      'activity-start-date-month': startMonth,
+      'activity-start-date-year': startYear,
+      'activity-end-date-day': endDay,
+      'activity-end-date-month': endMonth,
+      'activity-end-date-year': endYear
+    } = value
 
-    const startDateError = validateStartDateComponents(
-      startDay,
-      startMonth,
-      startYear,
-      helpers
-    )
-    if (startDateError) return startDateError
+    const startDate = new Date(Date.UTC(startYear, startMonth - 1, startDay))
+    const endDate = new Date(Date.UTC(endYear, endMonth - 1, endDay))
+    const today = new Date()
+    today.setHours(0, 0, 0, 0)
 
-    const endDateError = validateEndDateComponents(
-      endDay,
-      endMonth,
-      endYear,
-      helpers
-    )
-    if (endDateError) return endDateError
+    // Validate start date is a real date
+    if (
+      !isValidDate({
+        date: startDate,
+        day: startDay,
+        month: startMonth,
+        year: startYear
+      })
+    ) {
+      return helpers.error('custom.startDate.invalid')
+    }
 
-    const startDate = createDateFromComponents(startYear, startMonth, startDay)
-    const endDate = createDateFromComponents(endYear, endMonth, endDay)
+    // Validate end date is a real date
+    if (
+      !isValidDate({
+        date: endDate,
+        day: endDay,
+        month: endMonth,
+        year: endYear
+      })
+    ) {
+      return helpers.error('custom.endDate.invalid')
+    }
 
-    const relationshipError = validateDateRelationships(
-      startDate,
-      endDate,
-      helpers
-    )
-    if (relationshipError) return relationshipError
+    // Check end date future validation before date order (for consistency with existing behavior)
+    if (endDate < today) {
+      return helpers.error('custom.endDate.todayOrFuture')
+    }
+
+    // Validate date order
+    if (endDate < startDate) {
+      return helpers.error('custom.endDate.before.startDate')
+    }
+
+    // Check start date future validation last
+    if (startDate < today) {
+      return helpers.error('custom.startDate.todayOrFuture')
+    }
 
     return value
   })
   .messages({
-    [JOI_ERRORS.CUSTOM_START_DATE_INVALID]:
-      JOI_ERRORS.CUSTOM_START_DATE_INVALID,
-    [JOI_ERRORS.CUSTOM_END_DATE_INVALID]: JOI_ERRORS.CUSTOM_END_DATE_INVALID,
-    [JOI_ERRORS.CUSTOM_START_DATE_TODAY_OR_FUTURE]:
+    'activity-start-date-day': JOI_ERRORS.ACTIVITY_START_DATE_DAY,
+    'activity-start-date-month': JOI_ERRORS.ACTIVITY_START_DATE_MONTH,
+    'activity-start-date-year': JOI_ERRORS.ACTIVITY_START_DATE_YEAR,
+    'activity-end-date-day': JOI_ERRORS.ACTIVITY_END_DATE_DAY,
+    'activity-end-date-month': JOI_ERRORS.ACTIVITY_END_DATE_MONTH,
+    'activity-end-date-year': JOI_ERRORS.ACTIVITY_END_DATE_YEAR,
+    'custom.startDate.todayOrFuture':
       JOI_ERRORS.CUSTOM_START_DATE_TODAY_OR_FUTURE,
-    [JOI_ERRORS.CUSTOM_END_DATE_TODAY_OR_FUTURE]:
-      JOI_ERRORS.CUSTOM_END_DATE_TODAY_OR_FUTURE,
-    [JOI_ERRORS.CUSTOM_END_DATE_BEFORE_START_DATE]:
+    'custom.startDate.invalid': JOI_ERRORS.CUSTOM_START_DATE_INVALID,
+    'custom.endDate.invalid': JOI_ERRORS.CUSTOM_END_DATE_INVALID,
+    'custom.endDate.todayOrFuture': JOI_ERRORS.CUSTOM_END_DATE_TODAY_OR_FUTURE,
+    'custom.endDate.before.startDate':
       JOI_ERRORS.CUSTOM_END_DATE_BEFORE_START_DATE
   })
+
+// Export constants for reuse
+export {
+  MIN_YEAR,
+  MAX_YEAR,
+  MAX_YEAR_OFFSET,
+  MAX_DAYS_IN_MONTH,
+  MAX_MONTHS_IN_YEAR
+}

--- a/src/server/common/schemas/date.js
+++ b/src/server/common/schemas/date.js
@@ -2,8 +2,10 @@ import joi from 'joi'
 import { JOI_ERRORS } from '~/src/server/common/constants/joi.js'
 
 const CURRENT_YEAR = new Date().getFullYear()
-const MIN_YEAR = CURRENT_YEAR - 10 // Allow 10 years in the past for reasonable range validation
-const MAX_YEAR = CURRENT_YEAR + 75
+const YEARS_IN_PAST_ALLOWED = 10 // Allow 10 years in the past for reasonable range validation
+const YEARS_IN_FUTURE_ALLOWED = 75 // Allow 75 years in the future for long-term planning
+const MIN_YEAR = CURRENT_YEAR - YEARS_IN_PAST_ALLOWED
+const MAX_YEAR = CURRENT_YEAR + YEARS_IN_FUTURE_ALLOWED
 const MAX_DAYS_IN_MONTH = 31
 const MAX_MONTHS_IN_YEAR = 12
 

--- a/src/server/common/schemas/date.js
+++ b/src/server/common/schemas/date.js
@@ -14,6 +14,9 @@ const MAX_YEAR = MIN_YEAR + MAX_YEAR_OFFSET
 const MAX_DAYS_IN_MONTH = 31
 const MAX_MONTHS_IN_YEAR = 12
 
+// Date format constants
+const DATE_FORMAT_ISO = 'YYYY-MM-DD'
+
 /**
  * Creates individual date field validation schema
  * @param {object} config - Configuration object
@@ -78,7 +81,7 @@ const isValidDate = (year, month, day) => {
   // Create the date with strict parsing
   const date = dayjs.utc(
     `${year}-${month.toString().padStart(2, '0')}-${day.toString().padStart(2, '0')}`,
-    'YYYY-MM-DD',
+    DATE_FORMAT_ISO,
     true
   )
 
@@ -137,11 +140,11 @@ export const activityDatesSchema = joi
     // Create Day.js dates for comparison (we know they're valid now)
     const startDate = dayjs.utc(
       `${startYear}-${startMonth.toString().padStart(2, '0')}-${startDay.toString().padStart(2, '0')}`,
-      'YYYY-MM-DD'
+      DATE_FORMAT_ISO
     )
     const endDate = dayjs.utc(
       `${endYear}-${endMonth.toString().padStart(2, '0')}-${endDay.toString().padStart(2, '0')}`,
-      'YYYY-MM-DD'
+      DATE_FORMAT_ISO
     )
     const today = dayjs.utc().startOf('day')
 

--- a/src/server/common/schemas/date.test.js
+++ b/src/server/common/schemas/date.test.js
@@ -1,17 +1,35 @@
-import { activityDatesSchema } from '~/src/server/common/schemas/date.js'
+import {
+  activityDatesSchema,
+  individualDate
+} from '~/src/server/common/schemas/date.js'
+import joi from 'joi'
+import { JOI_ERRORS } from '~/src/server/common/constants/joi.js'
 
 describe('activityDatesSchema', () => {
-  const currentYear = new Date().getFullYear()
+  // Mock a fixed date to ensure consistent test results
+  const MOCK_DATE = new Date('2024-06-15T10:00:00.000Z') // June 15, 2024 at 10:00 AM UTC
+  const currentYear = MOCK_DATE.getFullYear()
+
+  beforeAll(() => {
+    // Mock the current date using Jest's built-in date mocking
+    jest.useFakeTimers()
+    jest.setSystemTime(MOCK_DATE)
+  })
+
+  afterAll(() => {
+    // Restore real timers
+    jest.useRealTimers()
+  })
 
   describe('Valid data', () => {
     test('should accept valid future dates', () => {
       const validData = {
-        'activity-start-date-day': '1',
-        'activity-start-date-month': '6',
-        'activity-start-date-year': (currentYear + 1).toString(),
-        'activity-end-date-day': '15',
-        'activity-end-date-month': '6',
-        'activity-end-date-year': (currentYear + 1).toString()
+        'activity-start-date-day': 1,
+        'activity-start-date-month': 6,
+        'activity-start-date-year': 2025,
+        'activity-end-date-day': 15,
+        'activity-end-date-month': 6,
+        'activity-end-date-year': 2025
       }
 
       const result = activityDatesSchema.validate(validData)
@@ -20,29 +38,29 @@ describe('activityDatesSchema', () => {
     })
 
     test('should accept same start and end dates', () => {
-      const validData = {
-        'activity-start-date-day': '1',
-        'activity-start-date-month': '6',
-        'activity-start-date-year': (currentYear + 1).toString(),
-        'activity-end-date-day': '1',
-        'activity-end-date-month': '6',
-        'activity-end-date-year': (currentYear + 1).toString()
+      const sameData = {
+        'activity-start-date-day': 1,
+        'activity-start-date-month': 6,
+        'activity-start-date-year': currentYear + 1,
+        'activity-end-date-day': 1,
+        'activity-end-date-month': 6,
+        'activity-end-date-year': currentYear + 1
       }
 
-      const result = activityDatesSchema.validate(validData)
+      const result = activityDatesSchema.validate(sameData)
       expect(result.error).toBeUndefined()
     })
   })
 
   describe('Required field validation', () => {
     test('should require all start date fields', () => {
-      const invalidData = {
-        'activity-end-date-day': '1',
-        'activity-end-date-month': '6',
-        'activity-end-date-year': (currentYear + 1).toString()
+      const missingStartData = {
+        'activity-end-date-day': 15,
+        'activity-end-date-month': 6,
+        'activity-end-date-year': currentYear + 1
       }
 
-      const result = activityDatesSchema.validate(invalidData, {
+      const result = activityDatesSchema.validate(missingStartData, {
         abortEarly: false
       })
       expect(result.error).toBeDefined()
@@ -53,13 +71,13 @@ describe('activityDatesSchema', () => {
     })
 
     test('should require all end date fields', () => {
-      const invalidData = {
-        'activity-start-date-day': '1',
-        'activity-start-date-month': '6',
-        'activity-start-date-year': (currentYear + 1).toString()
+      const missingEndData = {
+        'activity-start-date-day': 1,
+        'activity-start-date-month': 6,
+        'activity-start-date-year': currentYear + 1
       }
 
-      const result = activityDatesSchema.validate(invalidData, {
+      const result = activityDatesSchema.validate(missingEndData, {
         abortEarly: false
       })
       expect(result.error).toBeDefined()
@@ -70,107 +88,141 @@ describe('activityDatesSchema', () => {
     })
   })
 
-  describe('String pattern validation', () => {
-    test('should reject non-numeric strings', () => {
-      const invalidData = {
+  describe('Number validation', () => {
+    test('should reject non-numeric values', () => {
+      const nonNumericData = {
         'activity-start-date-day': 'abc',
-        'activity-start-date-month': '6',
-        'activity-start-date-year': (currentYear + 1).toString(),
-        'activity-end-date-day': '1',
-        'activity-end-date-month': '6',
-        'activity-end-date-year': (currentYear + 1).toString()
+        'activity-start-date-month': 6,
+        'activity-start-date-year': currentYear + 1,
+        'activity-end-date-day': 15,
+        'activity-end-date-month': 6,
+        'activity-end-date-year': currentYear + 1
       }
 
-      const result = activityDatesSchema.validate(invalidData)
+      const result = activityDatesSchema.validate(nonNumericData)
       expect(result.error).toBeDefined()
 
       const errorTypes = result.error.details.map((d) => d.type)
-      expect(errorTypes).toContain('string.pattern.base')
+      expect(errorTypes).toContain('number.base')
     })
 
-    test('should reject empty strings', () => {
-      const invalidData = {
-        'activity-start-date-day': '',
-        'activity-start-date-month': '6',
-        'activity-start-date-year': (currentYear + 1).toString(),
-        'activity-end-date-day': '1',
-        'activity-end-date-month': '6',
-        'activity-end-date-year': (currentYear + 1).toString()
+    test('should reject decimal numbers', () => {
+      const decimalData = {
+        'activity-start-date-day': 15.5,
+        'activity-start-date-month': 6,
+        'activity-start-date-year': currentYear + 1,
+        'activity-end-date-day': 15,
+        'activity-end-date-month': 6,
+        'activity-end-date-year': currentYear + 1
       }
 
-      const result = activityDatesSchema.validate(invalidData)
+      const result = activityDatesSchema.validate(decimalData)
       expect(result.error).toBeDefined()
 
       const errorTypes = result.error.details.map((d) => d.type)
-      expect(errorTypes).toContain('string.empty')
+      expect(errorTypes).toContain('number.integer')
     })
   })
 
   describe('Date range validation', () => {
     test('should reject invalid day (> 31)', () => {
-      const invalidData = {
-        'activity-start-date-day': '32',
-        'activity-start-date-month': '6',
-        'activity-start-date-year': (currentYear + 1).toString(),
-        'activity-end-date-day': '1',
-        'activity-end-date-month': '6',
-        'activity-end-date-year': (currentYear + 1).toString()
+      const invalidDayData = {
+        'activity-start-date-day': 32,
+        'activity-start-date-month': 6,
+        'activity-start-date-year': currentYear + 1,
+        'activity-end-date-day': 15,
+        'activity-end-date-month': 6,
+        'activity-end-date-year': currentYear + 1
       }
 
-      const result = activityDatesSchema.validate(invalidData)
+      const result = activityDatesSchema.validate(invalidDayData)
       expect(result.error).toBeDefined()
 
       const errorTypes = result.error.details.map((d) => d.type)
-      expect(errorTypes).toContain('custom.startDate.invalid')
+      expect(errorTypes).toContain('number.max')
     })
 
     test('should reject invalid month (> 12)', () => {
-      const invalidData = {
-        'activity-start-date-day': '1',
-        'activity-start-date-month': '6',
-        'activity-start-date-year': (currentYear + 1).toString(),
-        'activity-end-date-day': '1',
-        'activity-end-date-month': '14',
-        'activity-end-date-year': (currentYear + 1).toString()
+      const invalidMonthData = {
+        'activity-start-date-day': 15,
+        'activity-start-date-month': 13,
+        'activity-start-date-year': currentYear + 1,
+        'activity-end-date-day': 15,
+        'activity-end-date-month': 6,
+        'activity-end-date-year': currentYear + 1
       }
 
-      const result = activityDatesSchema.validate(invalidData)
+      const result = activityDatesSchema.validate(invalidMonthData)
       expect(result.error).toBeDefined()
 
       const errorTypes = result.error.details.map((d) => d.type)
-      expect(errorTypes).toContain('custom.endDate.invalid')
+      expect(errorTypes).toContain('number.max')
     })
 
     test('should reject invalid year (too far in future)', () => {
-      const invalidData = {
-        'activity-start-date-day': '1',
-        'activity-start-date-month': '6',
-        'activity-start-date-year': (currentYear + 100).toString(),
-        'activity-end-date-day': '1',
-        'activity-end-date-month': '6',
-        'activity-end-date-year': (currentYear + 100).toString()
+      const invalidYearData = {
+        'activity-start-date-day': 15,
+        'activity-start-date-month': 6,
+        'activity-start-date-year': currentYear + 100,
+        'activity-end-date-day': 15,
+        'activity-end-date-month': 6,
+        'activity-end-date-year': currentYear + 100
       }
 
-      const result = activityDatesSchema.validate(invalidData)
+      const result = activityDatesSchema.validate(invalidYearData)
       expect(result.error).toBeDefined()
 
       const errorTypes = result.error.details.map((d) => d.type)
-      expect(errorTypes).toContain('custom.startDate.invalid')
+      expect(errorTypes).toContain('number.max')
+    })
+
+    test('should reject invalid day (< 1)', () => {
+      const invalidDayData = {
+        'activity-start-date-day': 0,
+        'activity-start-date-month': 6,
+        'activity-start-date-year': currentYear + 1,
+        'activity-end-date-day': 15,
+        'activity-end-date-month': 6,
+        'activity-end-date-year': currentYear + 1
+      }
+
+      const result = activityDatesSchema.validate(invalidDayData)
+      expect(result.error).toBeDefined()
+
+      const errorTypes = result.error.details.map((d) => d.type)
+      expect(errorTypes).toContain('number.min')
+    })
+
+    test('should reject invalid month (< 1)', () => {
+      const invalidMonthData = {
+        'activity-start-date-day': 15,
+        'activity-start-date-month': 0,
+        'activity-start-date-year': currentYear + 1,
+        'activity-end-date-day': 15,
+        'activity-end-date-month': 6,
+        'activity-end-date-year': currentYear + 1
+      }
+
+      const result = activityDatesSchema.validate(invalidMonthData)
+      expect(result.error).toBeDefined()
+
+      const errorTypes = result.error.details.map((d) => d.type)
+      expect(errorTypes).toContain('number.min')
     })
   })
 
   describe('Date validity validation', () => {
     test('should reject impossible dates (February 30th)', () => {
-      const invalidData = {
-        'activity-start-date-day': '30',
-        'activity-start-date-month': '2',
-        'activity-start-date-year': (currentYear + 1).toString(),
-        'activity-end-date-day': '1',
-        'activity-end-date-month': '3',
-        'activity-end-date-year': (currentYear + 1).toString()
+      const impossibleData = {
+        'activity-start-date-day': 30,
+        'activity-start-date-month': 2,
+        'activity-start-date-year': currentYear + 1,
+        'activity-end-date-day': 15,
+        'activity-end-date-month': 6,
+        'activity-end-date-year': currentYear + 1
       }
 
-      const result = activityDatesSchema.validate(invalidData)
+      const result = activityDatesSchema.validate(impossibleData)
       expect(result.error).toBeDefined()
 
       const errorTypes = result.error.details.map((d) => d.type)
@@ -178,16 +230,33 @@ describe('activityDatesSchema', () => {
     })
 
     test('should reject impossible dates (April 31st)', () => {
-      const invalidData = {
-        'activity-start-date-day': '1',
-        'activity-start-date-month': '1',
-        'activity-start-date-year': (currentYear + 1).toString(),
-        'activity-end-date-day': '31',
-        'activity-end-date-month': '4',
-        'activity-end-date-year': (currentYear + 1).toString()
+      const impossibleData = {
+        'activity-start-date-day': 31,
+        'activity-start-date-month': 4,
+        'activity-start-date-year': currentYear + 1,
+        'activity-end-date-day': 15,
+        'activity-end-date-month': 6,
+        'activity-end-date-year': currentYear + 1
       }
 
-      const result = activityDatesSchema.validate(invalidData)
+      const result = activityDatesSchema.validate(impossibleData)
+      expect(result.error).toBeDefined()
+
+      const errorTypes = result.error.details.map((d) => d.type)
+      expect(errorTypes).toContain('custom.startDate.invalid')
+    })
+
+    test('should handle invalid date creation properly for impossible dates', () => {
+      const impossibleEndData = {
+        'activity-start-date-day': 15,
+        'activity-start-date-month': 6,
+        'activity-start-date-year': currentYear + 1,
+        'activity-end-date-day': 31,
+        'activity-end-date-month': 4,
+        'activity-end-date-year': currentYear + 1
+      }
+
+      const result = activityDatesSchema.validate(impossibleEndData)
       expect(result.error).toBeDefined()
 
       const errorTypes = result.error.details.map((d) => d.type)
@@ -197,53 +266,54 @@ describe('activityDatesSchema', () => {
 
   describe('Past date validation', () => {
     test('should reject past start dates', () => {
-      const pastData = {
-        'activity-start-date-day': '1',
-        'activity-start-date-month': '1',
-        'activity-start-date-year': '2020', // Past year
-        'activity-end-date-day': '15',
-        'activity-end-date-month': '1',
-        'activity-end-date-year': (currentYear + 1).toString()
+      const pastStartData = {
+        'activity-start-date-day': 1,
+        'activity-start-date-month': 1,
+        'activity-start-date-year': currentYear - 1,
+        'activity-end-date-day': 15,
+        'activity-end-date-month': 6,
+        'activity-end-date-year': currentYear + 1
       }
 
-      const result = activityDatesSchema.validate(pastData)
+      const result = activityDatesSchema.validate(pastStartData)
       expect(result.error).toBeDefined()
+
       const errorTypes = result.error.details.map((d) => d.type)
-      // Past dates now get the more specific "today or future" error instead of "invalid"
-      expect(errorTypes).toContain('custom.startDate.todayOrFuture')
+      // Past dates now get caught by the minYear validation first
+      expect(errorTypes).toContain('number.min')
     })
 
     test('should reject past end dates when start date is valid', () => {
       const pastEndData = {
-        'activity-start-date-day': '1',
-        'activity-start-date-month': '6',
-        'activity-start-date-year': (currentYear + 1).toString(),
-        'activity-end-date-day': '15',
-        'activity-end-date-month': '1',
-        'activity-end-date-year': '2020'
+        'activity-start-date-day': 1,
+        'activity-start-date-month': 6,
+        'activity-start-date-year': currentYear + 1,
+        'activity-end-date-day': 15,
+        'activity-end-date-month': 6,
+        'activity-end-date-year': currentYear - 1
       }
 
       const result = activityDatesSchema.validate(pastEndData)
       expect(result.error).toBeDefined()
+
       const errorTypes = result.error.details.map((d) => d.type)
-      // With the new validation order, date relationships are checked before "today or future"
-      // So a past end date with a future start date gets the more specific "before start date" error
-      expect(errorTypes).toContain('custom.endDate.before.startDate')
+      // Past dates now get caught by the minYear validation first
+      expect(errorTypes).toContain('number.min')
     })
   })
 
   describe('Date order validation', () => {
     test('should reject end date before start date (same year)', () => {
-      const invalidData = {
-        'activity-start-date-day': '15',
-        'activity-start-date-month': '6',
-        'activity-start-date-year': (currentYear + 1).toString(),
-        'activity-end-date-day': '14',
-        'activity-end-date-month': '6',
-        'activity-end-date-year': (currentYear + 1).toString()
+      const endBeforeStartData = {
+        'activity-start-date-day': 15,
+        'activity-start-date-month': 6,
+        'activity-start-date-year': currentYear + 1,
+        'activity-end-date-day': 10,
+        'activity-end-date-month': 6,
+        'activity-end-date-year': currentYear + 1
       }
 
-      const result = activityDatesSchema.validate(invalidData)
+      const result = activityDatesSchema.validate(endBeforeStartData)
       expect(result.error).toBeDefined()
 
       const errorTypes = result.error.details.map((d) => d.type)
@@ -251,16 +321,16 @@ describe('activityDatesSchema', () => {
     })
 
     test('should reject end date before start date (different months)', () => {
-      const invalidData = {
-        'activity-start-date-day': '1',
-        'activity-start-date-month': '12',
-        'activity-start-date-year': (currentYear + 1).toString(),
-        'activity-end-date-day': '30',
-        'activity-end-date-month': '11',
-        'activity-end-date-year': (currentYear + 1).toString()
+      const endBeforeStartData = {
+        'activity-start-date-day': 15,
+        'activity-start-date-month': 7,
+        'activity-start-date-year': currentYear + 1,
+        'activity-end-date-day': 15,
+        'activity-end-date-month': 6,
+        'activity-end-date-year': currentYear + 1
       }
 
-      const result = activityDatesSchema.validate(invalidData)
+      const result = activityDatesSchema.validate(endBeforeStartData)
       expect(result.error).toBeDefined()
 
       const errorTypes = result.error.details.map((d) => d.type)
@@ -268,16 +338,16 @@ describe('activityDatesSchema', () => {
     })
 
     test('should reject end date before start date (different years)', () => {
-      const invalidData = {
-        'activity-start-date-day': '15',
-        'activity-start-date-month': '6',
-        'activity-start-date-year': (currentYear + 2).toString(),
-        'activity-end-date-day': '15',
-        'activity-end-date-month': '6',
-        'activity-end-date-year': (currentYear + 1).toString()
+      const endBeforeStartData = {
+        'activity-start-date-day': 15,
+        'activity-start-date-month': 6,
+        'activity-start-date-year': currentYear + 2,
+        'activity-end-date-day': 15,
+        'activity-end-date-month': 6,
+        'activity-end-date-year': currentYear + 1
       }
 
-      const result = activityDatesSchema.validate(invalidData)
+      const result = activityDatesSchema.validate(endBeforeStartData)
       expect(result.error).toBeDefined()
 
       const errorTypes = result.error.details.map((d) => d.type)
@@ -288,22 +358,274 @@ describe('activityDatesSchema', () => {
   describe('Error message structure', () => {
     test('should provide correct error structure for custom validation', () => {
       const invalidData = {
-        'activity-start-date-day': '1',
-        'activity-start-date-month': '12',
-        'activity-start-date-year': (currentYear + 1).toString(),
-        'activity-end-date-day': '30',
-        'activity-end-date-month': '11',
-        'activity-end-date-year': (currentYear + 1).toString()
+        'activity-start-date-day': 31,
+        'activity-start-date-month': 4,
+        'activity-start-date-year': currentYear + 1,
+        'activity-end-date-day': 15,
+        'activity-end-date-month': 6,
+        'activity-end-date-year': currentYear + 1
       }
 
       const result = activityDatesSchema.validate(invalidData)
       expect(result.error).toBeDefined()
-      expect(result.error.details).toHaveLength(1)
+      expect(result.error.details[0]).toHaveProperty('message')
+      expect(result.error.details[0]).toHaveProperty('path')
+      expect(result.error.details[0]).toHaveProperty('type')
+    })
+  })
 
-      const errorDetail = result.error.details[0]
-      expect(errorDetail.type).toBe('custom.endDate.before.startDate')
-      expect(errorDetail.path).toEqual([])
-      expect(errorDetail.context).toBeDefined()
+  describe('Custom validation logic coverage', () => {
+    test('should verify custom validation exists for impossible date combinations', () => {
+      // Since MIN_YEAR = current year, any past year gets caught by Joi's number.min validation
+      // before reaching custom validation. The custom "today or future" validation is only
+      // reachable for dates with valid years (current year or future) but past dates.
+      //
+      // However, due to the validation architecture, this is extremely difficult to test
+      // because any date with current year that's in the past would have been yesterday
+      // or earlier, and the test would be time-dependent.
+      //
+      // Instead, we'll verify that the custom validation logic exists and handles
+      // the edge cases correctly by testing the validation flow.
+
+      // Test that custom validation catches impossible dates that pass Joi validation
+      const impossibleDate = {
+        'activity-start-date-day': 31,
+        'activity-start-date-month': 4, // April 31st doesn't exist
+        'activity-start-date-year': currentYear + 1,
+        'activity-end-date-day': 15,
+        'activity-end-date-month': 6,
+        'activity-end-date-year': currentYear + 1
+      }
+
+      const result = activityDatesSchema.validate(impossibleDate)
+      expect(result.error).toBeDefined()
+
+      const errorTypes = result.error.details.map((d) => d.type)
+      expect(errorTypes).toContain('custom.startDate.invalid')
+    })
+
+    test('should verify custom validation handles date relationships correctly', () => {
+      // Test that custom validation catches end date before start date
+      const endBeforeStart = {
+        'activity-start-date-day': 15,
+        'activity-start-date-month': 6,
+        'activity-start-date-year': currentYear + 1,
+        'activity-end-date-day': 10,
+        'activity-end-date-month': 6,
+        'activity-end-date-year': currentYear + 1
+      }
+
+      const result = activityDatesSchema.validate(endBeforeStart)
+      expect(result.error).toBeDefined()
+
+      const errorTypes = result.error.details.map((d) => d.type)
+      expect(errorTypes).toContain('custom.endDate.before.startDate')
+    })
+
+    test('should cover start date custom validation for past dates (line 147)', () => {
+      // This test covers line 147: if (startDate < today)
+      // Strategy: Mock Date constructor to make a current year date appear to be in the past
+
+      // Save the original Date constructor
+      const OriginalDate = Date
+
+      // Create a mock Date that returns a specific date for "new Date()" calls
+      // to make start date appear past but end date appear future
+      const mockDate = jest.fn().mockImplementation((...args) => {
+        if (args.length === 0) {
+          // new Date() calls - return a date between our start and end dates
+          return new OriginalDate('2025-07-15T12:00:00.000Z') // Mid-year
+        } else {
+          // Date.UTC calls and other constructors - use original behavior
+          return new OriginalDate(...args)
+        }
+      })
+
+      // Preserve static methods
+      mockDate.UTC = OriginalDate.UTC
+      mockDate.now = OriginalDate.now
+      mockDate.parse = OriginalDate.parse
+
+      // Replace global Date
+      global.Date = mockDate
+
+      try {
+        // Test data designed to trigger line 147
+        // Mocked "today" is July 15, 2025
+        // Start date: June 1, 2025 (before mocked today - should trigger line 147)
+        // End date: December 31, 2025 (after mocked today - should be valid)
+        const testData = {
+          'activity-start-date-day': 1,
+          'activity-start-date-month': 6, // June (before July 15)
+          'activity-start-date-year': 2025, // Current year, will pass Joi validation
+          'activity-end-date-day': 31,
+          'activity-end-date-month': 12, // December (after July 15)
+          'activity-end-date-year': 2025 // Same year
+        }
+
+        const result = activityDatesSchema.validate(testData)
+
+        // The validation should fail because our mocked "today" makes the start date appear past
+        expect(result.error).toBeDefined()
+        const errorTypes = result.error.details.map((d) => d.type)
+
+        // This should trigger line 147: if (startDate < today)
+        expect(errorTypes).toContain('custom.startDate.todayOrFuture')
+      } finally {
+        // Always restore the original Date constructor
+        global.Date = OriginalDate
+      }
+    })
+  })
+
+  describe('individualDate function', () => {
+    test('should validate a complete date', () => {
+      const result = joi
+        .object({
+          ...individualDate({
+            prefix: 'start-date',
+            minYear: 2020,
+            maxYear: 2030,
+            minYearError: JOI_ERRORS.CUSTOM_START_DATE_TODAY_OR_FUTURE
+          })
+        })
+        .validate(
+          {
+            'start-date-day': '',
+            'start-date-month': '',
+            'start-date-year': ''
+          },
+          { abortEarly: false }
+        )
+      expect(result.error.message).toBe(
+        'start-date-day. start-date-month. start-date-year'
+      )
+    })
+
+    test('should validate individual date with valid data', () => {
+      const result = joi
+        .object({
+          ...individualDate({
+            prefix: 'test-date',
+            minYear: 2020,
+            maxYear: 2030
+          })
+        })
+        .validate({
+          'test-date-day': 15,
+          'test-date-month': 6,
+          'test-date-year': 2025
+        })
+      expect(result.error).toBeUndefined()
+    })
+
+    test('should validate individual date with custom error message', () => {
+      const customError = 'Custom year error message'
+      const result = joi
+        .object({
+          ...individualDate({
+            prefix: 'custom-date',
+            minYear: 2025,
+            maxYear: 2030,
+            minYearError: customError
+          })
+        })
+        .validate({
+          'custom-date-day': 15,
+          'custom-date-month': 6,
+          'custom-date-year': 2020 // Below minYear
+        })
+      expect(result.error).toBeDefined()
+      expect(result.error.details[0].message).toBe(customError)
+    })
+
+    test('should use default minYear when not provided (line 22)', () => {
+      // Test that default minYear = MIN_YEAR is used when not explicitly set
+      const result = joi
+        .object({
+          ...individualDate({
+            prefix: 'default-min-year',
+            maxYear: 2030
+            // minYear not provided - should default to MIN_YEAR (current year)
+          })
+        })
+        .validate({
+          'default-min-year-day': 15,
+          'default-min-year-month': 6,
+          'default-min-year-year': 2020 // Should fail because it's less than MIN_YEAR (2025)
+        })
+      expect(result.error).toBeDefined()
+      expect(result.error.details[0].type).toBe('number.min')
+    })
+
+    test('should use default maxYear when not provided (line 23)', () => {
+      // Test that default maxYear = MAX_YEAR is used when not explicitly set
+      const result = joi
+        .object({
+          ...individualDate({
+            prefix: 'default-max-year',
+            minYear: 2020
+            // maxYear not provided - should default to MAX_YEAR (current year + 75)
+          })
+        })
+        .validate({
+          'default-max-year-day': 15,
+          'default-max-year-month': 6,
+          'default-max-year-year': 2200 // Should fail because it's greater than MAX_YEAR (2100)
+        })
+      expect(result.error).toBeDefined()
+      expect(result.error.details[0].type).toBe('number.max')
+    })
+
+    test('should use both default minYear and maxYear when neither provided', () => {
+      // Test that both default values are used when only prefix is provided
+      const result = joi
+        .object({
+          ...individualDate({
+            prefix: 'all-defaults'
+            // Both minYear and maxYear not provided - should use defaults
+          })
+        })
+        .validate({
+          'all-defaults-day': 15,
+          'all-defaults-month': 6,
+          'all-defaults-year': 2020 // Should fail because it's less than MIN_YEAR
+        })
+      expect(result.error).toBeDefined()
+      expect(result.error.details[0].type).toBe('number.min')
+    })
+  })
+
+  describe('Edge cases', () => {
+    test('should handle leap year dates correctly', () => {
+      const leapYearData = {
+        'activity-start-date-day': 29,
+        'activity-start-date-month': 2,
+        'activity-start-date-year': 2024, // 2024 is a leap year
+        'activity-end-date-day': 15,
+        'activity-end-date-month': 6,
+        'activity-end-date-year': 2024
+      }
+
+      const result = activityDatesSchema.validate(leapYearData)
+      // This should fail because 2024 is in the past relative to current year
+      expect(result.error).toBeDefined()
+    })
+
+    test('should reject February 29th in non-leap years', () => {
+      const nonLeapYearData = {
+        'activity-start-date-day': 29,
+        'activity-start-date-month': 2,
+        'activity-start-date-year': currentYear + 1, // Assuming this won't be a leap year
+        'activity-end-date-day': 15,
+        'activity-end-date-month': 6,
+        'activity-end-date-year': currentYear + 1
+      }
+
+      const result = activityDatesSchema.validate(nonLeapYearData)
+      expect(result.error).toBeDefined()
+      const errorTypes = result.error.details.map((d) => d.type)
+      expect(errorTypes).toContain('custom.startDate.invalid')
     })
   })
 })

--- a/src/server/common/schemas/date.test.js
+++ b/src/server/common/schemas/date.test.js
@@ -1,0 +1,309 @@
+import { activityDatesSchema } from '~/src/server/common/schemas/date.js'
+
+describe('activityDatesSchema', () => {
+  const currentYear = new Date().getFullYear()
+
+  describe('Valid data', () => {
+    test('should accept valid future dates', () => {
+      const validData = {
+        'activity-start-date-day': '1',
+        'activity-start-date-month': '6',
+        'activity-start-date-year': (currentYear + 1).toString(),
+        'activity-end-date-day': '15',
+        'activity-end-date-month': '6',
+        'activity-end-date-year': (currentYear + 1).toString()
+      }
+
+      const result = activityDatesSchema.validate(validData)
+      expect(result.error).toBeUndefined()
+      expect(result.value).toEqual(validData)
+    })
+
+    test('should accept same start and end dates', () => {
+      const validData = {
+        'activity-start-date-day': '1',
+        'activity-start-date-month': '6',
+        'activity-start-date-year': (currentYear + 1).toString(),
+        'activity-end-date-day': '1',
+        'activity-end-date-month': '6',
+        'activity-end-date-year': (currentYear + 1).toString()
+      }
+
+      const result = activityDatesSchema.validate(validData)
+      expect(result.error).toBeUndefined()
+    })
+  })
+
+  describe('Required field validation', () => {
+    test('should require all start date fields', () => {
+      const invalidData = {
+        'activity-end-date-day': '1',
+        'activity-end-date-month': '6',
+        'activity-end-date-year': (currentYear + 1).toString()
+      }
+
+      const result = activityDatesSchema.validate(invalidData, {
+        abortEarly: false
+      })
+      expect(result.error).toBeDefined()
+      expect(result.error.details).toHaveLength(3)
+
+      const errorTypes = result.error.details.map((d) => d.type)
+      expect(errorTypes).toContain('any.required')
+    })
+
+    test('should require all end date fields', () => {
+      const invalidData = {
+        'activity-start-date-day': '1',
+        'activity-start-date-month': '6',
+        'activity-start-date-year': (currentYear + 1).toString()
+      }
+
+      const result = activityDatesSchema.validate(invalidData, {
+        abortEarly: false
+      })
+      expect(result.error).toBeDefined()
+      expect(result.error.details).toHaveLength(3)
+
+      const errorTypes = result.error.details.map((d) => d.type)
+      expect(errorTypes).toContain('any.required')
+    })
+  })
+
+  describe('String pattern validation', () => {
+    test('should reject non-numeric strings', () => {
+      const invalidData = {
+        'activity-start-date-day': 'abc',
+        'activity-start-date-month': '6',
+        'activity-start-date-year': (currentYear + 1).toString(),
+        'activity-end-date-day': '1',
+        'activity-end-date-month': '6',
+        'activity-end-date-year': (currentYear + 1).toString()
+      }
+
+      const result = activityDatesSchema.validate(invalidData)
+      expect(result.error).toBeDefined()
+
+      const errorTypes = result.error.details.map((d) => d.type)
+      expect(errorTypes).toContain('string.pattern.base')
+    })
+
+    test('should reject empty strings', () => {
+      const invalidData = {
+        'activity-start-date-day': '',
+        'activity-start-date-month': '6',
+        'activity-start-date-year': (currentYear + 1).toString(),
+        'activity-end-date-day': '1',
+        'activity-end-date-month': '6',
+        'activity-end-date-year': (currentYear + 1).toString()
+      }
+
+      const result = activityDatesSchema.validate(invalidData)
+      expect(result.error).toBeDefined()
+
+      const errorTypes = result.error.details.map((d) => d.type)
+      expect(errorTypes).toContain('string.empty')
+    })
+  })
+
+  describe('Date range validation', () => {
+    test('should reject invalid day (> 31)', () => {
+      const invalidData = {
+        'activity-start-date-day': '32',
+        'activity-start-date-month': '6',
+        'activity-start-date-year': (currentYear + 1).toString(),
+        'activity-end-date-day': '1',
+        'activity-end-date-month': '6',
+        'activity-end-date-year': (currentYear + 1).toString()
+      }
+
+      const result = activityDatesSchema.validate(invalidData)
+      expect(result.error).toBeDefined()
+
+      const errorTypes = result.error.details.map((d) => d.type)
+      expect(errorTypes).toContain('custom.startDate.invalid')
+    })
+
+    test('should reject invalid month (> 12)', () => {
+      const invalidData = {
+        'activity-start-date-day': '1',
+        'activity-start-date-month': '6',
+        'activity-start-date-year': (currentYear + 1).toString(),
+        'activity-end-date-day': '1',
+        'activity-end-date-month': '14',
+        'activity-end-date-year': (currentYear + 1).toString()
+      }
+
+      const result = activityDatesSchema.validate(invalidData)
+      expect(result.error).toBeDefined()
+
+      const errorTypes = result.error.details.map((d) => d.type)
+      expect(errorTypes).toContain('custom.endDate.invalid')
+    })
+
+    test('should reject invalid year (too far in future)', () => {
+      const invalidData = {
+        'activity-start-date-day': '1',
+        'activity-start-date-month': '6',
+        'activity-start-date-year': (currentYear + 100).toString(),
+        'activity-end-date-day': '1',
+        'activity-end-date-month': '6',
+        'activity-end-date-year': (currentYear + 100).toString()
+      }
+
+      const result = activityDatesSchema.validate(invalidData)
+      expect(result.error).toBeDefined()
+
+      const errorTypes = result.error.details.map((d) => d.type)
+      expect(errorTypes).toContain('custom.startDate.invalid')
+    })
+  })
+
+  describe('Date validity validation', () => {
+    test('should reject impossible dates (February 30th)', () => {
+      const invalidData = {
+        'activity-start-date-day': '30',
+        'activity-start-date-month': '2',
+        'activity-start-date-year': (currentYear + 1).toString(),
+        'activity-end-date-day': '1',
+        'activity-end-date-month': '3',
+        'activity-end-date-year': (currentYear + 1).toString()
+      }
+
+      const result = activityDatesSchema.validate(invalidData)
+      expect(result.error).toBeDefined()
+
+      const errorTypes = result.error.details.map((d) => d.type)
+      expect(errorTypes).toContain('custom.startDate.invalid')
+    })
+
+    test('should reject impossible dates (April 31st)', () => {
+      const invalidData = {
+        'activity-start-date-day': '1',
+        'activity-start-date-month': '1',
+        'activity-start-date-year': (currentYear + 1).toString(),
+        'activity-end-date-day': '31',
+        'activity-end-date-month': '4',
+        'activity-end-date-year': (currentYear + 1).toString()
+      }
+
+      const result = activityDatesSchema.validate(invalidData)
+      expect(result.error).toBeDefined()
+
+      const errorTypes = result.error.details.map((d) => d.type)
+      expect(errorTypes).toContain('custom.endDate.invalid')
+    })
+  })
+
+  describe('Past date validation', () => {
+    test('should reject past start dates', () => {
+      const pastData = {
+        'activity-start-date-day': '1',
+        'activity-start-date-month': '1',
+        'activity-start-date-year': '2020', // Past year
+        'activity-end-date-day': '15',
+        'activity-end-date-month': '1',
+        'activity-end-date-year': (currentYear + 1).toString()
+      }
+
+      const result = activityDatesSchema.validate(pastData)
+      expect(result.error).toBeDefined()
+      const errorTypes = result.error.details.map((d) => d.type)
+      // Past dates now get the more specific "today or future" error instead of "invalid"
+      expect(errorTypes).toContain('custom.startDate.todayOrFuture')
+    })
+
+    test('should reject past end dates when start date is valid', () => {
+      const pastEndData = {
+        'activity-start-date-day': '1',
+        'activity-start-date-month': '6',
+        'activity-start-date-year': (currentYear + 1).toString(),
+        'activity-end-date-day': '15',
+        'activity-end-date-month': '1',
+        'activity-end-date-year': '2020'
+      }
+
+      const result = activityDatesSchema.validate(pastEndData)
+      expect(result.error).toBeDefined()
+      const errorTypes = result.error.details.map((d) => d.type)
+      // With the new validation order, date relationships are checked before "today or future"
+      // So a past end date with a future start date gets the more specific "before start date" error
+      expect(errorTypes).toContain('custom.endDate.before.startDate')
+    })
+  })
+
+  describe('Date order validation', () => {
+    test('should reject end date before start date (same year)', () => {
+      const invalidData = {
+        'activity-start-date-day': '15',
+        'activity-start-date-month': '6',
+        'activity-start-date-year': (currentYear + 1).toString(),
+        'activity-end-date-day': '14',
+        'activity-end-date-month': '6',
+        'activity-end-date-year': (currentYear + 1).toString()
+      }
+
+      const result = activityDatesSchema.validate(invalidData)
+      expect(result.error).toBeDefined()
+
+      const errorTypes = result.error.details.map((d) => d.type)
+      expect(errorTypes).toContain('custom.endDate.before.startDate')
+    })
+
+    test('should reject end date before start date (different months)', () => {
+      const invalidData = {
+        'activity-start-date-day': '1',
+        'activity-start-date-month': '12',
+        'activity-start-date-year': (currentYear + 1).toString(),
+        'activity-end-date-day': '30',
+        'activity-end-date-month': '11',
+        'activity-end-date-year': (currentYear + 1).toString()
+      }
+
+      const result = activityDatesSchema.validate(invalidData)
+      expect(result.error).toBeDefined()
+
+      const errorTypes = result.error.details.map((d) => d.type)
+      expect(errorTypes).toContain('custom.endDate.before.startDate')
+    })
+
+    test('should reject end date before start date (different years)', () => {
+      const invalidData = {
+        'activity-start-date-day': '15',
+        'activity-start-date-month': '6',
+        'activity-start-date-year': (currentYear + 2).toString(),
+        'activity-end-date-day': '15',
+        'activity-end-date-month': '6',
+        'activity-end-date-year': (currentYear + 1).toString()
+      }
+
+      const result = activityDatesSchema.validate(invalidData)
+      expect(result.error).toBeDefined()
+
+      const errorTypes = result.error.details.map((d) => d.type)
+      expect(errorTypes).toContain('custom.endDate.before.startDate')
+    })
+  })
+
+  describe('Error message structure', () => {
+    test('should provide correct error structure for custom validation', () => {
+      const invalidData = {
+        'activity-start-date-day': '1',
+        'activity-start-date-month': '12',
+        'activity-start-date-year': (currentYear + 1).toString(),
+        'activity-end-date-day': '30',
+        'activity-end-date-month': '11',
+        'activity-end-date-year': (currentYear + 1).toString()
+      }
+
+      const result = activityDatesSchema.validate(invalidData)
+      expect(result.error).toBeDefined()
+      expect(result.error.details).toHaveLength(1)
+
+      const errorDetail = result.error.details[0]
+      expect(errorDetail.type).toBe('custom.endDate.before.startDate')
+      expect(errorDetail.path).toEqual([])
+      expect(errorDetail.context).toBeDefined()
+    })
+  })
+})

--- a/src/server/exemption/activity-dates/controller.js
+++ b/src/server/exemption/activity-dates/controller.js
@@ -36,10 +36,6 @@ const FIELD_NAMES = {
 
 const activityDatesViewSettings = {
   title: 'Activity dates',
-  descriptionParagraphs: [
-    "Enter the activity dates. Allow time for potential delays, like consents (for example, a river works licence) or bad weather. If you miss the dates, you'll need to restart the process.",
-    "You can enter a start date from today and begin your activity as soon as you've sent your information."
-  ],
   backLink: routes.TASK_LIST,
   cancelLink: routes.TASK_LIST
 }

--- a/src/server/exemption/activity-dates/controller.js
+++ b/src/server/exemption/activity-dates/controller.js
@@ -14,6 +14,15 @@ import { activityDatesSchema } from '~/src/server/common/schemas/date.js'
 
 export const ACTIVITY_DATES_VIEW_ROUTE = 'exemption/activity-dates/index'
 
+const FIELD_NAMES = {
+  START_DATE_DAY: 'activity-start-date-day',
+  START_DATE_MONTH: 'activity-start-date-month',
+  START_DATE_YEAR: 'activity-start-date-year',
+  END_DATE_DAY: 'activity-end-date-day',
+  END_DATE_MONTH: 'activity-end-date-month',
+  END_DATE_YEAR: 'activity-end-date-year'
+}
+
 const activityDatesViewSettings = {
   title: 'Activity dates',
   descriptionParagraphs: [
@@ -60,6 +69,190 @@ function createDateISO(year, month, day) {
 
   const date = new Date(Date.UTC(numYear, numMonth - 1, numDay))
   return date.toISOString()
+}
+
+/**
+ * Creates error type mapping from JOI error details
+ * @param {Array} errorDetails - JOI error details array
+ * @returns {Object} Error type mapping
+ */
+function createErrorTypeMap(errorDetails) {
+  const errorTypeMap = {}
+  errorDetails.forEach((detail) => {
+    errorTypeMap[detail.type] = detail
+  })
+  return errorTypeMap
+}
+
+/**
+ * Checks if all date components are missing for complete date validation
+ * @param {Object} errors - Error descriptions by field name
+ * @param {string} dateType - 'start' or 'end'
+ * @returns {boolean}
+ */
+function isCompleteDateMissing(errors, dateType) {
+  const dayError =
+    dateType === 'start'
+      ? JOI_ERRORS.ACTIVITY_START_DATE_DAY
+      : JOI_ERRORS.ACTIVITY_END_DATE_DAY
+  const monthError =
+    dateType === 'start'
+      ? JOI_ERRORS.ACTIVITY_START_DATE_MONTH
+      : JOI_ERRORS.ACTIVITY_END_DATE_MONTH
+  const yearError =
+    dateType === 'start'
+      ? JOI_ERRORS.ACTIVITY_START_DATE_YEAR
+      : JOI_ERRORS.ACTIVITY_END_DATE_YEAR
+
+  return errors[dayError] && errors[monthError] && errors[yearError]
+}
+
+/**
+ * Adds custom validation errors to error summary
+ * @param {Array} errorSummary - Current error summary array
+ * @param {Object} errorTypeMap - Error type mapping
+ */
+function addCustomValidationErrors(errorSummary, errorTypeMap) {
+  // Start date custom errors
+  if (errorTypeMap[JOI_ERRORS.CUSTOM_START_DATE_TODAY_OR_FUTURE]) {
+    errorSummary.push({
+      href: `#${FIELD_NAMES.START_DATE_DAY}`,
+      text: errorMessages[JOI_ERRORS.CUSTOM_START_DATE_TODAY_OR_FUTURE]
+    })
+  } else if (errorTypeMap[JOI_ERRORS.CUSTOM_START_DATE_INVALID]) {
+    errorSummary.push({
+      href: `#${FIELD_NAMES.START_DATE_DAY}`,
+      text: errorMessages[JOI_ERRORS.CUSTOM_START_DATE_INVALID]
+    })
+  }
+
+  // End date custom errors
+  if (errorTypeMap[JOI_ERRORS.CUSTOM_END_DATE_TODAY_OR_FUTURE]) {
+    errorSummary.push({
+      href: `#${FIELD_NAMES.END_DATE_DAY}`,
+      text: errorMessages[JOI_ERRORS.CUSTOM_END_DATE_TODAY_OR_FUTURE]
+    })
+  } else if (errorTypeMap[JOI_ERRORS.CUSTOM_END_DATE_INVALID]) {
+    errorSummary.push({
+      href: `#${FIELD_NAMES.END_DATE_DAY}`,
+      text: errorMessages[JOI_ERRORS.CUSTOM_END_DATE_INVALID]
+    })
+  }
+
+  // Date relationship error
+  if (errorTypeMap[JOI_ERRORS.CUSTOM_END_DATE_BEFORE_START_DATE]) {
+    errorSummary.push({
+      href: `#${FIELD_NAMES.END_DATE_DAY}`,
+      text: errorMessages[JOI_ERRORS.CUSTOM_END_DATE_BEFORE_START_DATE]
+    })
+  }
+}
+
+/**
+ * Handles missing complete date errors in summary
+ * @param {Array} errorSummary - Current error summary array
+ * @param {boolean} isStartMissing - Whether start date is completely missing
+ * @param {boolean} isEndMissing - Whether end date is completely missing
+ * @returns {Array} Modified error summary
+ */
+function handleMissingDateErrors(errorSummary, isStartMissing, isEndMissing) {
+  let modifiedSummary = [...errorSummary]
+
+  if (isStartMissing) {
+    modifiedSummary = modifiedSummary.filter(
+      (error) => !error.href.includes('#activity-start-date')
+    )
+    modifiedSummary.unshift({
+      href: `#${FIELD_NAMES.START_DATE_DAY}`,
+      text: errorMessages[JOI_ERRORS.CUSTOM_START_DATE_MISSING]
+    })
+  }
+
+  if (isEndMissing) {
+    modifiedSummary = modifiedSummary.filter(
+      (error) => !error.href.includes('#activity-end-date')
+    )
+    modifiedSummary.push({
+      href: `#${FIELD_NAMES.END_DATE_DAY}`,
+      text: errorMessages[JOI_ERRORS.CUSTOM_END_DATE_MISSING]
+    })
+  }
+
+  return modifiedSummary
+}
+
+/**
+ * Determines the appropriate error message for start date
+ * @param {boolean} isStartMissing - Whether start date is completely missing
+ * @param {Object} errorTypeMap - Error type mapping
+ * @param {Object} errors - Error descriptions by field name
+ * @returns {Object|null} Error message object or null
+ */
+function getStartDateErrorMessage(isStartMissing, errorTypeMap, errors) {
+  if (isStartMissing) {
+    return { text: errorMessages[JOI_ERRORS.CUSTOM_START_DATE_MISSING] }
+  }
+
+  if (errorTypeMap[JOI_ERRORS.CUSTOM_START_DATE_TODAY_OR_FUTURE]) {
+    return { text: errorMessages[JOI_ERRORS.CUSTOM_START_DATE_TODAY_OR_FUTURE] }
+  }
+
+  if (errorTypeMap[JOI_ERRORS.CUSTOM_START_DATE_INVALID]) {
+    return { text: errorMessages[JOI_ERRORS.CUSTOM_START_DATE_INVALID] }
+  }
+
+  if (errors[JOI_ERRORS.ACTIVITY_START_DATE_DAY]) {
+    return { text: errorMessages[JOI_ERRORS.ACTIVITY_START_DATE_DAY] }
+  }
+
+  if (errors[JOI_ERRORS.ACTIVITY_START_DATE_MONTH]) {
+    return { text: errorMessages[JOI_ERRORS.ACTIVITY_START_DATE_MONTH] }
+  }
+
+  if (errors[JOI_ERRORS.ACTIVITY_START_DATE_YEAR]) {
+    return { text: errorMessages[JOI_ERRORS.ACTIVITY_START_DATE_YEAR] }
+  }
+
+  return null
+}
+
+/**
+ * Determines the appropriate error message for end date
+ * @param {boolean} isEndMissing - Whether end date is completely missing
+ * @param {Object} errorTypeMap - Error type mapping
+ * @param {Object} errors - Error descriptions by field name
+ * @returns {Object|null} Error message object or null
+ */
+function getEndDateErrorMessage(isEndMissing, errorTypeMap, errors) {
+  if (isEndMissing) {
+    return { text: errorMessages[JOI_ERRORS.CUSTOM_END_DATE_MISSING] }
+  }
+
+  if (errorTypeMap[JOI_ERRORS.CUSTOM_END_DATE_TODAY_OR_FUTURE]) {
+    return { text: errorMessages[JOI_ERRORS.CUSTOM_END_DATE_TODAY_OR_FUTURE] }
+  }
+
+  if (errorTypeMap[JOI_ERRORS.CUSTOM_END_DATE_INVALID]) {
+    return { text: errorMessages[JOI_ERRORS.CUSTOM_END_DATE_INVALID] }
+  }
+
+  if (errorTypeMap[JOI_ERRORS.CUSTOM_END_DATE_BEFORE_START_DATE]) {
+    return { text: errorMessages[JOI_ERRORS.CUSTOM_END_DATE_BEFORE_START_DATE] }
+  }
+
+  if (errors[JOI_ERRORS.ACTIVITY_END_DATE_DAY]) {
+    return { text: errorMessages[JOI_ERRORS.ACTIVITY_END_DATE_DAY] }
+  }
+
+  if (errors[JOI_ERRORS.ACTIVITY_END_DATE_MONTH]) {
+    return { text: errorMessages[JOI_ERRORS.ACTIVITY_END_DATE_MONTH] }
+  }
+
+  if (errors[JOI_ERRORS.ACTIVITY_END_DATE_YEAR]) {
+    return { text: errorMessages[JOI_ERRORS.ACTIVITY_END_DATE_YEAR] }
+  }
+
+  return null
 }
 
 /**
@@ -128,142 +321,44 @@ export const activityDatesSubmitController = {
 
         const errorSummary = mapErrorsForDisplay(err.details, errorMessages)
         const errors = errorDescriptionByFieldName(errorSummary)
+        const errorTypeMap = createErrorTypeMap(err.details)
 
-        const errorTypeMap = {}
-        err.details.forEach((detail) => {
-          errorTypeMap[detail.type] = detail
-        })
-
-        // Check if all three date components are missing to consolidate error messages
-        const isStartMissing =
-          errors[JOI_ERRORS.ACTIVITY_START_DATE_DAY] &&
-          errors[JOI_ERRORS.ACTIVITY_START_DATE_MONTH] &&
-          errors[JOI_ERRORS.ACTIVITY_START_DATE_YEAR]
-
-        const isEndMissing =
-          errors[JOI_ERRORS.ACTIVITY_END_DATE_DAY] &&
-          errors[JOI_ERRORS.ACTIVITY_END_DATE_MONTH] &&
-          errors[JOI_ERRORS.ACTIVITY_END_DATE_YEAR]
+        const isStartMissing = isCompleteDateMissing(errors, 'start')
+        const isEndMissing = isCompleteDateMissing(errors, 'end')
 
         let modifiedErrorSummary = errorSummary.filter(
           (error) =>
             error.href && error.href !== '#' && error.href !== '#undefined'
         )
-        let startDateErrorMessage = null
-        let endDateErrorMessage = null
 
-        // Prioritize specific error messages over generic ones
-        if (errorTypeMap[JOI_ERRORS.CUSTOM_START_DATE_TODAY_OR_FUTURE]) {
-          modifiedErrorSummary.push({
-            href: '#activity-start-date-day',
-            text: errorMessages[JOI_ERRORS.CUSTOM_START_DATE_TODAY_OR_FUTURE]
-          })
-        } else if (errorTypeMap[JOI_ERRORS.CUSTOM_START_DATE_INVALID]) {
-          modifiedErrorSummary.push({
-            href: '#activity-start-date-day',
-            text: errorMessages[JOI_ERRORS.CUSTOM_START_DATE_INVALID]
-          })
-        }
+        addCustomValidationErrors(modifiedErrorSummary, errorTypeMap)
+        modifiedErrorSummary = handleMissingDateErrors(
+          modifiedErrorSummary,
+          isStartMissing,
+          isEndMissing
+        )
 
-        if (errorTypeMap[JOI_ERRORS.CUSTOM_END_DATE_TODAY_OR_FUTURE]) {
-          modifiedErrorSummary.push({
-            href: '#activity-end-date-day',
-            text: errorMessages[JOI_ERRORS.CUSTOM_END_DATE_TODAY_OR_FUTURE]
-          })
-        } else if (errorTypeMap[JOI_ERRORS.CUSTOM_END_DATE_INVALID]) {
-          modifiedErrorSummary.push({
-            href: '#activity-end-date-day',
-            text: errorMessages[JOI_ERRORS.CUSTOM_END_DATE_INVALID]
-          })
-        }
-
-        if (errorTypeMap[JOI_ERRORS.CUSTOM_END_DATE_BEFORE_START_DATE]) {
-          modifiedErrorSummary.push({
-            href: '#activity-end-date-day',
-            text: errorMessages[JOI_ERRORS.CUSTOM_END_DATE_BEFORE_START_DATE]
-          })
-        }
-
-        if (isStartMissing) {
-          modifiedErrorSummary = modifiedErrorSummary.filter(
-            (error) => !error.href.includes('#activity-start-date')
-          )
-          modifiedErrorSummary.unshift({
-            href: '#activity-start-date-day',
-            text: errorMessages[JOI_ERRORS.CUSTOM_START_DATE_MISSING]
-          })
-          startDateErrorMessage = {
-            text: errorMessages[JOI_ERRORS.CUSTOM_START_DATE_MISSING]
-          }
-        } else if (errorTypeMap[JOI_ERRORS.CUSTOM_START_DATE_TODAY_OR_FUTURE]) {
-          startDateErrorMessage = {
-            text: errorMessages[JOI_ERRORS.CUSTOM_START_DATE_TODAY_OR_FUTURE]
-          }
-        } else if (errorTypeMap[JOI_ERRORS.CUSTOM_START_DATE_INVALID]) {
-          startDateErrorMessage = {
-            text: errorMessages[JOI_ERRORS.CUSTOM_START_DATE_INVALID]
-          }
-        } else if (errors[JOI_ERRORS.ACTIVITY_START_DATE_DAY]) {
-          startDateErrorMessage = {
-            text: errorMessages[JOI_ERRORS.ACTIVITY_START_DATE_DAY]
-          }
-        } else if (errors[JOI_ERRORS.ACTIVITY_START_DATE_MONTH]) {
-          startDateErrorMessage = {
-            text: errorMessages[JOI_ERRORS.ACTIVITY_START_DATE_MONTH]
-          }
-        } else if (errors[JOI_ERRORS.ACTIVITY_START_DATE_YEAR]) {
-          startDateErrorMessage = {
-            text: errorMessages[JOI_ERRORS.ACTIVITY_START_DATE_YEAR]
-          }
-        }
-
-        if (isEndMissing) {
-          modifiedErrorSummary = modifiedErrorSummary.filter(
-            (error) => !error.href.includes('#activity-end-date')
-          )
-          modifiedErrorSummary.push({
-            href: '#activity-end-date-day',
-            text: errorMessages[JOI_ERRORS.CUSTOM_END_DATE_MISSING]
-          })
-          endDateErrorMessage = {
-            text: errorMessages[JOI_ERRORS.CUSTOM_END_DATE_MISSING]
-          }
-        } else if (errorTypeMap[JOI_ERRORS.CUSTOM_END_DATE_TODAY_OR_FUTURE]) {
-          endDateErrorMessage = {
-            text: errorMessages[JOI_ERRORS.CUSTOM_END_DATE_TODAY_OR_FUTURE]
-          }
-        } else if (errorTypeMap[JOI_ERRORS.CUSTOM_END_DATE_INVALID]) {
-          endDateErrorMessage = {
-            text: errorMessages[JOI_ERRORS.CUSTOM_END_DATE_INVALID]
-          }
-        } else if (errorTypeMap[JOI_ERRORS.CUSTOM_END_DATE_BEFORE_START_DATE]) {
-          endDateErrorMessage = {
-            text: errorMessages[JOI_ERRORS.CUSTOM_END_DATE_BEFORE_START_DATE]
-          }
-        } else if (errors[JOI_ERRORS.ACTIVITY_END_DATE_DAY]) {
-          endDateErrorMessage = {
-            text: errorMessages[JOI_ERRORS.ACTIVITY_END_DATE_DAY]
-          }
-        } else if (errors[JOI_ERRORS.ACTIVITY_END_DATE_MONTH]) {
-          endDateErrorMessage = {
-            text: errorMessages[JOI_ERRORS.ACTIVITY_END_DATE_MONTH]
-          }
-        } else if (errors[JOI_ERRORS.ACTIVITY_END_DATE_YEAR]) {
-          endDateErrorMessage = {
-            text: errorMessages[JOI_ERRORS.ACTIVITY_END_DATE_YEAR]
-          }
-        }
+        const startDateErrorMessage = getStartDateErrorMessage(
+          isStartMissing,
+          errorTypeMap,
+          errors
+        )
+        const endDateErrorMessage = getEndDateErrorMessage(
+          isEndMissing,
+          errorTypeMap,
+          errors
+        )
 
         return h
           .view(ACTIVITY_DATES_VIEW_ROUTE, {
             ...activityDatesViewSettings,
             projectName: exemption.projectName,
-            activityStartDateDay: payload['activity-start-date-day'] || '',
-            activityStartDateMonth: payload['activity-start-date-month'] || '',
-            activityStartDateYear: payload['activity-start-date-year'] || '',
-            activityEndDateDay: payload['activity-end-date-day'] || '',
-            activityEndDateMonth: payload['activity-end-date-month'] || '',
-            activityEndDateYear: payload['activity-end-date-year'] || '',
+            activityStartDateDay: payload[FIELD_NAMES.START_DATE_DAY] || '',
+            activityStartDateMonth: payload[FIELD_NAMES.START_DATE_MONTH] || '',
+            activityStartDateYear: payload[FIELD_NAMES.START_DATE_YEAR] || '',
+            activityEndDateDay: payload[FIELD_NAMES.END_DATE_DAY] || '',
+            activityEndDateMonth: payload[FIELD_NAMES.END_DATE_MONTH] || '',
+            activityEndDateYear: payload[FIELD_NAMES.END_DATE_YEAR] || '',
             errors,
             errorSummary: modifiedErrorSummary,
             startDateErrorMessage,
@@ -279,15 +374,15 @@ export const activityDatesSubmitController = {
 
     try {
       const start = createDateISO(
-        payload['activity-start-date-year'],
-        payload['activity-start-date-month'],
-        payload['activity-start-date-day']
+        payload[FIELD_NAMES.START_DATE_YEAR],
+        payload[FIELD_NAMES.START_DATE_MONTH],
+        payload[FIELD_NAMES.START_DATE_DAY]
       )
 
       const end = createDateISO(
-        payload['activity-end-date-year'],
-        payload['activity-end-date-month'],
-        payload['activity-end-date-day']
+        payload[FIELD_NAMES.END_DATE_YEAR],
+        payload[FIELD_NAMES.END_DATE_MONTH],
+        payload[FIELD_NAMES.END_DATE_DAY]
       )
 
       await Wreck.patch(
@@ -324,12 +419,12 @@ export const activityDatesSubmitController = {
       return h.view(ACTIVITY_DATES_VIEW_ROUTE, {
         ...activityDatesViewSettings,
         projectName: exemption.projectName,
-        activityStartDateDay: payload['activity-start-date-day'] || '',
-        activityStartDateMonth: payload['activity-start-date-month'] || '',
-        activityStartDateYear: payload['activity-start-date-year'] || '',
-        activityEndDateDay: payload['activity-end-date-day'] || '',
-        activityEndDateMonth: payload['activity-end-date-month'] || '',
-        activityEndDateYear: payload['activity-end-date-year'] || '',
+        activityStartDateDay: payload[FIELD_NAMES.START_DATE_DAY] || '',
+        activityStartDateMonth: payload[FIELD_NAMES.START_DATE_MONTH] || '',
+        activityStartDateYear: payload[FIELD_NAMES.START_DATE_YEAR] || '',
+        activityEndDateDay: payload[FIELD_NAMES.END_DATE_DAY] || '',
+        activityEndDateMonth: payload[FIELD_NAMES.END_DATE_MONTH] || '',
+        activityEndDateYear: payload[FIELD_NAMES.END_DATE_YEAR] || '',
         errors,
         errorSummary
       })

--- a/src/server/exemption/activity-dates/controller.js
+++ b/src/server/exemption/activity-dates/controller.js
@@ -29,7 +29,8 @@ const activityDatesViewSettings = {
     "Enter the activity dates. Allow time for potential delays, like consents (for example, a river works licence) or bad weather. If you miss the dates, you'll need to restart the process.",
     "You can enter a start date from today and begin your activity as soon as you've sent your information."
   ],
-  backLink: routes.TASK_LIST
+  backLink: routes.TASK_LIST,
+  cancelLink: routes.TASK_LIST
 }
 
 const errorMessages = {
@@ -74,7 +75,7 @@ function createDateISO(year, month, day) {
 /**
  * Creates error type mapping from JOI error details
  * @param {Array} errorDetails - JOI error details array
- * @returns {Object} Error type mapping
+ * @returns {object} Error type mapping
  */
 function createErrorTypeMap(errorDetails) {
   const errorTypeMap = {}
@@ -86,7 +87,7 @@ function createErrorTypeMap(errorDetails) {
 
 /**
  * Checks if all date components are missing for complete date validation
- * @param {Object} errors - Error descriptions by field name
+ * @param {object} errors - Error descriptions by field name
  * @param {string} dateType - 'start' or 'end'
  * @returns {boolean}
  */
@@ -110,7 +111,7 @@ function isCompleteDateMissing(errors, dateType) {
 /**
  * Adds custom validation errors to error summary
  * @param {Array} errorSummary - Current error summary array
- * @param {Object} errorTypeMap - Error type mapping
+ * @param {object} errorTypeMap - Error type mapping
  */
 function addCustomValidationErrors(errorSummary, errorTypeMap) {
   // Start date custom errors
@@ -184,9 +185,9 @@ function handleMissingDateErrors(errorSummary, isStartMissing, isEndMissing) {
 /**
  * Determines the appropriate error message for start date
  * @param {boolean} isStartMissing - Whether start date is completely missing
- * @param {Object} errorTypeMap - Error type mapping
- * @param {Object} errors - Error descriptions by field name
- * @returns {Object|null} Error message object or null
+ * @param {object} errorTypeMap - Error type mapping
+ * @param {object} errors - Error descriptions by field name
+ * @returns {object|null} Error message object or null
  */
 function getStartDateErrorMessage(isStartMissing, errorTypeMap, errors) {
   if (isStartMissing) {
@@ -219,9 +220,9 @@ function getStartDateErrorMessage(isStartMissing, errorTypeMap, errors) {
 /**
  * Determines the appropriate error message for end date
  * @param {boolean} isEndMissing - Whether end date is completely missing
- * @param {Object} errorTypeMap - Error type mapping
- * @param {Object} errors - Error descriptions by field name
- * @returns {Object|null} Error message object or null
+ * @param {object} errorTypeMap - Error type mapping
+ * @param {object} errors - Error descriptions by field name
+ * @returns {object|null} Error message object or null
  */
 function getEndDateErrorMessage(isEndMissing, errorTypeMap, errors) {
   if (isEndMissing) {

--- a/src/server/exemption/activity-dates/controller.js
+++ b/src/server/exemption/activity-dates/controller.js
@@ -59,7 +59,7 @@ const errorMessages = {
  * @param {string|number} day
  * @returns {string|null}
  */
-function createDateISO(year, month, day) {
+export function createDateISO(year, month, day) {
   const numYear = parseInt(year, 10)
   const numMonth = parseInt(month, 10)
   const numDay = parseInt(day, 10)
@@ -81,6 +81,10 @@ function createErrorTypeMap(errorDetails) {
   const errorTypeMap = {}
   errorDetails.forEach((detail) => {
     errorTypeMap[detail.type] = detail
+    // Also map by message for custom error types
+    if (detail.message !== detail.type) {
+      errorTypeMap[detail.message] = detail
+    }
   })
   return errorTypeMap
 }

--- a/src/server/exemption/activity-dates/controller.js
+++ b/src/server/exemption/activity-dates/controller.js
@@ -11,20 +11,27 @@ import { config } from '~/src/config/config.js'
 import { routes } from '~/src/server/common/constants/routes.js'
 import { JOI_ERRORS } from '~/src/server/common/constants/joi.js'
 import { activityDatesSchema } from '~/src/server/common/schemas/date.js'
+import { createDateISO } from '~/src/server/common/helpers/date-utils.js'
 import {
-  createDateISO,
-  extractDateComponents
-} from '~/src/server/common/helpers/date-utils.js'
+  createDateFieldNames,
+  extractMultipleDateFields,
+  createDateFieldsFromValue,
+  handleDateValidationErrors,
+  addCustomValidationErrors as genericAddCustomValidationErrors
+} from '~/src/server/common/helpers/date-form-utils.js'
 
 export const ACTIVITY_DATES_VIEW_ROUTE = 'exemption/activity-dates/index'
 
+const START_DATE_FIELD_NAMES = createDateFieldNames('activity-start-date')
+const END_DATE_FIELD_NAMES = createDateFieldNames('activity-end-date')
+
 const FIELD_NAMES = {
-  START_DATE_DAY: 'activity-start-date-day',
-  START_DATE_MONTH: 'activity-start-date-month',
-  START_DATE_YEAR: 'activity-start-date-year',
-  END_DATE_DAY: 'activity-end-date-day',
-  END_DATE_MONTH: 'activity-end-date-month',
-  END_DATE_YEAR: 'activity-end-date-year'
+  START_DATE_DAY: START_DATE_FIELD_NAMES.DAY,
+  START_DATE_MONTH: START_DATE_FIELD_NAMES.MONTH,
+  START_DATE_YEAR: START_DATE_FIELD_NAMES.YEAR,
+  END_DATE_DAY: END_DATE_FIELD_NAMES.DAY,
+  END_DATE_MONTH: END_DATE_FIELD_NAMES.MONTH,
+  END_DATE_YEAR: END_DATE_FIELD_NAMES.YEAR
 }
 
 const activityDatesViewSettings = {
@@ -62,14 +69,12 @@ export const errorMessages = {
  * @returns {object} Date field values
  */
 export function extractDateFieldsFromPayload(payload) {
-  return {
-    activityStartDateDay: payload[FIELD_NAMES.START_DATE_DAY] || '',
-    activityStartDateMonth: payload[FIELD_NAMES.START_DATE_MONTH] || '',
-    activityStartDateYear: payload[FIELD_NAMES.START_DATE_YEAR] || '',
-    activityEndDateDay: payload[FIELD_NAMES.END_DATE_DAY] || '',
-    activityEndDateMonth: payload[FIELD_NAMES.END_DATE_MONTH] || '',
-    activityEndDateYear: payload[FIELD_NAMES.END_DATE_YEAR] || ''
-  }
+  const dateConfigs = [
+    { key: 'activityStartDate', prefix: 'activity-start-date' },
+    { key: 'activityEndDate', prefix: 'activity-end-date' }
+  ]
+
+  return extractMultipleDateFields(payload, dateConfigs)
 }
 
 /**
@@ -84,20 +89,20 @@ export function createTemplateData(exemption, payload = null) {
   if (payload) {
     dateFields = extractDateFieldsFromPayload(payload)
   } else {
-    const startDateComponents = extractDateComponents(
+    const startDateFields = createDateFieldsFromValue(
       exemption.activityDates?.start
     )
-    const endDateComponents = extractDateComponents(
+    const endDateFields = createDateFieldsFromValue(
       exemption.activityDates?.end
     )
 
     dateFields = {
-      activityStartDateDay: startDateComponents.day,
-      activityStartDateMonth: startDateComponents.month,
-      activityStartDateYear: startDateComponents.year,
-      activityEndDateDay: endDateComponents.day,
-      activityEndDateMonth: endDateComponents.month,
-      activityEndDateYear: endDateComponents.year
+      activityStartDateDay: startDateFields.day,
+      activityStartDateMonth: startDateFields.month,
+      activityStartDateYear: startDateFields.year,
+      activityEndDateDay: endDateFields.day,
+      activityEndDateMonth: endDateFields.month,
+      activityEndDateYear: endDateFields.year
     }
   }
 
@@ -108,289 +113,60 @@ export function createTemplateData(exemption, payload = null) {
   }
 }
 
-/**
- * Creates error type mapping from JOI error details
- * @param {Array} errorDetails - JOI error details array
- * @returns {object} Error type mapping
- */
-function createErrorTypeMap(errorDetails) {
-  const errorTypeMap = {}
-  errorDetails.forEach((detail) => {
-    errorTypeMap[detail.type] = detail
-    // Also map by message for custom error types
-    if (detail.message !== detail.type) {
-      errorTypeMap[detail.message] = detail
-    }
-  })
-  return errorTypeMap
-}
+// Date configuration for the generic date form utilities
+const DATE_CONFIGS = [
+  {
+    prefix: 'activity-start-date',
+    fieldNames: START_DATE_FIELD_NAMES,
+    errorMessageKey: 'startDateErrorMessage',
+    errorKeys: {
+      MISSING: JOI_ERRORS.CUSTOM_START_DATE_MISSING,
+      INVALID: JOI_ERRORS.CUSTOM_START_DATE_INVALID,
+      TODAY_OR_FUTURE: JOI_ERRORS.CUSTOM_START_DATE_TODAY_OR_FUTURE,
+      DAY: JOI_ERRORS.ACTIVITY_START_DATE_DAY,
+      MONTH: JOI_ERRORS.ACTIVITY_START_DATE_MONTH,
+      YEAR: JOI_ERRORS.ACTIVITY_START_DATE_YEAR
+    },
+    fieldErrorKeys: {
+      [START_DATE_FIELD_NAMES.DAY]: JOI_ERRORS.ACTIVITY_START_DATE_DAY,
+      [START_DATE_FIELD_NAMES.MONTH]: JOI_ERRORS.ACTIVITY_START_DATE_MONTH,
+      [START_DATE_FIELD_NAMES.YEAR]: JOI_ERRORS.ACTIVITY_START_DATE_YEAR
+    },
+    errorMessages
+  },
+  {
+    prefix: 'activity-end-date',
+    fieldNames: END_DATE_FIELD_NAMES,
+    errorMessageKey: 'endDateErrorMessage',
+    errorKeys: {
+      MISSING: JOI_ERRORS.CUSTOM_END_DATE_MISSING,
+      INVALID: JOI_ERRORS.CUSTOM_END_DATE_INVALID,
+      TODAY_OR_FUTURE: JOI_ERRORS.CUSTOM_END_DATE_TODAY_OR_FUTURE,
+      BEFORE_OTHER_DATE: JOI_ERRORS.CUSTOM_END_DATE_BEFORE_START_DATE,
+      DAY: JOI_ERRORS.ACTIVITY_END_DATE_DAY,
+      MONTH: JOI_ERRORS.ACTIVITY_END_DATE_MONTH,
+      YEAR: JOI_ERRORS.ACTIVITY_END_DATE_YEAR
+    },
+    fieldErrorKeys: {
+      [END_DATE_FIELD_NAMES.DAY]: JOI_ERRORS.ACTIVITY_END_DATE_DAY,
+      [END_DATE_FIELD_NAMES.MONTH]: JOI_ERRORS.ACTIVITY_END_DATE_MONTH,
+      [END_DATE_FIELD_NAMES.YEAR]: JOI_ERRORS.ACTIVITY_END_DATE_YEAR
+    },
+    errorMessages
+  }
+]
 
 /**
- * Checks if all date components are missing for complete date validation
- * @param {object} errors - Error descriptions by field name
- * @param {string} dateType - 'start' or 'end'
- * @returns {boolean}
- */
-function isCompleteDateMissing(errors, dateType) {
-  const dayError =
-    dateType === 'start'
-      ? JOI_ERRORS.ACTIVITY_START_DATE_DAY
-      : JOI_ERRORS.ACTIVITY_END_DATE_DAY
-  const monthError =
-    dateType === 'start'
-      ? JOI_ERRORS.ACTIVITY_START_DATE_MONTH
-      : JOI_ERRORS.ACTIVITY_END_DATE_MONTH
-  const yearError =
-    dateType === 'start'
-      ? JOI_ERRORS.ACTIVITY_START_DATE_YEAR
-      : JOI_ERRORS.ACTIVITY_END_DATE_YEAR
-
-  return errors[dayError] && errors[monthError] && errors[yearError]
-}
-
-/**
- * Adds custom validation errors to error summary
+ * Backwards compatibility wrapper for addCustomValidationErrors
  * @param {Array} errorSummary - Current error summary array
  * @param {object} errorTypeMap - Error type mapping
  */
 export function addCustomValidationErrors(errorSummary, errorTypeMap) {
-  // Check for number.max errors that should be treated as invalid date errors
-  const hasStartInvalidFieldErrors = hasNumberMaxErrorsForDate(
-    'start',
-    errorTypeMap
+  return genericAddCustomValidationErrors(
+    errorSummary,
+    errorTypeMap,
+    DATE_CONFIGS
   )
-  const hasEndInvalidFieldErrors = hasNumberMaxErrorsForDate(
-    'end',
-    errorTypeMap
-  )
-
-  // Start date custom errors - check for today/future first (higher priority)
-  let startDateErrorAdded = false
-
-  if (errorTypeMap[JOI_ERRORS.CUSTOM_START_DATE_TODAY_OR_FUTURE]) {
-    errorSummary.push({
-      href: `#${FIELD_NAMES.START_DATE_DAY}`,
-      text: errorMessages[JOI_ERRORS.CUSTOM_START_DATE_TODAY_OR_FUTURE]
-    })
-    startDateErrorAdded = true
-  }
-
-  // Add invalid date error if no today/future error was added AND we have either
-  // a custom invalid error OR number.max errors for date fields
-  if (
-    !startDateErrorAdded &&
-    (errorTypeMap[JOI_ERRORS.CUSTOM_START_DATE_INVALID] ||
-      hasStartInvalidFieldErrors)
-  ) {
-    errorSummary.push({
-      href: `#${FIELD_NAMES.START_DATE_DAY}`,
-      text: errorMessages[JOI_ERRORS.CUSTOM_START_DATE_INVALID]
-    })
-    startDateErrorAdded = true
-  }
-
-  // End date custom errors - check for today/future first (higher priority)
-  let endDateErrorAdded = false
-
-  if (errorTypeMap[JOI_ERRORS.CUSTOM_END_DATE_TODAY_OR_FUTURE]) {
-    errorSummary.push({
-      href: `#${FIELD_NAMES.END_DATE_DAY}`,
-      text: errorMessages[JOI_ERRORS.CUSTOM_END_DATE_TODAY_OR_FUTURE]
-    })
-    endDateErrorAdded = true
-  }
-
-  // Add invalid date error if no today/future error was added AND we have either
-  // a custom invalid error OR number.max errors for date fields
-  if (
-    !endDateErrorAdded &&
-    (errorTypeMap[JOI_ERRORS.CUSTOM_END_DATE_INVALID] ||
-      hasEndInvalidFieldErrors)
-  ) {
-    errorSummary.push({
-      href: `#${FIELD_NAMES.END_DATE_DAY}`,
-      text: errorMessages[JOI_ERRORS.CUSTOM_END_DATE_INVALID]
-    })
-    endDateErrorAdded = true
-  }
-
-  // Date relationship error
-  if (errorTypeMap[JOI_ERRORS.CUSTOM_END_DATE_BEFORE_START_DATE]) {
-    errorSummary.push({
-      href: `#${FIELD_NAMES.END_DATE_DAY}`,
-      text: errorMessages[JOI_ERRORS.CUSTOM_END_DATE_BEFORE_START_DATE]
-    })
-  }
-}
-
-/**
- * Handles missing complete date errors in summary
- * @param {Array} errorSummary - Current error summary array
- * @param {boolean} isStartMissing - Whether start date is completely missing
- * @param {boolean} isEndMissing - Whether end date is completely missing
- * @returns {Array} Modified error summary
- */
-function handleMissingDateErrors(errorSummary, isStartMissing, isEndMissing) {
-  let modifiedSummary = [...errorSummary]
-
-  if (isStartMissing) {
-    modifiedSummary = modifiedSummary.filter(
-      (error) => !error.href.includes('#activity-start-date')
-    )
-    modifiedSummary.unshift({
-      href: `#${FIELD_NAMES.START_DATE_DAY}`,
-      text: errorMessages[JOI_ERRORS.CUSTOM_START_DATE_MISSING]
-    })
-  }
-
-  if (isEndMissing) {
-    modifiedSummary = modifiedSummary.filter(
-      (error) => !error.href.includes('#activity-end-date')
-    )
-    modifiedSummary.push({
-      href: `#${FIELD_NAMES.END_DATE_DAY}`,
-      text: errorMessages[JOI_ERRORS.CUSTOM_END_DATE_MISSING]
-    })
-  }
-
-  return modifiedSummary
-}
-
-/**
- * Checks if there are any number.max errors for date fields that should be treated as invalid date errors
- * @param {string} dateType - 'start' or 'end'
- * @param {object} errorTypeMap - Error type mapping
- * @returns {boolean} True if there are number.max errors for date fields
- */
-function hasNumberMaxErrorsForDate(dateType, errorTypeMap) {
-  const prefix =
-    dateType === 'start' ? 'activity-start-date' : 'activity-end-date'
-  const dayField = `${prefix}-day`
-  const monthField = `${prefix}-month`
-
-  // Check if any of the date field errors are caused by number.max validation
-  const dayError = errorTypeMap[dayField]
-  const monthError = errorTypeMap[monthField]
-
-  return (
-    (dayError && dayError.type === 'number.max') ||
-    (monthError && monthError.type === 'number.max')
-  )
-}
-
-/**
- * Generic error message resolver for date fields
- * @param {string} dateType - 'start' or 'end'
- * @param {boolean} isDateMissing - Whether date is completely missing
- * @param {object} errorTypeMap - Error type mapping
- * @param {object} errors - Error descriptions by field name
- * @returns {object|null} Error message object or null
- */
-function getDateErrorMessage(dateType, isDateMissing, errorTypeMap, errors) {
-  // Check if we have number.max errors that should be treated as invalid date errors
-  const hasInvalidDateFieldErrors = hasNumberMaxErrorsForDate(
-    dateType,
-    errorTypeMap
-  )
-
-  const errorPriority =
-    dateType === 'start'
-      ? [
-          {
-            condition: isDateMissing,
-            key: JOI_ERRORS.CUSTOM_START_DATE_MISSING
-          },
-          {
-            condition:
-              errorTypeMap[JOI_ERRORS.CUSTOM_START_DATE_INVALID] ||
-              hasInvalidDateFieldErrors,
-            key: JOI_ERRORS.CUSTOM_START_DATE_INVALID
-          },
-          {
-            condition:
-              errorTypeMap[JOI_ERRORS.CUSTOM_START_DATE_TODAY_OR_FUTURE],
-            key: JOI_ERRORS.CUSTOM_START_DATE_TODAY_OR_FUTURE
-          },
-          {
-            condition:
-              errors[JOI_ERRORS.ACTIVITY_START_DATE_DAY] &&
-              !hasInvalidDateFieldErrors,
-            key: JOI_ERRORS.ACTIVITY_START_DATE_DAY
-          },
-          {
-            condition:
-              errors[JOI_ERRORS.ACTIVITY_START_DATE_MONTH] &&
-              !hasInvalidDateFieldErrors,
-            key: JOI_ERRORS.ACTIVITY_START_DATE_MONTH
-          },
-          {
-            condition:
-              errors[JOI_ERRORS.ACTIVITY_START_DATE_YEAR] &&
-              !hasInvalidDateFieldErrors,
-            key: JOI_ERRORS.ACTIVITY_START_DATE_YEAR
-          }
-        ]
-      : [
-          { condition: isDateMissing, key: JOI_ERRORS.CUSTOM_END_DATE_MISSING },
-          {
-            condition:
-              errorTypeMap[JOI_ERRORS.CUSTOM_END_DATE_INVALID] ||
-              hasInvalidDateFieldErrors,
-            key: JOI_ERRORS.CUSTOM_END_DATE_INVALID
-          },
-          {
-            condition:
-              errorTypeMap[JOI_ERRORS.CUSTOM_END_DATE_BEFORE_START_DATE],
-            key: JOI_ERRORS.CUSTOM_END_DATE_BEFORE_START_DATE
-          },
-          {
-            condition: errorTypeMap[JOI_ERRORS.CUSTOM_END_DATE_TODAY_OR_FUTURE],
-            key: JOI_ERRORS.CUSTOM_END_DATE_TODAY_OR_FUTURE
-          },
-          {
-            condition:
-              errors[JOI_ERRORS.ACTIVITY_END_DATE_DAY] &&
-              !hasInvalidDateFieldErrors,
-            key: JOI_ERRORS.ACTIVITY_END_DATE_DAY
-          },
-          {
-            condition:
-              errors[JOI_ERRORS.ACTIVITY_END_DATE_MONTH] &&
-              !hasInvalidDateFieldErrors,
-            key: JOI_ERRORS.ACTIVITY_END_DATE_MONTH
-          },
-          {
-            condition:
-              errors[JOI_ERRORS.ACTIVITY_END_DATE_YEAR] &&
-              !hasInvalidDateFieldErrors,
-            key: JOI_ERRORS.ACTIVITY_END_DATE_YEAR
-          }
-        ]
-
-  const errorToShow = errorPriority.find((error) => error.condition)
-  return errorToShow ? { text: errorMessages[errorToShow.key] } : null
-}
-
-/**
- * Determines the appropriate error message for start date
- * @param {boolean} isStartMissing - Whether start date is completely missing
- * @param {object} errorTypeMap - Error type mapping
- * @param {object} errors - Error descriptions by field name
- * @returns {object|null} Error message object or null
- */
-function getStartDateErrorMessage(isStartMissing, errorTypeMap, errors) {
-  return getDateErrorMessage('start', isStartMissing, errorTypeMap, errors)
-}
-
-/**
- * Determines the appropriate error message for end date
- * @param {boolean} isEndMissing - Whether end date is completely missing
- * @param {object} errorTypeMap - Error type mapping
- * @param {object} errors - Error descriptions by field name
- * @returns {object|null} Error message object or null
- */
-function getEndDateErrorMessage(isEndMissing, errorTypeMap, errors) {
-  return getDateErrorMessage('end', isEndMissing, errorTypeMap, errors)
 }
 
 /**
@@ -413,53 +189,17 @@ export const activityDatesController = {
  * @returns {object} Response with error template
  */
 function handleValidationErrors(request, h, err) {
-  const { payload } = request
   const exemption = getExemptionCache(request)
 
-  if (!err.details) {
-    return h
-      .view(ACTIVITY_DATES_VIEW_ROUTE, createTemplateData(exemption, payload))
-      .takeover()
-  }
-
-  const errorSummary = mapErrorsForDisplay(err.details, errorMessages)
-  const errors = errorDescriptionByFieldName(errorSummary)
-  const errorTypeMap = createErrorTypeMap(err.details)
-
-  const isStartMissing = isCompleteDateMissing(errors, 'start')
-  const isEndMissing = isCompleteDateMissing(errors, 'end')
-
-  let modifiedErrorSummary = errorSummary.filter(
-    (error) => error.href && error.href !== '#' && error.href !== '#undefined'
-  )
-
-  addCustomValidationErrors(modifiedErrorSummary, errorTypeMap)
-  modifiedErrorSummary = handleMissingDateErrors(
-    modifiedErrorSummary,
-    isStartMissing,
-    isEndMissing
-  )
-
-  const startDateErrorMessage = getStartDateErrorMessage(
-    isStartMissing,
-    errorTypeMap,
-    errors
-  )
-  const endDateErrorMessage = getEndDateErrorMessage(
-    isEndMissing,
-    errorTypeMap,
-    errors
-  )
-
-  return h
-    .view(ACTIVITY_DATES_VIEW_ROUTE, {
-      ...createTemplateData(exemption, payload),
-      errors,
-      errorSummary: modifiedErrorSummary,
-      startDateErrorMessage,
-      endDateErrorMessage
-    })
-    .takeover()
+  return handleDateValidationErrors({
+    request,
+    h,
+    err,
+    dateConfigs: DATE_CONFIGS,
+    errorMessages,
+    createTemplateData: (payload) => createTemplateData(exemption, payload),
+    viewRoute: ACTIVITY_DATES_VIEW_ROUTE
+  })
 }
 
 /**

--- a/src/server/exemption/activity-dates/controller.js
+++ b/src/server/exemption/activity-dates/controller.js
@@ -33,7 +33,7 @@ const activityDatesViewSettings = {
   cancelLink: routes.TASK_LIST
 }
 
-const errorMessages = {
+export const errorMessages = {
   [JOI_ERRORS.ACTIVITY_START_DATE_DAY]: 'The start date must include a day',
   [JOI_ERRORS.ACTIVITY_START_DATE_MONTH]: 'The start date must include a month',
   [JOI_ERRORS.ACTIVITY_START_DATE_YEAR]: 'The start date must include a year',
@@ -117,27 +117,42 @@ function isCompleteDateMissing(errors, dateType) {
  * @param {Array} errorSummary - Current error summary array
  * @param {object} errorTypeMap - Error type mapping
  */
-function addCustomValidationErrors(errorSummary, errorTypeMap) {
-  // Start date custom errors
+export function addCustomValidationErrors(errorSummary, errorTypeMap) {
+  // Start date custom errors - check for today/future first (higher priority)
+  let startDateErrorAdded = false
+
   if (errorTypeMap[JOI_ERRORS.CUSTOM_START_DATE_TODAY_OR_FUTURE]) {
     errorSummary.push({
       href: `#${FIELD_NAMES.START_DATE_DAY}`,
       text: errorMessages[JOI_ERRORS.CUSTOM_START_DATE_TODAY_OR_FUTURE]
     })
-  } else if (errorTypeMap[JOI_ERRORS.CUSTOM_START_DATE_INVALID]) {
+    startDateErrorAdded = true
+  }
+
+  // Only add invalid date error if no today/future error was added
+  if (
+    !startDateErrorAdded &&
+    errorTypeMap[JOI_ERRORS.CUSTOM_START_DATE_INVALID]
+  ) {
     errorSummary.push({
       href: `#${FIELD_NAMES.START_DATE_DAY}`,
       text: errorMessages[JOI_ERRORS.CUSTOM_START_DATE_INVALID]
     })
   }
 
-  // End date custom errors
+  // End date custom errors - check for today/future first (higher priority)
+  let endDateErrorAdded = false
+
   if (errorTypeMap[JOI_ERRORS.CUSTOM_END_DATE_TODAY_OR_FUTURE]) {
     errorSummary.push({
       href: `#${FIELD_NAMES.END_DATE_DAY}`,
       text: errorMessages[JOI_ERRORS.CUSTOM_END_DATE_TODAY_OR_FUTURE]
     })
-  } else if (errorTypeMap[JOI_ERRORS.CUSTOM_END_DATE_INVALID]) {
+    endDateErrorAdded = true
+  }
+
+  // Only add invalid date error if no today/future error was added
+  if (!endDateErrorAdded && errorTypeMap[JOI_ERRORS.CUSTOM_END_DATE_INVALID]) {
     errorSummary.push({
       href: `#${FIELD_NAMES.END_DATE_DAY}`,
       text: errorMessages[JOI_ERRORS.CUSTOM_END_DATE_INVALID]

--- a/src/server/exemption/activity-dates/controller.js
+++ b/src/server/exemption/activity-dates/controller.js
@@ -11,6 +11,10 @@ import { config } from '~/src/config/config.js'
 import { routes } from '~/src/server/common/constants/routes.js'
 import { JOI_ERRORS } from '~/src/server/common/constants/joi.js'
 import { activityDatesSchema } from '~/src/server/common/schemas/date.js'
+import {
+  createDateISO,
+  extractDateComponents
+} from '~/src/server/common/helpers/date-utils.js'
 
 export const ACTIVITY_DATES_VIEW_ROUTE = 'exemption/activity-dates/index'
 
@@ -53,23 +57,55 @@ export const errorMessages = {
 }
 
 /**
- * Creates a date from individual components and returns ISO string
- * @param {string|number} year
- * @param {string|number} month
- * @param {string|number} day
- * @returns {string|null}
+ * Extracts date fields from payload for display
+ * @param {object} payload - Form payload
+ * @returns {object} Date field values
  */
-export function createDateISO(year, month, day) {
-  const numYear = parseInt(year, 10)
-  const numMonth = parseInt(month, 10)
-  const numDay = parseInt(day, 10)
+export function extractDateFieldsFromPayload(payload) {
+  return {
+    activityStartDateDay: payload[FIELD_NAMES.START_DATE_DAY] || '',
+    activityStartDateMonth: payload[FIELD_NAMES.START_DATE_MONTH] || '',
+    activityStartDateYear: payload[FIELD_NAMES.START_DATE_YEAR] || '',
+    activityEndDateDay: payload[FIELD_NAMES.END_DATE_DAY] || '',
+    activityEndDateMonth: payload[FIELD_NAMES.END_DATE_MONTH] || '',
+    activityEndDateYear: payload[FIELD_NAMES.END_DATE_YEAR] || ''
+  }
+}
 
-  if (isNaN(numYear) || isNaN(numMonth) || isNaN(numDay)) {
-    return null
+/**
+ * Creates base template data with date fields
+ * @param {object} exemption - Exemption cache data
+ * @param {object} payload - Optional form payload
+ * @returns {object} Template data
+ */
+export function createTemplateData(exemption, payload = null) {
+  let dateFields
+
+  if (payload) {
+    dateFields = extractDateFieldsFromPayload(payload)
+  } else {
+    const startDateComponents = extractDateComponents(
+      exemption.activityDates?.start
+    )
+    const endDateComponents = extractDateComponents(
+      exemption.activityDates?.end
+    )
+
+    dateFields = {
+      activityStartDateDay: startDateComponents.day,
+      activityStartDateMonth: startDateComponents.month,
+      activityStartDateYear: startDateComponents.year,
+      activityEndDateDay: endDateComponents.day,
+      activityEndDateMonth: endDateComponents.month,
+      activityEndDateYear: endDateComponents.year
+    }
   }
 
-  const date = new Date(Date.UTC(numYear, numMonth - 1, numDay))
-  return date.toISOString()
+  return {
+    ...activityDatesViewSettings,
+    projectName: exemption.projectName,
+    ...dateFields
+  }
 }
 
 /**
@@ -118,6 +154,16 @@ function isCompleteDateMissing(errors, dateType) {
  * @param {object} errorTypeMap - Error type mapping
  */
 export function addCustomValidationErrors(errorSummary, errorTypeMap) {
+  // Check for number.max errors that should be treated as invalid date errors
+  const hasStartInvalidFieldErrors = hasNumberMaxErrorsForDate(
+    'start',
+    errorTypeMap
+  )
+  const hasEndInvalidFieldErrors = hasNumberMaxErrorsForDate(
+    'end',
+    errorTypeMap
+  )
+
   // Start date custom errors - check for today/future first (higher priority)
   let startDateErrorAdded = false
 
@@ -129,15 +175,18 @@ export function addCustomValidationErrors(errorSummary, errorTypeMap) {
     startDateErrorAdded = true
   }
 
-  // Only add invalid date error if no today/future error was added
+  // Add invalid date error if no today/future error was added AND we have either
+  // a custom invalid error OR number.max errors for date fields
   if (
     !startDateErrorAdded &&
-    errorTypeMap[JOI_ERRORS.CUSTOM_START_DATE_INVALID]
+    (errorTypeMap[JOI_ERRORS.CUSTOM_START_DATE_INVALID] ||
+      hasStartInvalidFieldErrors)
   ) {
     errorSummary.push({
       href: `#${FIELD_NAMES.START_DATE_DAY}`,
       text: errorMessages[JOI_ERRORS.CUSTOM_START_DATE_INVALID]
     })
+    startDateErrorAdded = true
   }
 
   // End date custom errors - check for today/future first (higher priority)
@@ -151,12 +200,18 @@ export function addCustomValidationErrors(errorSummary, errorTypeMap) {
     endDateErrorAdded = true
   }
 
-  // Only add invalid date error if no today/future error was added
-  if (!endDateErrorAdded && errorTypeMap[JOI_ERRORS.CUSTOM_END_DATE_INVALID]) {
+  // Add invalid date error if no today/future error was added AND we have either
+  // a custom invalid error OR number.max errors for date fields
+  if (
+    !endDateErrorAdded &&
+    (errorTypeMap[JOI_ERRORS.CUSTOM_END_DATE_INVALID] ||
+      hasEndInvalidFieldErrors)
+  ) {
     errorSummary.push({
       href: `#${FIELD_NAMES.END_DATE_DAY}`,
       text: errorMessages[JOI_ERRORS.CUSTOM_END_DATE_INVALID]
     })
+    endDateErrorAdded = true
   }
 
   // Date relationship error
@@ -202,6 +257,121 @@ function handleMissingDateErrors(errorSummary, isStartMissing, isEndMissing) {
 }
 
 /**
+ * Checks if there are any number.max errors for date fields that should be treated as invalid date errors
+ * @param {string} dateType - 'start' or 'end'
+ * @param {object} errorTypeMap - Error type mapping
+ * @returns {boolean} True if there are number.max errors for date fields
+ */
+function hasNumberMaxErrorsForDate(dateType, errorTypeMap) {
+  const prefix =
+    dateType === 'start' ? 'activity-start-date' : 'activity-end-date'
+  const dayField = `${prefix}-day`
+  const monthField = `${prefix}-month`
+
+  // Check if any of the date field errors are caused by number.max validation
+  const dayError = errorTypeMap[dayField]
+  const monthError = errorTypeMap[monthField]
+
+  return (
+    (dayError && dayError.type === 'number.max') ||
+    (monthError && monthError.type === 'number.max')
+  )
+}
+
+/**
+ * Generic error message resolver for date fields
+ * @param {string} dateType - 'start' or 'end'
+ * @param {boolean} isDateMissing - Whether date is completely missing
+ * @param {object} errorTypeMap - Error type mapping
+ * @param {object} errors - Error descriptions by field name
+ * @returns {object|null} Error message object or null
+ */
+function getDateErrorMessage(dateType, isDateMissing, errorTypeMap, errors) {
+  // Check if we have number.max errors that should be treated as invalid date errors
+  const hasInvalidDateFieldErrors = hasNumberMaxErrorsForDate(
+    dateType,
+    errorTypeMap
+  )
+
+  const errorPriority =
+    dateType === 'start'
+      ? [
+          {
+            condition: isDateMissing,
+            key: JOI_ERRORS.CUSTOM_START_DATE_MISSING
+          },
+          {
+            condition:
+              errorTypeMap[JOI_ERRORS.CUSTOM_START_DATE_INVALID] ||
+              hasInvalidDateFieldErrors,
+            key: JOI_ERRORS.CUSTOM_START_DATE_INVALID
+          },
+          {
+            condition:
+              errorTypeMap[JOI_ERRORS.CUSTOM_START_DATE_TODAY_OR_FUTURE],
+            key: JOI_ERRORS.CUSTOM_START_DATE_TODAY_OR_FUTURE
+          },
+          {
+            condition:
+              errors[JOI_ERRORS.ACTIVITY_START_DATE_DAY] &&
+              !hasInvalidDateFieldErrors,
+            key: JOI_ERRORS.ACTIVITY_START_DATE_DAY
+          },
+          {
+            condition:
+              errors[JOI_ERRORS.ACTIVITY_START_DATE_MONTH] &&
+              !hasInvalidDateFieldErrors,
+            key: JOI_ERRORS.ACTIVITY_START_DATE_MONTH
+          },
+          {
+            condition:
+              errors[JOI_ERRORS.ACTIVITY_START_DATE_YEAR] &&
+              !hasInvalidDateFieldErrors,
+            key: JOI_ERRORS.ACTIVITY_START_DATE_YEAR
+          }
+        ]
+      : [
+          { condition: isDateMissing, key: JOI_ERRORS.CUSTOM_END_DATE_MISSING },
+          {
+            condition:
+              errorTypeMap[JOI_ERRORS.CUSTOM_END_DATE_INVALID] ||
+              hasInvalidDateFieldErrors,
+            key: JOI_ERRORS.CUSTOM_END_DATE_INVALID
+          },
+          {
+            condition:
+              errorTypeMap[JOI_ERRORS.CUSTOM_END_DATE_BEFORE_START_DATE],
+            key: JOI_ERRORS.CUSTOM_END_DATE_BEFORE_START_DATE
+          },
+          {
+            condition: errorTypeMap[JOI_ERRORS.CUSTOM_END_DATE_TODAY_OR_FUTURE],
+            key: JOI_ERRORS.CUSTOM_END_DATE_TODAY_OR_FUTURE
+          },
+          {
+            condition:
+              errors[JOI_ERRORS.ACTIVITY_END_DATE_DAY] &&
+              !hasInvalidDateFieldErrors,
+            key: JOI_ERRORS.ACTIVITY_END_DATE_DAY
+          },
+          {
+            condition:
+              errors[JOI_ERRORS.ACTIVITY_END_DATE_MONTH] &&
+              !hasInvalidDateFieldErrors,
+            key: JOI_ERRORS.ACTIVITY_END_DATE_MONTH
+          },
+          {
+            condition:
+              errors[JOI_ERRORS.ACTIVITY_END_DATE_YEAR] &&
+              !hasInvalidDateFieldErrors,
+            key: JOI_ERRORS.ACTIVITY_END_DATE_YEAR
+          }
+        ]
+
+  const errorToShow = errorPriority.find((error) => error.condition)
+  return errorToShow ? { text: errorMessages[errorToShow.key] } : null
+}
+
+/**
  * Determines the appropriate error message for start date
  * @param {boolean} isStartMissing - Whether start date is completely missing
  * @param {object} errorTypeMap - Error type mapping
@@ -209,31 +379,7 @@ function handleMissingDateErrors(errorSummary, isStartMissing, isEndMissing) {
  * @returns {object|null} Error message object or null
  */
 function getStartDateErrorMessage(isStartMissing, errorTypeMap, errors) {
-  if (isStartMissing) {
-    return { text: errorMessages[JOI_ERRORS.CUSTOM_START_DATE_MISSING] }
-  }
-
-  if (errorTypeMap[JOI_ERRORS.CUSTOM_START_DATE_TODAY_OR_FUTURE]) {
-    return { text: errorMessages[JOI_ERRORS.CUSTOM_START_DATE_TODAY_OR_FUTURE] }
-  }
-
-  if (errorTypeMap[JOI_ERRORS.CUSTOM_START_DATE_INVALID]) {
-    return { text: errorMessages[JOI_ERRORS.CUSTOM_START_DATE_INVALID] }
-  }
-
-  if (errors[JOI_ERRORS.ACTIVITY_START_DATE_DAY]) {
-    return { text: errorMessages[JOI_ERRORS.ACTIVITY_START_DATE_DAY] }
-  }
-
-  if (errors[JOI_ERRORS.ACTIVITY_START_DATE_MONTH]) {
-    return { text: errorMessages[JOI_ERRORS.ACTIVITY_START_DATE_MONTH] }
-  }
-
-  if (errors[JOI_ERRORS.ACTIVITY_START_DATE_YEAR]) {
-    return { text: errorMessages[JOI_ERRORS.ACTIVITY_START_DATE_YEAR] }
-  }
-
-  return null
+  return getDateErrorMessage('start', isStartMissing, errorTypeMap, errors)
 }
 
 /**
@@ -244,35 +390,7 @@ function getStartDateErrorMessage(isStartMissing, errorTypeMap, errors) {
  * @returns {object|null} Error message object or null
  */
 function getEndDateErrorMessage(isEndMissing, errorTypeMap, errors) {
-  if (isEndMissing) {
-    return { text: errorMessages[JOI_ERRORS.CUSTOM_END_DATE_MISSING] }
-  }
-
-  if (errorTypeMap[JOI_ERRORS.CUSTOM_END_DATE_TODAY_OR_FUTURE]) {
-    return { text: errorMessages[JOI_ERRORS.CUSTOM_END_DATE_TODAY_OR_FUTURE] }
-  }
-
-  if (errorTypeMap[JOI_ERRORS.CUSTOM_END_DATE_INVALID]) {
-    return { text: errorMessages[JOI_ERRORS.CUSTOM_END_DATE_INVALID] }
-  }
-
-  if (errorTypeMap[JOI_ERRORS.CUSTOM_END_DATE_BEFORE_START_DATE]) {
-    return { text: errorMessages[JOI_ERRORS.CUSTOM_END_DATE_BEFORE_START_DATE] }
-  }
-
-  if (errors[JOI_ERRORS.ACTIVITY_END_DATE_DAY]) {
-    return { text: errorMessages[JOI_ERRORS.ACTIVITY_END_DATE_DAY] }
-  }
-
-  if (errors[JOI_ERRORS.ACTIVITY_END_DATE_MONTH]) {
-    return { text: errorMessages[JOI_ERRORS.ACTIVITY_END_DATE_MONTH] }
-  }
-
-  if (errors[JOI_ERRORS.ACTIVITY_END_DATE_YEAR]) {
-    return { text: errorMessages[JOI_ERRORS.ACTIVITY_END_DATE_YEAR] }
-  }
-
-  return null
+  return getDateErrorMessage('end', isEndMissing, errorTypeMap, errors)
 }
 
 /**
@@ -283,38 +401,65 @@ export const activityDatesController = {
   handler(request, h) {
     const exemption = getExemptionCache(request)
 
-    let activityStartDateDay = ''
-    let activityStartDateMonth = ''
-    let activityStartDateYear = ''
-    let activityEndDateDay = ''
-    let activityEndDateMonth = ''
-    let activityEndDateYear = ''
-
-    if (exemption.activityDates?.start) {
-      const startDate = new Date(exemption.activityDates.start)
-      activityStartDateDay = startDate.getUTCDate().toString()
-      activityStartDateMonth = (startDate.getUTCMonth() + 1).toString()
-      activityStartDateYear = startDate.getUTCFullYear().toString()
-    }
-
-    if (exemption.activityDates?.end) {
-      const endDate = new Date(exemption.activityDates.end)
-      activityEndDateDay = endDate.getUTCDate().toString()
-      activityEndDateMonth = (endDate.getUTCMonth() + 1).toString()
-      activityEndDateYear = endDate.getUTCFullYear().toString()
-    }
-
-    return h.view(ACTIVITY_DATES_VIEW_ROUTE, {
-      ...activityDatesViewSettings,
-      projectName: exemption.projectName,
-      activityStartDateDay,
-      activityStartDateMonth,
-      activityStartDateYear,
-      activityEndDateDay,
-      activityEndDateMonth,
-      activityEndDateYear
-    })
+    return h.view(ACTIVITY_DATES_VIEW_ROUTE, createTemplateData(exemption))
   }
+}
+
+/**
+ * Processes validation errors and returns template data
+ * @param {object} request - Hapi request object
+ * @param {object} h - Hapi response toolkit
+ * @param {Error} err - Validation error
+ * @returns {object} Response with error template
+ */
+function handleValidationErrors(request, h, err) {
+  const { payload } = request
+  const exemption = getExemptionCache(request)
+
+  if (!err.details) {
+    return h
+      .view(ACTIVITY_DATES_VIEW_ROUTE, createTemplateData(exemption, payload))
+      .takeover()
+  }
+
+  const errorSummary = mapErrorsForDisplay(err.details, errorMessages)
+  const errors = errorDescriptionByFieldName(errorSummary)
+  const errorTypeMap = createErrorTypeMap(err.details)
+
+  const isStartMissing = isCompleteDateMissing(errors, 'start')
+  const isEndMissing = isCompleteDateMissing(errors, 'end')
+
+  let modifiedErrorSummary = errorSummary.filter(
+    (error) => error.href && error.href !== '#' && error.href !== '#undefined'
+  )
+
+  addCustomValidationErrors(modifiedErrorSummary, errorTypeMap)
+  modifiedErrorSummary = handleMissingDateErrors(
+    modifiedErrorSummary,
+    isStartMissing,
+    isEndMissing
+  )
+
+  const startDateErrorMessage = getStartDateErrorMessage(
+    isStartMissing,
+    errorTypeMap,
+    errors
+  )
+  const endDateErrorMessage = getEndDateErrorMessage(
+    isEndMissing,
+    errorTypeMap,
+    errors
+  )
+
+  return h
+    .view(ACTIVITY_DATES_VIEW_ROUTE, {
+      ...createTemplateData(exemption, payload),
+      errors,
+      errorSummary: modifiedErrorSummary,
+      startDateErrorMessage,
+      endDateErrorMessage
+    })
+    .takeover()
 }
 
 /**
@@ -325,67 +470,7 @@ export const activityDatesSubmitController = {
   options: {
     validate: {
       payload: activityDatesSchema,
-      failAction: (request, h, err) => {
-        const { payload } = request
-        const exemption = getExemptionCache(request)
-
-        if (!err.details) {
-          return h
-            .view(ACTIVITY_DATES_VIEW_ROUTE, {
-              ...activityDatesViewSettings,
-              projectName: exemption.projectName,
-              payload
-            })
-            .takeover()
-        }
-
-        const errorSummary = mapErrorsForDisplay(err.details, errorMessages)
-        const errors = errorDescriptionByFieldName(errorSummary)
-        const errorTypeMap = createErrorTypeMap(err.details)
-
-        const isStartMissing = isCompleteDateMissing(errors, 'start')
-        const isEndMissing = isCompleteDateMissing(errors, 'end')
-
-        let modifiedErrorSummary = errorSummary.filter(
-          (error) =>
-            error.href && error.href !== '#' && error.href !== '#undefined'
-        )
-
-        addCustomValidationErrors(modifiedErrorSummary, errorTypeMap)
-        modifiedErrorSummary = handleMissingDateErrors(
-          modifiedErrorSummary,
-          isStartMissing,
-          isEndMissing
-        )
-
-        const startDateErrorMessage = getStartDateErrorMessage(
-          isStartMissing,
-          errorTypeMap,
-          errors
-        )
-        const endDateErrorMessage = getEndDateErrorMessage(
-          isEndMissing,
-          errorTypeMap,
-          errors
-        )
-
-        return h
-          .view(ACTIVITY_DATES_VIEW_ROUTE, {
-            ...activityDatesViewSettings,
-            projectName: exemption.projectName,
-            activityStartDateDay: payload[FIELD_NAMES.START_DATE_DAY] || '',
-            activityStartDateMonth: payload[FIELD_NAMES.START_DATE_MONTH] || '',
-            activityStartDateYear: payload[FIELD_NAMES.START_DATE_YEAR] || '',
-            activityEndDateDay: payload[FIELD_NAMES.END_DATE_DAY] || '',
-            activityEndDateMonth: payload[FIELD_NAMES.END_DATE_MONTH] || '',
-            activityEndDateYear: payload[FIELD_NAMES.END_DATE_YEAR] || '',
-            errors,
-            errorSummary: modifiedErrorSummary,
-            startDateErrorMessage,
-            endDateErrorMessage
-          })
-          .takeover()
-      }
+      failAction: handleValidationErrors
     }
   },
   async handler(request, h) {
@@ -437,14 +522,7 @@ export const activityDatesSubmitController = {
       const errors = errorDescriptionByFieldName(errorSummary)
 
       return h.view(ACTIVITY_DATES_VIEW_ROUTE, {
-        ...activityDatesViewSettings,
-        projectName: exemption.projectName,
-        activityStartDateDay: payload[FIELD_NAMES.START_DATE_DAY] || '',
-        activityStartDateMonth: payload[FIELD_NAMES.START_DATE_MONTH] || '',
-        activityStartDateYear: payload[FIELD_NAMES.START_DATE_YEAR] || '',
-        activityEndDateDay: payload[FIELD_NAMES.END_DATE_DAY] || '',
-        activityEndDateMonth: payload[FIELD_NAMES.END_DATE_MONTH] || '',
-        activityEndDateYear: payload[FIELD_NAMES.END_DATE_YEAR] || '',
+        ...createTemplateData(exemption, payload),
         errors,
         errorSummary
       })

--- a/src/server/exemption/activity-dates/controller.js
+++ b/src/server/exemption/activity-dates/controller.js
@@ -22,8 +22,12 @@ import {
 
 export const ACTIVITY_DATES_VIEW_ROUTE = 'exemption/activity-dates/index'
 
-const START_DATE_FIELD_NAMES = createDateFieldNames('activity-start-date')
-const END_DATE_FIELD_NAMES = createDateFieldNames('activity-end-date')
+// Date field prefix constants
+const ACTIVITY_START_DATE_PREFIX = 'activity-start-date'
+const ACTIVITY_END_DATE_PREFIX = 'activity-end-date'
+
+const START_DATE_FIELD_NAMES = createDateFieldNames(ACTIVITY_START_DATE_PREFIX)
+const END_DATE_FIELD_NAMES = createDateFieldNames(ACTIVITY_END_DATE_PREFIX)
 
 const FIELD_NAMES = {
   START_DATE_DAY: START_DATE_FIELD_NAMES.DAY,
@@ -66,8 +70,8 @@ export const errorMessages = {
  */
 export function extractDateFieldsFromPayload(payload) {
   const dateConfigs = [
-    { key: 'activityStartDate', prefix: 'activity-start-date' },
-    { key: 'activityEndDate', prefix: 'activity-end-date' }
+    { key: 'activityStartDate', prefix: ACTIVITY_START_DATE_PREFIX },
+    { key: 'activityEndDate', prefix: ACTIVITY_END_DATE_PREFIX }
   ]
 
   return extractMultipleDateFields(payload, dateConfigs)
@@ -112,7 +116,7 @@ export function createTemplateData(exemption, payload = null) {
 // Date configuration for the generic date form utilities
 const DATE_CONFIGS = [
   {
-    prefix: 'activity-start-date',
+    prefix: ACTIVITY_START_DATE_PREFIX,
     fieldNames: START_DATE_FIELD_NAMES,
     errorMessageKey: 'startDateErrorMessage',
     errorKeys: {
@@ -131,7 +135,7 @@ const DATE_CONFIGS = [
     errorMessages
   },
   {
-    prefix: 'activity-end-date',
+    prefix: ACTIVITY_END_DATE_PREFIX,
     fieldNames: END_DATE_FIELD_NAMES,
     errorMessageKey: 'endDateErrorMessage',
     errorKeys: {

--- a/src/server/exemption/activity-dates/controller.js
+++ b/src/server/exemption/activity-dates/controller.js
@@ -1,0 +1,342 @@
+import Wreck from '@hapi/wreck'
+import {
+  getExemptionCache,
+  setExemptionCache
+} from '~/src/server/common/helpers/session-cache/utils.js'
+import {
+  errorDescriptionByFieldName,
+  mapErrorsForDisplay
+} from '~/src/server/common/helpers/errors.js'
+import { config } from '~/src/config/config.js'
+import { routes } from '~/src/server/common/constants/routes.js'
+import { JOI_ERRORS } from '~/src/server/common/constants/joi.js'
+import { activityDatesSchema } from '~/src/server/common/schemas/date.js'
+
+export const ACTIVITY_DATES_VIEW_ROUTE = 'exemption/activity-dates/index'
+
+const activityDatesViewSettings = {
+  title: 'Activity dates',
+  descriptionParagraphs: [
+    "Enter the activity dates. Allow time for potential delays, like consents (for example, a river works licence) or bad weather. If you miss the dates, you'll need to restart the process.",
+    "You can enter a start date from today and begin your activity as soon as you've sent your information."
+  ],
+  backLink: routes.TASK_LIST
+}
+
+const errorMessages = {
+  [JOI_ERRORS.ACTIVITY_START_DATE_DAY]: 'The start date must include a day',
+  [JOI_ERRORS.ACTIVITY_START_DATE_MONTH]: 'The start date must include a month',
+  [JOI_ERRORS.ACTIVITY_START_DATE_YEAR]: 'The start date must include a year',
+  [JOI_ERRORS.ACTIVITY_END_DATE_DAY]: 'The end date must include a day',
+  [JOI_ERRORS.ACTIVITY_END_DATE_MONTH]: 'The end date must include a month',
+  [JOI_ERRORS.ACTIVITY_END_DATE_YEAR]: 'The end date must include a year',
+  [JOI_ERRORS.CUSTOM_START_DATE_MISSING]: 'Enter the start date',
+  [JOI_ERRORS.CUSTOM_END_DATE_MISSING]: 'Enter the end date',
+  [JOI_ERRORS.CUSTOM_START_DATE_INVALID]: 'The start date must be a real date',
+  [JOI_ERRORS.CUSTOM_END_DATE_INVALID]: 'The end date must be a real date',
+  [JOI_ERRORS.CUSTOM_START_DATE_TODAY_OR_FUTURE]:
+    'The start date must be today or in the future',
+  [JOI_ERRORS.CUSTOM_END_DATE_TODAY_OR_FUTURE]:
+    'The end date must be today or in the future',
+  [JOI_ERRORS.CUSTOM_END_DATE_BEFORE_START_DATE]:
+    'The end date must be the same as or after the start date'
+}
+
+/**
+ * Creates a date from individual components and returns ISO string
+ * @param {string|number} year
+ * @param {string|number} month
+ * @param {string|number} day
+ * @returns {string|null}
+ */
+function createDateISO(year, month, day) {
+  const numYear = parseInt(year, 10)
+  const numMonth = parseInt(month, 10)
+  const numDay = parseInt(day, 10)
+
+  if (isNaN(numYear) || isNaN(numMonth) || isNaN(numDay)) {
+    return null
+  }
+
+  const date = new Date(Date.UTC(numYear, numMonth - 1, numDay))
+  return date.toISOString()
+}
+
+/**
+ * Activity dates GET controller.
+ * @satisfies {Partial<ServerRoute>}
+ */
+export const activityDatesController = {
+  handler(request, h) {
+    const exemption = getExemptionCache(request)
+
+    let activityStartDateDay = ''
+    let activityStartDateMonth = ''
+    let activityStartDateYear = ''
+    let activityEndDateDay = ''
+    let activityEndDateMonth = ''
+    let activityEndDateYear = ''
+
+    if (exemption.activityDates?.start) {
+      const startDate = new Date(exemption.activityDates.start)
+      activityStartDateDay = startDate.getUTCDate().toString()
+      activityStartDateMonth = (startDate.getUTCMonth() + 1).toString()
+      activityStartDateYear = startDate.getUTCFullYear().toString()
+    }
+
+    if (exemption.activityDates?.end) {
+      const endDate = new Date(exemption.activityDates.end)
+      activityEndDateDay = endDate.getUTCDate().toString()
+      activityEndDateMonth = (endDate.getUTCMonth() + 1).toString()
+      activityEndDateYear = endDate.getUTCFullYear().toString()
+    }
+
+    return h.view(ACTIVITY_DATES_VIEW_ROUTE, {
+      ...activityDatesViewSettings,
+      projectName: exemption.projectName,
+      activityStartDateDay,
+      activityStartDateMonth,
+      activityStartDateYear,
+      activityEndDateDay,
+      activityEndDateMonth,
+      activityEndDateYear
+    })
+  }
+}
+
+/**
+ * Activity dates POST controller.
+ * @satisfies {Partial<ServerRoute>}
+ */
+export const activityDatesSubmitController = {
+  options: {
+    validate: {
+      payload: activityDatesSchema,
+      failAction: (request, h, err) => {
+        const { payload } = request
+        const exemption = getExemptionCache(request)
+
+        if (!err.details) {
+          return h
+            .view(ACTIVITY_DATES_VIEW_ROUTE, {
+              ...activityDatesViewSettings,
+              projectName: exemption.projectName,
+              payload
+            })
+            .takeover()
+        }
+
+        const errorSummary = mapErrorsForDisplay(err.details, errorMessages)
+        const errors = errorDescriptionByFieldName(errorSummary)
+
+        const errorTypeMap = {}
+        err.details.forEach((detail) => {
+          errorTypeMap[detail.type] = detail
+        })
+
+        // Check if all three date components are missing to consolidate error messages
+        const isStartMissing =
+          errors[JOI_ERRORS.ACTIVITY_START_DATE_DAY] &&
+          errors[JOI_ERRORS.ACTIVITY_START_DATE_MONTH] &&
+          errors[JOI_ERRORS.ACTIVITY_START_DATE_YEAR]
+
+        const isEndMissing =
+          errors[JOI_ERRORS.ACTIVITY_END_DATE_DAY] &&
+          errors[JOI_ERRORS.ACTIVITY_END_DATE_MONTH] &&
+          errors[JOI_ERRORS.ACTIVITY_END_DATE_YEAR]
+
+        let modifiedErrorSummary = errorSummary.filter(
+          (error) =>
+            error.href && error.href !== '#' && error.href !== '#undefined'
+        )
+        let startDateErrorMessage = null
+        let endDateErrorMessage = null
+
+        // Prioritize specific error messages over generic ones
+        if (errorTypeMap[JOI_ERRORS.CUSTOM_START_DATE_TODAY_OR_FUTURE]) {
+          modifiedErrorSummary.push({
+            href: '#activity-start-date-day',
+            text: errorMessages[JOI_ERRORS.CUSTOM_START_DATE_TODAY_OR_FUTURE]
+          })
+        } else if (errorTypeMap[JOI_ERRORS.CUSTOM_START_DATE_INVALID]) {
+          modifiedErrorSummary.push({
+            href: '#activity-start-date-day',
+            text: errorMessages[JOI_ERRORS.CUSTOM_START_DATE_INVALID]
+          })
+        }
+
+        if (errorTypeMap[JOI_ERRORS.CUSTOM_END_DATE_TODAY_OR_FUTURE]) {
+          modifiedErrorSummary.push({
+            href: '#activity-end-date-day',
+            text: errorMessages[JOI_ERRORS.CUSTOM_END_DATE_TODAY_OR_FUTURE]
+          })
+        } else if (errorTypeMap[JOI_ERRORS.CUSTOM_END_DATE_INVALID]) {
+          modifiedErrorSummary.push({
+            href: '#activity-end-date-day',
+            text: errorMessages[JOI_ERRORS.CUSTOM_END_DATE_INVALID]
+          })
+        }
+
+        if (errorTypeMap[JOI_ERRORS.CUSTOM_END_DATE_BEFORE_START_DATE]) {
+          modifiedErrorSummary.push({
+            href: '#activity-end-date-day',
+            text: errorMessages[JOI_ERRORS.CUSTOM_END_DATE_BEFORE_START_DATE]
+          })
+        }
+
+        if (isStartMissing) {
+          modifiedErrorSummary = modifiedErrorSummary.filter(
+            (error) => !error.href.includes('#activity-start-date')
+          )
+          modifiedErrorSummary.unshift({
+            href: '#activity-start-date-day',
+            text: errorMessages[JOI_ERRORS.CUSTOM_START_DATE_MISSING]
+          })
+          startDateErrorMessage = {
+            text: errorMessages[JOI_ERRORS.CUSTOM_START_DATE_MISSING]
+          }
+        } else if (errorTypeMap[JOI_ERRORS.CUSTOM_START_DATE_TODAY_OR_FUTURE]) {
+          startDateErrorMessage = {
+            text: errorMessages[JOI_ERRORS.CUSTOM_START_DATE_TODAY_OR_FUTURE]
+          }
+        } else if (errorTypeMap[JOI_ERRORS.CUSTOM_START_DATE_INVALID]) {
+          startDateErrorMessage = {
+            text: errorMessages[JOI_ERRORS.CUSTOM_START_DATE_INVALID]
+          }
+        } else if (errors[JOI_ERRORS.ACTIVITY_START_DATE_DAY]) {
+          startDateErrorMessage = {
+            text: errorMessages[JOI_ERRORS.ACTIVITY_START_DATE_DAY]
+          }
+        } else if (errors[JOI_ERRORS.ACTIVITY_START_DATE_MONTH]) {
+          startDateErrorMessage = {
+            text: errorMessages[JOI_ERRORS.ACTIVITY_START_DATE_MONTH]
+          }
+        } else if (errors[JOI_ERRORS.ACTIVITY_START_DATE_YEAR]) {
+          startDateErrorMessage = {
+            text: errorMessages[JOI_ERRORS.ACTIVITY_START_DATE_YEAR]
+          }
+        }
+
+        if (isEndMissing) {
+          modifiedErrorSummary = modifiedErrorSummary.filter(
+            (error) => !error.href.includes('#activity-end-date')
+          )
+          modifiedErrorSummary.push({
+            href: '#activity-end-date-day',
+            text: errorMessages[JOI_ERRORS.CUSTOM_END_DATE_MISSING]
+          })
+          endDateErrorMessage = {
+            text: errorMessages[JOI_ERRORS.CUSTOM_END_DATE_MISSING]
+          }
+        } else if (errorTypeMap[JOI_ERRORS.CUSTOM_END_DATE_TODAY_OR_FUTURE]) {
+          endDateErrorMessage = {
+            text: errorMessages[JOI_ERRORS.CUSTOM_END_DATE_TODAY_OR_FUTURE]
+          }
+        } else if (errorTypeMap[JOI_ERRORS.CUSTOM_END_DATE_INVALID]) {
+          endDateErrorMessage = {
+            text: errorMessages[JOI_ERRORS.CUSTOM_END_DATE_INVALID]
+          }
+        } else if (errorTypeMap[JOI_ERRORS.CUSTOM_END_DATE_BEFORE_START_DATE]) {
+          endDateErrorMessage = {
+            text: errorMessages[JOI_ERRORS.CUSTOM_END_DATE_BEFORE_START_DATE]
+          }
+        } else if (errors[JOI_ERRORS.ACTIVITY_END_DATE_DAY]) {
+          endDateErrorMessage = {
+            text: errorMessages[JOI_ERRORS.ACTIVITY_END_DATE_DAY]
+          }
+        } else if (errors[JOI_ERRORS.ACTIVITY_END_DATE_MONTH]) {
+          endDateErrorMessage = {
+            text: errorMessages[JOI_ERRORS.ACTIVITY_END_DATE_MONTH]
+          }
+        } else if (errors[JOI_ERRORS.ACTIVITY_END_DATE_YEAR]) {
+          endDateErrorMessage = {
+            text: errorMessages[JOI_ERRORS.ACTIVITY_END_DATE_YEAR]
+          }
+        }
+
+        return h
+          .view(ACTIVITY_DATES_VIEW_ROUTE, {
+            ...activityDatesViewSettings,
+            projectName: exemption.projectName,
+            activityStartDateDay: payload['activity-start-date-day'] || '',
+            activityStartDateMonth: payload['activity-start-date-month'] || '',
+            activityStartDateYear: payload['activity-start-date-year'] || '',
+            activityEndDateDay: payload['activity-end-date-day'] || '',
+            activityEndDateMonth: payload['activity-end-date-month'] || '',
+            activityEndDateYear: payload['activity-end-date-year'] || '',
+            errors,
+            errorSummary: modifiedErrorSummary,
+            startDateErrorMessage,
+            endDateErrorMessage
+          })
+          .takeover()
+      }
+    }
+  },
+  async handler(request, h) {
+    const { payload } = request
+    const exemption = getExemptionCache(request)
+
+    try {
+      const start = createDateISO(
+        payload['activity-start-date-year'],
+        payload['activity-start-date-month'],
+        payload['activity-start-date-day']
+      )
+
+      const end = createDateISO(
+        payload['activity-end-date-year'],
+        payload['activity-end-date-month'],
+        payload['activity-end-date-day']
+      )
+
+      await Wreck.patch(
+        `${config.get('backend').apiUrl}/exemption/activity-dates`,
+        {
+          payload: {
+            id: exemption.id,
+            start,
+            end
+          },
+          json: true
+        }
+      )
+
+      setExemptionCache(request, {
+        ...exemption,
+        activityDates: {
+          start,
+          end
+        }
+      })
+
+      return h.redirect(routes.TASK_LIST)
+    } catch (e) {
+      const { details } = e.data?.payload?.validation ?? {}
+
+      if (!details) {
+        throw e
+      }
+
+      const errorSummary = mapErrorsForDisplay(details, errorMessages)
+      const errors = errorDescriptionByFieldName(errorSummary)
+
+      return h.view(ACTIVITY_DATES_VIEW_ROUTE, {
+        ...activityDatesViewSettings,
+        projectName: exemption.projectName,
+        activityStartDateDay: payload['activity-start-date-day'] || '',
+        activityStartDateMonth: payload['activity-start-date-month'] || '',
+        activityStartDateYear: payload['activity-start-date-year'] || '',
+        activityEndDateDay: payload['activity-end-date-day'] || '',
+        activityEndDateMonth: payload['activity-end-date-month'] || '',
+        activityEndDateYear: payload['activity-end-date-year'] || '',
+        errors,
+        errorSummary
+      })
+    }
+  }
+}
+
+/**
+ * @import { ServerRoute } from '@hapi/hapi'
+ */

--- a/src/server/exemption/activity-dates/controller.test.js
+++ b/src/server/exemption/activity-dates/controller.test.js
@@ -1,6 +1,7 @@
 import { createServer } from '~/src/server/index.js'
 import { statusCodes } from '~/src/server/common/constants/status-codes.js'
 import { routes } from '~/src/server/common/constants/routes.js'
+import { JOI_ERRORS } from '~/src/server/common/constants/joi.js'
 import { mockExemption } from '~/src/server/test-helpers/mocks.js'
 import { config } from '~/src/config/config.js'
 import Wreck from '@hapi/wreck'
@@ -9,7 +10,9 @@ import {
   activityDatesController,
   activityDatesSubmitController,
   ACTIVITY_DATES_VIEW_ROUTE,
-  createDateISO
+  createDateISO,
+  addCustomValidationErrors,
+  errorMessages
 } from '~/src/server/exemption/activity-dates/controller.js'
 import * as cacheUtils from '~/src/server/common/helpers/session-cache/utils.js'
 
@@ -1135,6 +1138,76 @@ describe('#activityDatesController', () => {
       expect(viewData.activityEndDateDay).toBe('') // Line 426 fallback
       expect(viewData.activityEndDateMonth).toBe('') // Line 427 fallback
       expect(viewData.activityEndDateYear).toBe('') // Line 428 fallback
+    })
+
+    test('should prioritize today/future error over invalid error for start date', () => {
+      const errorSummary = []
+      const errorTypeMap = {
+        [JOI_ERRORS.CUSTOM_START_DATE_TODAY_OR_FUTURE]: true,
+        [JOI_ERRORS.CUSTOM_START_DATE_INVALID]: true // Both errors present
+      }
+
+      // Call the function directly to test the refactored logic
+      addCustomValidationErrors(errorSummary, errorTypeMap)
+
+      // Should only add the today/future error, not the invalid error
+      expect(errorSummary).toHaveLength(1)
+      expect(errorSummary[0].text).toBe(
+        errorMessages[JOI_ERRORS.CUSTOM_START_DATE_TODAY_OR_FUTURE]
+      )
+      expect(errorSummary[0].href).toBe('#activity-start-date-day')
+    })
+
+    test('should prioritize today/future error over invalid error for end date', () => {
+      const errorSummary = []
+      const errorTypeMap = {
+        [JOI_ERRORS.CUSTOM_END_DATE_TODAY_OR_FUTURE]: true,
+        [JOI_ERRORS.CUSTOM_END_DATE_INVALID]: true // Both errors present
+      }
+
+      // Call the function directly to test the refactored logic
+      addCustomValidationErrors(errorSummary, errorTypeMap)
+
+      // Should only add the today/future error, not the invalid error
+      expect(errorSummary).toHaveLength(1)
+      expect(errorSummary[0].text).toBe(
+        errorMessages[JOI_ERRORS.CUSTOM_END_DATE_TODAY_OR_FUTURE]
+      )
+      expect(errorSummary[0].href).toBe('#activity-end-date-day')
+    })
+
+    test('should add invalid error when no today/future error exists for start date', () => {
+      const errorSummary = []
+      const errorTypeMap = {
+        [JOI_ERRORS.CUSTOM_START_DATE_INVALID]: true // Only invalid error present
+      }
+
+      // Call the function directly to test the refactored logic
+      addCustomValidationErrors(errorSummary, errorTypeMap)
+
+      // Should add the invalid error since no today/future error exists
+      expect(errorSummary).toHaveLength(1)
+      expect(errorSummary[0].text).toBe(
+        errorMessages[JOI_ERRORS.CUSTOM_START_DATE_INVALID]
+      )
+      expect(errorSummary[0].href).toBe('#activity-start-date-day')
+    })
+
+    test('should add invalid error when no today/future error exists for end date', () => {
+      const errorSummary = []
+      const errorTypeMap = {
+        [JOI_ERRORS.CUSTOM_END_DATE_INVALID]: true // Only invalid error present
+      }
+
+      // Call the function directly to test the refactored logic
+      addCustomValidationErrors(errorSummary, errorTypeMap)
+
+      // Should add the invalid error since no today/future error exists
+      expect(errorSummary).toHaveLength(1)
+      expect(errorSummary[0].text).toBe(
+        errorMessages[JOI_ERRORS.CUSTOM_END_DATE_INVALID]
+      )
+      expect(errorSummary[0].href).toBe('#activity-end-date-day')
     })
   })
 })

--- a/src/server/exemption/activity-dates/controller.test.js
+++ b/src/server/exemption/activity-dates/controller.test.js
@@ -10,10 +10,10 @@ import {
   activityDatesController,
   activityDatesSubmitController,
   ACTIVITY_DATES_VIEW_ROUTE,
-  createDateISO,
   addCustomValidationErrors,
   errorMessages
 } from '~/src/server/exemption/activity-dates/controller.js'
+import { createDateISO } from '~/src/server/common/helpers/date-utils.js'
 import * as cacheUtils from '~/src/server/common/helpers/session-cache/utils.js'
 
 jest.mock('~/src/server/common/helpers/session-cache/utils.js')
@@ -237,14 +237,16 @@ describe('#activityDatesController', () => {
       const errorSummary = document.querySelector('.govuk-error-summary')
       expect(errorSummary).toBeTruthy()
 
-      // With new validation order, end date future validation is checked first
-      // So past end dates trigger "today or future" error before relationship checks
-      expect(result).toContain('The end date must be today or in the future')
+      // Date order validation now takes precedence over future date validation
+      // This ensures end date before start date errors are shown correctly
+      expect(result).toContain(
+        'The end date must be the same as or after the start date'
+      )
 
       const endDateError = document.querySelector('#activity-end-date-error')
       expect(endDateError).toBeTruthy()
       expect(endDateError.textContent.trim()).toContain(
-        'The end date must be today or in the future'
+        'The end date must be the same as or after the start date'
       )
     })
 
@@ -270,14 +272,16 @@ describe('#activityDatesController', () => {
       const errorSummary = document.querySelector('.govuk-error-summary')
       expect(errorSummary).toBeTruthy()
 
-      // With new validation order, end date future validation is checked first
-      // So past end dates trigger "today or future" error before relationship checks
-      expect(result).toContain('The end date must be today or in the future')
+      // Date order validation now takes precedence over future date validation
+      // This ensures end date before start date errors are shown correctly
+      expect(result).toContain(
+        'The end date must be the same as or after the start date'
+      )
 
       const endDateError = document.querySelector('#activity-end-date-error')
       expect(endDateError).toBeTruthy()
       expect(endDateError.textContent.trim()).toContain(
-        'The end date must be today or in the future'
+        'The end date must be the same as or after the start date'
       )
     })
 
@@ -470,6 +474,80 @@ describe('#activityDatesController', () => {
 
       expect(statusCode).toBe(statusCodes.ok)
       expect(result).toContain('Activity dates')
+    })
+
+    test('should handle impossible dates with field-level real date errors', async () => {
+      // Test month 14 which triggers number.max validation
+      const payloadMonth14 = {
+        'activity-start-date-day': '1',
+        'activity-start-date-month': '1',
+        'activity-start-date-year': (new Date().getFullYear() + 1).toString(),
+        'activity-end-date-day': '1',
+        'activity-end-date-month': '14', // Invalid month > 12
+        'activity-end-date-year': (new Date().getFullYear() + 1).toString()
+      }
+
+      const { result: resultMonth14, statusCode: statusCodeMonth14 } =
+        await server.inject({
+          method: 'POST',
+          url: routes.ACTIVITY_DATES,
+          payload: payloadMonth14
+        })
+
+      expect(statusCodeMonth14).toBe(statusCodes.ok)
+
+      const { document: documentMonth14 } = new JSDOM(resultMonth14).window
+      const errorSummaryMonth14 = documentMonth14.querySelector(
+        '.govuk-error-summary'
+      )
+      expect(errorSummaryMonth14).toBeTruthy()
+
+      // Should show "real date" error message in field-level error element
+      expect(resultMonth14).toContain('The end date must be a real date')
+
+      const endDateErrorMonth14 = documentMonth14.querySelector(
+        '#activity-end-date-error'
+      )
+      expect(endDateErrorMonth14).toBeTruthy()
+      expect(endDateErrorMonth14.textContent.trim()).toContain(
+        'The end date must be a real date'
+      )
+
+      // Test day 32 which also triggers number.max validation
+      const payloadDay32 = {
+        'activity-start-date-day': '32', // Invalid day > 31
+        'activity-start-date-month': '1',
+        'activity-start-date-year': (new Date().getFullYear() + 1).toString(),
+        'activity-end-date-day': '1',
+        'activity-end-date-month': '1',
+        'activity-end-date-year': (new Date().getFullYear() + 1).toString()
+      }
+
+      const { result: resultDay32, statusCode: statusCodeDay32 } =
+        await server.inject({
+          method: 'POST',
+          url: routes.ACTIVITY_DATES,
+          payload: payloadDay32
+        })
+
+      expect(statusCodeDay32).toBe(statusCodes.ok)
+
+      const { document: documentDay32 } = new JSDOM(resultDay32).window
+      const errorSummaryDay32 = documentDay32.querySelector(
+        '.govuk-error-summary'
+      )
+      expect(errorSummaryDay32).toBeTruthy()
+
+      // Should show "real date" error message in field-level error element
+      expect(resultDay32).toContain('The start date must be a real date')
+
+      const startDateErrorDay32 = documentDay32.querySelector(
+        '#activity-start-date-error'
+      )
+      expect(startDateErrorDay32).toBeTruthy()
+      expect(startDateErrorDay32.textContent.trim()).toContain(
+        'The start date must be a real date'
+      )
     })
   })
 
@@ -983,7 +1061,14 @@ describe('#activityDatesController', () => {
         ACTIVITY_DATES_VIEW_ROUTE,
         expect.objectContaining({
           projectName: 'Test Project',
-          payload: { 'test-field': 'test-value' }
+          title: 'Activity dates',
+          // The payload is now processed by createTemplateData, not passed directly
+          activityStartDateDay: '',
+          activityStartDateMonth: '',
+          activityStartDateYear: '',
+          activityEndDateDay: '',
+          activityEndDateMonth: '',
+          activityEndDateYear: ''
         })
       )
       expect(h.takeover).toHaveBeenCalled()

--- a/src/server/exemption/activity-dates/controller.test.js
+++ b/src/server/exemption/activity-dates/controller.test.js
@@ -77,6 +77,7 @@ describe('#activityDatesController', () => {
           "You can enter a start date from today and begin your activity as soon as you've sent your information."
         ],
         backLink: routes.TASK_LIST,
+        cancelLink: routes.TASK_LIST,
         projectName: mockExemptionState.projectName,
         activityStartDateDay: '',
         activityStartDateMonth: '',
@@ -110,6 +111,7 @@ describe('#activityDatesController', () => {
           "You can enter a start date from today and begin your activity as soon as you've sent your information."
         ],
         backLink: routes.TASK_LIST,
+        cancelLink: routes.TASK_LIST,
         projectName: exemptionWithDates.projectName,
         activityStartDateDay: '15',
         activityStartDateMonth: '6',

--- a/src/server/exemption/activity-dates/controller.test.js
+++ b/src/server/exemption/activity-dates/controller.test.js
@@ -76,10 +76,6 @@ describe('#activityDatesController', () => {
 
       expect(h.view).toHaveBeenCalledWith(ACTIVITY_DATES_VIEW_ROUTE, {
         title: 'Activity dates',
-        descriptionParagraphs: [
-          "Enter the activity dates. Allow time for potential delays, like consents (for example, a river works licence) or bad weather. If you miss the dates, you'll need to restart the process.",
-          "You can enter a start date from today and begin your activity as soon as you've sent your information."
-        ],
         backLink: routes.TASK_LIST,
         cancelLink: routes.TASK_LIST,
         projectName: mockExemptionState.projectName,
@@ -110,10 +106,6 @@ describe('#activityDatesController', () => {
 
       expect(h.view).toHaveBeenCalledWith(ACTIVITY_DATES_VIEW_ROUTE, {
         title: 'Activity dates',
-        descriptionParagraphs: [
-          "Enter the activity dates. Allow time for potential delays, like consents (for example, a river works licence) or bad weather. If you miss the dates, you'll need to restart the process.",
-          "You can enter a start date from today and begin your activity as soon as you've sent your information."
-        ],
         backLink: routes.TASK_LIST,
         cancelLink: routes.TASK_LIST,
         projectName: exemptionWithDates.projectName,

--- a/src/server/exemption/activity-dates/controller.test.js
+++ b/src/server/exemption/activity-dates/controller.test.js
@@ -1,0 +1,575 @@
+import { createServer } from '~/src/server/index.js'
+import { statusCodes } from '~/src/server/common/constants/status-codes.js'
+import { routes } from '~/src/server/common/constants/routes.js'
+import { mockExemption } from '~/src/server/test-helpers/mocks.js'
+import { config } from '~/src/config/config.js'
+import Wreck from '@hapi/wreck'
+import { JSDOM } from 'jsdom'
+import {
+  activityDatesController,
+  activityDatesSubmitController,
+  ACTIVITY_DATES_VIEW_ROUTE
+} from '~/src/server/exemption/activity-dates/controller.js'
+import * as cacheUtils from '~/src/server/common/helpers/session-cache/utils.js'
+
+jest.mock('~/src/server/common/helpers/session-cache/utils.js')
+
+describe('#activityDatesController', () => {
+  let server
+  let getExemptionCacheSpy
+
+  const mockExemptionState = {
+    id: 'test-exemption-id',
+    projectName: 'Test Project'
+  }
+
+  beforeAll(async () => {
+    server = await createServer()
+    await server.initialize()
+  })
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+
+    getExemptionCacheSpy = jest
+      .spyOn(cacheUtils, 'getExemptionCache')
+      .mockReturnValue(mockExemptionState)
+
+    jest
+      .spyOn(Wreck, 'patch')
+      .mockResolvedValue({ payload: { id: mockExemption.id } })
+  })
+
+  afterAll(async () => {
+    await server.stop({ timeout: 0 })
+  })
+
+  describe('activityDatesController GET', () => {
+    test('should render the activity dates page', async () => {
+      const { result, statusCode } = await server.inject({
+        method: 'GET',
+        url: routes.ACTIVITY_DATES
+      })
+
+      expect(statusCode).toBe(statusCodes.ok)
+      expect(result).toContain('Activity dates')
+
+      const { document } = new JSDOM(result).window
+      expect(document.querySelector('h1').textContent.trim()).toBe(
+        'Activity dates'
+      )
+      expect(document.querySelector('form').method).toBe('post')
+      expect(
+        document.querySelector('button[type="submit"]').textContent.trim()
+      ).toBe('Save and continue')
+    })
+
+    test('should render with empty date fields when no existing data', () => {
+      const h = { view: jest.fn() }
+      const request = {}
+
+      activityDatesController.handler(request, h)
+
+      expect(h.view).toHaveBeenCalledWith(ACTIVITY_DATES_VIEW_ROUTE, {
+        title: 'Activity dates',
+        descriptionParagraphs: [
+          "Enter the activity dates. Allow time for potential delays, like consents (for example, a river works licence) or bad weather. If you miss the dates, you'll need to restart the process.",
+          "You can enter a start date from today and begin your activity as soon as you've sent your information."
+        ],
+        backLink: routes.TASK_LIST,
+        projectName: mockExemptionState.projectName,
+        activityStartDateDay: '',
+        activityStartDateMonth: '',
+        activityStartDateYear: '',
+        activityEndDateDay: '',
+        activityEndDateMonth: '',
+        activityEndDateYear: ''
+      })
+    })
+
+    test('should pre-populate form with existing activity dates', () => {
+      const exemptionWithDates = {
+        ...mockExemptionState,
+        activityDates: {
+          start: '2025-06-15T00:00:00.000Z',
+          end: '2025-06-30T00:00:00.000Z'
+        }
+      }
+
+      getExemptionCacheSpy.mockReturnValue(exemptionWithDates)
+
+      const h = { view: jest.fn() }
+      const request = {}
+
+      activityDatesController.handler(request, h)
+
+      expect(h.view).toHaveBeenCalledWith(ACTIVITY_DATES_VIEW_ROUTE, {
+        title: 'Activity dates',
+        descriptionParagraphs: [
+          "Enter the activity dates. Allow time for potential delays, like consents (for example, a river works licence) or bad weather. If you miss the dates, you'll need to restart the process.",
+          "You can enter a start date from today and begin your activity as soon as you've sent your information."
+        ],
+        backLink: routes.TASK_LIST,
+        projectName: exemptionWithDates.projectName,
+        activityStartDateDay: '15',
+        activityStartDateMonth: '6',
+        activityStartDateYear: '2025',
+        activityEndDateDay: '30',
+        activityEndDateMonth: '6',
+        activityEndDateYear: '2025'
+      })
+    })
+  })
+
+  describe('activityDatesController POST', () => {
+    test('should handle form submission with valid data', async () => {
+      const currentYear = new Date().getFullYear()
+      const payload = {
+        'activity-start-date-day': '1',
+        'activity-start-date-month': '6',
+        'activity-start-date-year': (currentYear + 1).toString(),
+        'activity-end-date-day': '15',
+        'activity-end-date-month': '6',
+        'activity-end-date-year': (currentYear + 1).toString()
+      }
+
+      const { statusCode, headers } = await server.inject({
+        method: 'POST',
+        url: routes.ACTIVITY_DATES,
+        payload
+      })
+
+      expect(Wreck.patch).toHaveBeenCalledWith(
+        `${config.get('backend').apiUrl}/exemption/activity-dates`,
+        expect.objectContaining({
+          payload: expect.objectContaining({
+            id: mockExemptionState.id,
+            start: expect.any(String),
+            end: expect.any(String)
+          }),
+          json: true
+        })
+      )
+      expect(statusCode).toBe(statusCodes.redirect)
+      expect(headers.location).toBe(routes.TASK_LIST)
+    })
+
+    test('should handle validation errors for missing start date', async () => {
+      const payload = {
+        'activity-start-date-day': '',
+        'activity-start-date-month': '',
+        'activity-start-date-year': '',
+        'activity-end-date-day': '15',
+        'activity-end-date-month': '6',
+        'activity-end-date-year': '2025'
+      }
+
+      const { result, statusCode } = await server.inject({
+        method: 'POST',
+        url: routes.ACTIVITY_DATES,
+        payload
+      })
+
+      expect(statusCode).toBe(statusCodes.ok)
+
+      const { document } = new JSDOM(result).window
+      expect(document.querySelector('.govuk-error-summary')).toBeTruthy()
+      expect(result).toContain('Enter the start date')
+    })
+
+    test('should handle validation errors for end date before start date', async () => {
+      const currentYear = new Date().getFullYear()
+      const payload = {
+        'activity-start-date-day': '15',
+        'activity-start-date-month': '6',
+        'activity-start-date-year': (currentYear + 1).toString(),
+        'activity-end-date-day': '14',
+        'activity-end-date-month': '6',
+        'activity-end-date-year': (currentYear + 1).toString()
+      }
+
+      const { result, statusCode } = await server.inject({
+        method: 'POST',
+        url: routes.ACTIVITY_DATES,
+        payload
+      })
+
+      expect(statusCode).toBe(statusCodes.ok)
+
+      const { document } = new JSDOM(result).window
+      expect(document.querySelector('.govuk-error-summary')).toBeTruthy()
+      expect(result).toContain(
+        'The end date must be the same as or after the start date'
+      )
+
+      const endDateError = document.querySelector('#activity-end-date-error')
+      expect(endDateError).toBeTruthy()
+      expect(endDateError.textContent.trim()).toContain(
+        'The end date must be the same as or after the start date'
+      )
+    })
+
+    test('should handle end date before start date - specific scenario 1 (15/06/2025 vs 14/06/2025)', async () => {
+      const payload = {
+        'activity-start-date-day': '15',
+        'activity-start-date-month': '6',
+        'activity-start-date-year': '2025',
+        'activity-end-date-day': '14',
+        'activity-end-date-month': '6',
+        'activity-end-date-year': '2025'
+      }
+
+      const { result, statusCode } = await server.inject({
+        method: 'POST',
+        url: routes.ACTIVITY_DATES,
+        payload
+      })
+
+      expect(statusCode).toBe(statusCodes.ok)
+
+      const { document } = new JSDOM(result).window
+      const errorSummary = document.querySelector('.govuk-error-summary')
+      expect(errorSummary).toBeTruthy()
+
+      expect(result).toContain(
+        'The end date must be the same as or after the start date'
+      )
+
+      const endDateError = document.querySelector('#activity-end-date-error')
+      expect(endDateError).toBeTruthy()
+      expect(endDateError.textContent.trim()).toContain(
+        'The end date must be the same as or after the start date'
+      )
+    })
+
+    test('should handle end date before start date - specific scenario 2 (15/06/2026 vs 15/06/2025)', async () => {
+      const payload = {
+        'activity-start-date-day': '15',
+        'activity-start-date-month': '6',
+        'activity-start-date-year': '2026',
+        'activity-end-date-day': '15',
+        'activity-end-date-month': '6',
+        'activity-end-date-year': '2025'
+      }
+
+      const { result, statusCode } = await server.inject({
+        method: 'POST',
+        url: routes.ACTIVITY_DATES,
+        payload
+      })
+
+      expect(statusCode).toBe(statusCodes.ok)
+
+      const { document } = new JSDOM(result).window
+      const errorSummary = document.querySelector('.govuk-error-summary')
+      expect(errorSummary).toBeTruthy()
+
+      expect(result).toContain(
+        'The end date must be the same as or after the start date'
+      )
+
+      const endDateError = document.querySelector('#activity-end-date-error')
+      expect(endDateError).toBeTruthy()
+      expect(endDateError.textContent.trim()).toContain(
+        'The end date must be the same as or after the start date'
+      )
+    })
+
+    test('should handle past end date - specific scenario 3 (01/12/2023 vs 01/01/2024)', async () => {
+      const payload = {
+        'activity-start-date-day': '1',
+        'activity-start-date-month': '12',
+        'activity-start-date-year': '2023',
+        'activity-end-date-day': '1',
+        'activity-end-date-month': '1',
+        'activity-end-date-year': '2024'
+      }
+
+      const { result, statusCode } = await server.inject({
+        method: 'POST',
+        url: routes.ACTIVITY_DATES,
+        payload
+      })
+
+      expect(statusCode).toBe(statusCodes.ok)
+
+      const { document } = new JSDOM(result).window
+      const errorSummary = document.querySelector('.govuk-error-summary')
+      expect(errorSummary).toBeTruthy()
+
+      // For past dates, JOI returns on first error (start date), so we expect start date error
+      expect(result).toContain('The start date must be today or in the future')
+
+      const startDateError = document.querySelector(
+        '#activity-start-date-error'
+      )
+      expect(startDateError).toBeTruthy()
+      expect(startDateError.textContent.trim()).toContain(
+        'The start date must be today or in the future'
+      )
+
+      // Since JOI returns early, we might not get an end date error
+      // This is expected behavior for this scenario
+    })
+
+    test('should handle validation errors for invalid dates', async () => {
+      const currentYear = new Date().getFullYear()
+      const payload = {
+        'activity-start-date-day': '1',
+        'activity-start-date-month': '1',
+        'activity-start-date-year': (currentYear + 1).toString(),
+        'activity-end-date-day': '31',
+        'activity-end-date-month': '4',
+        'activity-end-date-year': (currentYear + 1).toString()
+      }
+
+      const { result, statusCode } = await server.inject({
+        method: 'POST',
+        url: routes.ACTIVITY_DATES,
+        payload
+      })
+
+      expect(statusCode).toBe(statusCodes.ok)
+
+      const { document } = new JSDOM(result).window
+      expect(document.querySelector('.govuk-error-summary')).toBeTruthy()
+      expect(result).toContain('The end date must be a real date')
+    })
+
+    test('should handle validation errors for past dates', async () => {
+      const { result, statusCode } = await server.inject({
+        method: 'POST',
+        url: routes.ACTIVITY_DATES,
+        payload: {
+          'activity-start-date-day': '15',
+          'activity-start-date-month': '6',
+          'activity-start-date-year': '2020',
+          'activity-end-date-day': '16',
+          'activity-end-date-month': '6',
+          'activity-end-date-year': '2020'
+        }
+      })
+
+      expect(statusCode).toBe(statusCodes.ok)
+
+      const { document } = new JSDOM(result).window
+      const errorSummary = document.querySelector('.govuk-error-summary')
+      expect(errorSummary).not.toBeNull()
+
+      const errorLinks = Array.from(errorSummary.querySelectorAll('a'))
+      const errorTexts = errorLinks.map((link) => link.textContent.trim())
+
+      const errorCounts = {}
+      errorTexts.forEach((text) => {
+        errorCounts[text] = (errorCounts[text] || 0) + 1
+      })
+
+      Object.values(errorCounts).forEach((count) => {
+        expect(count).toBe(1)
+      })
+
+      // JOI custom validation returns on first error, so we expect start date error first
+      // Verify that start date error is "today or in the future" (not "invalid")
+      expect(errorTexts).toContain(
+        'The start date must be today or in the future'
+      )
+
+      expect(errorTexts).not.toContain('The start date must be a real date')
+      expect(errorTexts).not.toContain('The end date must be a real date')
+
+      // Since JOI returns early, we may not get the end date error
+      // This is expected behavior for custom validation
+    })
+
+    test('should not show duplicate error messages for past dates', async () => {
+      const { result, statusCode } = await server.inject({
+        method: 'POST',
+        url: routes.ACTIVITY_DATES,
+        payload: {
+          'activity-start-date-day': '15',
+          'activity-start-date-month': '6',
+          'activity-start-date-year': '2025',
+          'activity-end-date-day': '16',
+          'activity-end-date-month': '6',
+          'activity-end-date-year': '2025'
+        }
+      })
+
+      expect(statusCode).toBe(statusCodes.ok)
+
+      const { document } = new JSDOM(result).window
+      const errorSummary = document.querySelector('.govuk-error-summary')
+      expect(errorSummary).toBeTruthy()
+
+      const errorLinks = Array.from(errorSummary.querySelectorAll('a'))
+      const errorTexts = errorLinks.map((link) => link.textContent.trim())
+      const uniqueErrors = new Set(errorTexts)
+      expect(uniqueErrors.size).toBe(errorTexts.length)
+    })
+
+    test('should handle API errors gracefully', async () => {
+      const apiPatchMock = jest.spyOn(Wreck, 'patch')
+      apiPatchMock.mockRejectedValueOnce({
+        res: { statusCode: 500 },
+        data: {}
+      })
+
+      const currentYear = new Date().getFullYear()
+      const payload = {
+        'activity-start-date-day': '1',
+        'activity-start-date-month': '6',
+        'activity-start-date-year': (currentYear + 1).toString(),
+        'activity-end-date-day': '15',
+        'activity-end-date-month': '6',
+        'activity-end-date-year': (currentYear + 1).toString()
+      }
+
+      const { result, statusCode } = await server.inject({
+        method: 'POST',
+        url: routes.ACTIVITY_DATES,
+        payload
+      })
+
+      expect(statusCode).toBe(statusCodes.internalServerError)
+      expect(result).toContain('500')
+    })
+
+    test('should handle API validation errors', async () => {
+      const apiPatchMock = jest.spyOn(Wreck, 'patch')
+      apiPatchMock.mockRejectedValueOnce({
+        data: {
+          payload: {
+            validation: {
+              details: [
+                {
+                  path: ['start'],
+                  message: 'CUSTOM_START_DATE_INVALID',
+                  type: 'custom.startDate.invalid'
+                }
+              ]
+            }
+          }
+        }
+      })
+
+      const currentYear = new Date().getFullYear()
+      const payload = {
+        'activity-start-date-day': '1',
+        'activity-start-date-month': '6',
+        'activity-start-date-year': (currentYear + 1).toString(),
+        'activity-end-date-day': '15',
+        'activity-end-date-month': '6',
+        'activity-end-date-year': (currentYear + 1).toString()
+      }
+
+      const { result, statusCode } = await server.inject({
+        method: 'POST',
+        url: routes.ACTIVITY_DATES,
+        payload
+      })
+
+      expect(statusCode).toBe(statusCodes.ok)
+      expect(result).toContain('Activity dates')
+    })
+  })
+
+  describe('Error handling logic', () => {
+    test('should correctly identify missing complete start date', () => {
+      const h = {
+        view: jest.fn().mockReturnThis(),
+        takeover: jest.fn()
+      }
+
+      const err = {
+        details: [
+          {
+            type: 'activity-start-date-day',
+            path: ['activity-start-date-day']
+          },
+          {
+            type: 'activity-start-date-month',
+            path: ['activity-start-date-month']
+          },
+          {
+            type: 'activity-start-date-year',
+            path: ['activity-start-date-year']
+          }
+        ]
+      }
+
+      const request = { payload: {} }
+
+      activityDatesSubmitController.options.validate.failAction(request, h, err)
+
+      expect(h.view).toHaveBeenCalled()
+      const viewCall = h.view.mock.calls[0]
+      const viewData = viewCall[1]
+
+      expect(viewData.startDateErrorMessage).toEqual({
+        text: 'Enter the start date'
+      })
+    })
+
+    test('should correctly identify custom validation errors', () => {
+      const h = {
+        view: jest.fn().mockReturnThis(),
+        takeover: jest.fn()
+      }
+
+      const err = {
+        details: [
+          {
+            type: 'custom.endDate.before.startDate',
+            path: [],
+            message: 'custom.endDate.before.startDate'
+          }
+        ]
+      }
+
+      const request = { payload: {} }
+
+      activityDatesSubmitController.options.validate.failAction(request, h, err)
+
+      expect(h.view).toHaveBeenCalled()
+      const viewCall = h.view.mock.calls[0]
+      const viewData = viewCall[1]
+
+      expect(viewData.endDateErrorMessage).toEqual({
+        text: 'The end date must be the same as or after the start date'
+      })
+      expect(viewData.errorSummary).toContainEqual({
+        href: '#activity-end-date-day',
+        text: 'The end date must be the same as or after the start date'
+      })
+    })
+
+    test('should correctly handle individual field errors', () => {
+      const h = {
+        view: jest.fn().mockReturnThis(),
+        takeover: jest.fn()
+      }
+
+      const err = {
+        details: [
+          {
+            type: 'activity-start-date-day',
+            path: ['activity-start-date-day'],
+            message: 'activity-start-date-day'
+          }
+        ]
+      }
+
+      const request = { payload: {} }
+
+      activityDatesSubmitController.options.validate.failAction(request, h, err)
+
+      expect(h.view).toHaveBeenCalled()
+      const viewCall = h.view.mock.calls[0]
+      const viewData = viewCall[1]
+
+      expect(viewData.startDateErrorMessage).toEqual({
+        text: 'The start date must include a day'
+      })
+    })
+  })
+})

--- a/src/server/exemption/activity-dates/controller.test.js
+++ b/src/server/exemption/activity-dates/controller.test.js
@@ -8,7 +8,8 @@ import { JSDOM } from 'jsdom'
 import {
   activityDatesController,
   activityDatesSubmitController,
-  ACTIVITY_DATES_VIEW_ROUTE
+  ACTIVITY_DATES_VIEW_ROUTE,
+  createDateISO
 } from '~/src/server/exemption/activity-dates/controller.js'
 import * as cacheUtils from '~/src/server/common/helpers/session-cache/utils.js'
 
@@ -233,14 +234,14 @@ describe('#activityDatesController', () => {
       const errorSummary = document.querySelector('.govuk-error-summary')
       expect(errorSummary).toBeTruthy()
 
-      expect(result).toContain(
-        'The end date must be the same as or after the start date'
-      )
+      // With new validation order, end date future validation is checked first
+      // So past end dates trigger "today or future" error before relationship checks
+      expect(result).toContain('The end date must be today or in the future')
 
       const endDateError = document.querySelector('#activity-end-date-error')
       expect(endDateError).toBeTruthy()
       expect(endDateError.textContent.trim()).toContain(
-        'The end date must be the same as or after the start date'
+        'The end date must be today or in the future'
       )
     })
 
@@ -266,25 +267,28 @@ describe('#activityDatesController', () => {
       const errorSummary = document.querySelector('.govuk-error-summary')
       expect(errorSummary).toBeTruthy()
 
-      expect(result).toContain(
-        'The end date must be the same as or after the start date'
-      )
+      // With new validation order, end date future validation is checked first
+      // So past end dates trigger "today or future" error before relationship checks
+      expect(result).toContain('The end date must be today or in the future')
 
       const endDateError = document.querySelector('#activity-end-date-error')
       expect(endDateError).toBeTruthy()
       expect(endDateError.textContent.trim()).toContain(
-        'The end date must be the same as or after the start date'
+        'The end date must be today or in the future'
       )
     })
 
-    test('should handle past end date - specific scenario 3 (01/12/2023 vs 01/01/2024)', async () => {
+    test('should handle past start date - year validation error', async () => {
+      // With the new joi.number() approach, past years get caught by MIN_YEAR validation
+      // This test verifies that behavior - the minYearError should be used for past years
+      const currentYear = new Date().getFullYear()
       const payload = {
         'activity-start-date-day': '1',
         'activity-start-date-month': '12',
-        'activity-start-date-year': '2023',
+        'activity-start-date-year': (currentYear - 1).toString(), // Past year
         'activity-end-date-day': '1',
         'activity-end-date-month': '1',
-        'activity-end-date-year': '2024'
+        'activity-end-date-year': (currentYear + 1).toString() // Future year
       }
 
       const { result, statusCode } = await server.inject({
@@ -299,7 +303,7 @@ describe('#activityDatesController', () => {
       const errorSummary = document.querySelector('.govuk-error-summary')
       expect(errorSummary).toBeTruthy()
 
-      // For past dates, JOI returns on first error (start date), so we expect start date error
+      // The minYearError should map to the custom error message via the controller's errorMessages mapping
       expect(result).toContain('The start date must be today or in the future')
 
       const startDateError = document.querySelector(
@@ -309,9 +313,6 @@ describe('#activityDatesController', () => {
       expect(startDateError.textContent.trim()).toContain(
         'The start date must be today or in the future'
       )
-
-      // Since JOI returns early, we might not get an end date error
-      // This is expected behavior for this scenario
     })
 
     test('should handle validation errors for invalid dates', async () => {
@@ -361,26 +362,20 @@ describe('#activityDatesController', () => {
       const errorLinks = Array.from(errorSummary.querySelectorAll('a'))
       const errorTexts = errorLinks.map((link) => link.textContent.trim())
 
-      const errorCounts = {}
-      errorTexts.forEach((text) => {
-        errorCounts[text] = (errorCounts[text] || 0) + 1
-      })
-
-      Object.values(errorCounts).forEach((count) => {
-        expect(count).toBe(1)
-      })
-
-      // JOI custom validation returns on first error, so we expect start date error first
-      // Verify that start date error is "today or in the future" (not "invalid")
+      // With the new joi.number() approach, both start and end dates from 2020
+      // will trigger year validation errors, resulting in two similar messages
       expect(errorTexts).toContain(
         'The start date must be today or in the future'
+      )
+      expect(errorTexts).toContain(
+        'The end date must be today or in the future'
       )
 
       expect(errorTexts).not.toContain('The start date must be a real date')
       expect(errorTexts).not.toContain('The end date must be a real date')
 
-      // Since JOI returns early, we may not get the end date error
-      // This is expected behavior for custom validation
+      // Both dates should have appropriate error messages for past years
+      expect(errorTexts.length).toBeGreaterThanOrEqual(2)
     })
 
     test('should not show duplicate error messages for past dates', async () => {
@@ -476,6 +471,16 @@ describe('#activityDatesController', () => {
   })
 
   describe('Error handling logic', () => {
+    test('should test createDateISO function with valid input', () => {
+      const result = createDateISO('2025', '6', '15')
+      expect(result).toBe('2025-06-15T00:00:00.000Z')
+    })
+
+    test('should test createDateISO function with invalid input', () => {
+      const result = createDateISO('invalid', 'invalid', 'invalid')
+      expect(result).toBeNull()
+    })
+
     test('should correctly identify missing complete start date', () => {
       const h = {
         view: jest.fn().mockReturnThis(),
@@ -572,6 +577,564 @@ describe('#activityDatesController', () => {
       expect(viewData.startDateErrorMessage).toEqual({
         text: 'The start date must include a day'
       })
+    })
+
+    test('should handle start date invalid custom error', () => {
+      const h = {
+        view: jest.fn().mockReturnThis(),
+        takeover: jest.fn()
+      }
+
+      const err = {
+        details: [
+          {
+            type: 'custom.startDate.invalid',
+            path: [],
+            message: 'custom.startDate.invalid'
+          }
+        ]
+      }
+
+      const request = { payload: {} }
+
+      activityDatesSubmitController.options.validate.failAction(request, h, err)
+
+      expect(h.view).toHaveBeenCalled()
+      const viewCall = h.view.mock.calls[0]
+      const viewData = viewCall[1]
+
+      expect(viewData.startDateErrorMessage).toEqual({
+        text: 'The start date must be a real date'
+      })
+    })
+
+    test('should handle start date month error', () => {
+      const h = {
+        view: jest.fn().mockReturnThis(),
+        takeover: jest.fn()
+      }
+
+      const err = {
+        details: [
+          {
+            type: 'activity-start-date-month',
+            path: ['activity-start-date-month'],
+            message: 'activity-start-date-month'
+          }
+        ]
+      }
+
+      const request = { payload: {} }
+
+      activityDatesSubmitController.options.validate.failAction(request, h, err)
+
+      expect(h.view).toHaveBeenCalled()
+      const viewCall = h.view.mock.calls[0]
+      const viewData = viewCall[1]
+
+      expect(viewData.startDateErrorMessage).toEqual({
+        text: 'The start date must include a month'
+      })
+    })
+
+    test('should return null for start date when no errors match', () => {
+      const h = {
+        view: jest.fn().mockReturnThis(),
+        takeover: jest.fn()
+      }
+
+      const err = {
+        details: [
+          {
+            type: 'some-other-error',
+            path: ['some-field'],
+            message: 'some-other-error'
+          }
+        ]
+      }
+
+      const request = { payload: {} }
+
+      activityDatesSubmitController.options.validate.failAction(request, h, err)
+
+      expect(h.view).toHaveBeenCalled()
+      const viewCall = h.view.mock.calls[0]
+      const viewData = viewCall[1]
+
+      expect(viewData.startDateErrorMessage).toBeNull()
+    })
+
+    test('should handle end date missing complete error', () => {
+      const h = {
+        view: jest.fn().mockReturnThis(),
+        takeover: jest.fn()
+      }
+
+      const err = {
+        details: [
+          {
+            type: 'activity-end-date-day',
+            path: ['activity-end-date-day']
+          },
+          {
+            type: 'activity-end-date-month',
+            path: ['activity-end-date-month']
+          },
+          {
+            type: 'activity-end-date-year',
+            path: ['activity-end-date-year']
+          }
+        ]
+      }
+
+      const request = { payload: {} }
+
+      activityDatesSubmitController.options.validate.failAction(request, h, err)
+
+      expect(h.view).toHaveBeenCalled()
+      const viewCall = h.view.mock.calls[0]
+      const viewData = viewCall[1]
+
+      expect(viewData.endDateErrorMessage).toEqual({
+        text: 'Enter the end date'
+      })
+    })
+
+    test('should handle end date invalid custom error', () => {
+      const h = {
+        view: jest.fn().mockReturnThis(),
+        takeover: jest.fn()
+      }
+
+      const err = {
+        details: [
+          {
+            type: 'custom.endDate.invalid',
+            path: [],
+            message: 'custom.endDate.invalid'
+          }
+        ]
+      }
+
+      const request = { payload: {} }
+
+      activityDatesSubmitController.options.validate.failAction(request, h, err)
+
+      expect(h.view).toHaveBeenCalled()
+      const viewCall = h.view.mock.calls[0]
+      const viewData = viewCall[1]
+
+      expect(viewData.endDateErrorMessage).toEqual({
+        text: 'The end date must be a real date'
+      })
+    })
+
+    test('should handle end date day error', () => {
+      const h = {
+        view: jest.fn().mockReturnThis(),
+        takeover: jest.fn()
+      }
+
+      const err = {
+        details: [
+          {
+            type: 'activity-end-date-day',
+            path: ['activity-end-date-day'],
+            message: 'activity-end-date-day'
+          }
+        ]
+      }
+
+      const request = { payload: {} }
+
+      activityDatesSubmitController.options.validate.failAction(request, h, err)
+
+      expect(h.view).toHaveBeenCalled()
+      const viewCall = h.view.mock.calls[0]
+      const viewData = viewCall[1]
+
+      expect(viewData.endDateErrorMessage).toEqual({
+        text: 'The end date must include a day'
+      })
+    })
+
+    test('should handle end date month error', () => {
+      const h = {
+        view: jest.fn().mockReturnThis(),
+        takeover: jest.fn()
+      }
+
+      const err = {
+        details: [
+          {
+            type: 'activity-end-date-month',
+            path: ['activity-end-date-month'],
+            message: 'activity-end-date-month'
+          }
+        ]
+      }
+
+      const request = { payload: {} }
+
+      activityDatesSubmitController.options.validate.failAction(request, h, err)
+
+      expect(h.view).toHaveBeenCalled()
+      const viewCall = h.view.mock.calls[0]
+      const viewData = viewCall[1]
+
+      expect(viewData.endDateErrorMessage).toEqual({
+        text: 'The end date must include a month'
+      })
+    })
+
+    test('should return null for end date when no errors match', () => {
+      const h = {
+        view: jest.fn().mockReturnThis(),
+        takeover: jest.fn()
+      }
+
+      const err = {
+        details: [
+          {
+            type: 'some-other-error',
+            path: ['some-field'],
+            message: 'some-other-error'
+          }
+        ]
+      }
+
+      const request = { payload: {} }
+
+      activityDatesSubmitController.options.validate.failAction(request, h, err)
+
+      expect(h.view).toHaveBeenCalled()
+      const viewCall = h.view.mock.calls[0]
+      const viewData = viewCall[1]
+
+      expect(viewData.endDateErrorMessage).toBeNull()
+    })
+
+    test('should handle API errors without validation details', async () => {
+      const apiPatchMock = jest.spyOn(Wreck, 'patch')
+      apiPatchMock.mockRejectedValueOnce({
+        message: 'Network error',
+        data: {}
+      })
+
+      const currentYear = new Date().getFullYear()
+      const payload = {
+        'activity-start-date-day': '1',
+        'activity-start-date-month': '6',
+        'activity-start-date-year': (currentYear + 1).toString(),
+        'activity-end-date-day': '15',
+        'activity-end-date-month': '6',
+        'activity-end-date-year': (currentYear + 1).toString()
+      }
+
+      const { statusCode } = await server.inject({
+        method: 'POST',
+        url: routes.ACTIVITY_DATES,
+        payload
+      })
+
+      expect(statusCode).toBe(statusCodes.internalServerError)
+    })
+
+    test('should handle start date year error specifically', () => {
+      const h = {
+        view: jest.fn().mockReturnThis(),
+        takeover: jest.fn()
+      }
+
+      const err = {
+        details: [
+          {
+            type: 'activity-start-date-year',
+            path: ['activity-start-date-year'],
+            message: 'activity-start-date-year'
+          }
+        ]
+      }
+
+      const request = { payload: {} }
+
+      activityDatesSubmitController.options.validate.failAction(request, h, err)
+
+      expect(h.view).toHaveBeenCalled()
+      const viewCall = h.view.mock.calls[0]
+      const viewData = viewCall[1]
+
+      expect(viewData.startDateErrorMessage).toEqual({
+        text: 'The start date must include a year'
+      })
+    })
+
+    test('should handle end date year error specifically', () => {
+      const h = {
+        view: jest.fn().mockReturnThis(),
+        takeover: jest.fn()
+      }
+
+      const err = {
+        details: [
+          {
+            type: 'activity-end-date-year',
+            path: ['activity-end-date-year'],
+            message: 'activity-end-date-year'
+          }
+        ]
+      }
+
+      const request = { payload: {} }
+
+      activityDatesSubmitController.options.validate.failAction(request, h, err)
+
+      expect(h.view).toHaveBeenCalled()
+      const viewCall = h.view.mock.calls[0]
+      const viewData = viewCall[1]
+
+      expect(viewData.endDateErrorMessage).toEqual({
+        text: 'The end date must include a year'
+      })
+    })
+
+    test('should cover line 132 - end date invalid custom error in addCustomValidationErrors', () => {
+      const h = {
+        view: jest.fn().mockReturnThis(),
+        takeover: jest.fn()
+      }
+
+      const err = {
+        details: [
+          {
+            type: 'custom.endDate.invalid',
+            path: [],
+            message: 'custom.endDate.invalid'
+          }
+        ]
+      }
+
+      const request = { payload: {} }
+
+      activityDatesSubmitController.options.validate.failAction(request, h, err)
+
+      expect(h.view).toHaveBeenCalled()
+      const viewCall = h.view.mock.calls[0]
+      const viewData = viewCall[1]
+
+      // Check that the error is added to error summary (line 132)
+      expect(viewData.errorSummary).toContainEqual({
+        href: '#activity-end-date-day',
+        text: 'The end date must be a real date'
+      })
+    })
+
+    test('should cover line 233 - end date today or future error message', () => {
+      const h = {
+        view: jest.fn().mockReturnThis(),
+        takeover: jest.fn()
+      }
+
+      const err = {
+        details: [
+          {
+            type: 'custom.endDate.todayOrFuture',
+            path: [],
+            message: 'custom.endDate.todayOrFuture'
+          }
+        ]
+      }
+
+      const request = { payload: {} }
+
+      activityDatesSubmitController.options.validate.failAction(request, h, err)
+
+      expect(h.view).toHaveBeenCalled()
+      const viewCall = h.view.mock.calls[0]
+      const viewData = viewCall[1]
+
+      // Check that line 233 is covered
+      expect(viewData.endDateErrorMessage).toEqual({
+        text: 'The end date must be today or in the future'
+      })
+    })
+
+    test('should cover line 314 - return h.view when no error details in failAction', () => {
+      const h = {
+        view: jest.fn().mockReturnThis(),
+        takeover: jest.fn()
+      }
+
+      // Create an error without details to trigger line 314 (return h)
+      const err = {} // No details property
+
+      const request = { payload: { 'test-field': 'test-value' } }
+
+      getExemptionCacheSpy.mockReturnValueOnce({
+        projectName: 'Test Project'
+      })
+
+      activityDatesSubmitController.options.validate.failAction(request, h, err)
+
+      expect(h.view).toHaveBeenCalledWith(
+        ACTIVITY_DATES_VIEW_ROUTE,
+        expect.objectContaining({
+          projectName: 'Test Project',
+          payload: { 'test-field': 'test-value' }
+        })
+      )
+      expect(h.takeover).toHaveBeenCalled()
+    })
+
+    test('should cover line 414 - throw error when no validation details in handler', async () => {
+      const apiPatchMock = jest.spyOn(Wreck, 'patch')
+      // Create an error without validation details to trigger the throw on line 414
+      const networkError = new Error('Network error')
+      networkError.data = { payload: {} } // No validation property
+      apiPatchMock.mockRejectedValueOnce(networkError)
+
+      // Mock getExemptionCache to return a valid exemption
+      getExemptionCacheSpy.mockReturnValueOnce({
+        id: 'test-id',
+        projectName: 'Test Project'
+      })
+
+      const currentYear = new Date().getFullYear()
+      const payload = {
+        'activity-start-date-day': '1',
+        'activity-start-date-month': '6',
+        'activity-start-date-year': (currentYear + 1).toString(),
+        'activity-end-date-day': '15',
+        'activity-end-date-month': '6',
+        'activity-end-date-year': (currentYear + 1).toString()
+      }
+
+      const request = { payload }
+      const h = { redirect: jest.fn() }
+
+      // This should trigger line 414 (throw e) since there are no validation details
+      await expect(
+        activityDatesSubmitController.handler(request, h)
+      ).rejects.toThrow('Network error')
+    })
+
+    test('should cover lines 423-428 - API error with validation details', async () => {
+      // Mock the API to return an error with validation details
+      const apiPatchMock = jest.spyOn(Wreck, 'patch')
+      const apiError = new Error('API validation error')
+      apiError.data = {
+        payload: {
+          validation: {
+            details: [
+              {
+                type: 'activity-start-date-day',
+                path: ['activity-start-date-day'],
+                message: 'Start date day is invalid'
+              }
+            ]
+          }
+        }
+      }
+      apiPatchMock.mockRejectedValueOnce(apiError)
+
+      // Mock getExemptionCache to return a valid exemption
+      getExemptionCacheSpy.mockReturnValueOnce({
+        id: 'test-id',
+        projectName: 'Test Project'
+      })
+
+      const h = {
+        view: jest.fn()
+      }
+
+      const currentYear = new Date().getFullYear()
+      const payload = {
+        'activity-start-date-day': '1',
+        'activity-start-date-month': '6',
+        'activity-start-date-year': (currentYear + 1).toString(),
+        'activity-end-date-day': '15',
+        'activity-end-date-month': '6',
+        'activity-end-date-year': (currentYear + 1).toString()
+      }
+
+      const request = { payload }
+
+      // Call the handler directly to hit the catch block
+      await activityDatesSubmitController.handler(request, h)
+
+      // Verify that h.view was called with the correct parameters (lines 423-428)
+      expect(h.view).toHaveBeenCalledWith(
+        ACTIVITY_DATES_VIEW_ROUTE,
+        expect.objectContaining({
+          projectName: 'Test Project',
+          activityStartDateDay: '1',
+          activityStartDateMonth: '6',
+          activityStartDateYear: (currentYear + 1).toString(),
+          activityEndDateDay: '15',
+          activityEndDateMonth: '6',
+          activityEndDateYear: (currentYear + 1).toString(),
+          errors: expect.any(Object),
+          errorSummary: expect.any(Array)
+        })
+      )
+
+      // Verify specific payload assignments that should cover lines 423-428
+      const viewCall = h.view.mock.calls[0]
+      const viewData = viewCall[1]
+      expect(viewData.activityStartDateDay).toBe('1') // Line 423
+      expect(viewData.activityStartDateMonth).toBe('6') // Line 424
+      expect(viewData.activityStartDateYear).toBe((currentYear + 1).toString()) // Line 425
+      expect(viewData.activityEndDateDay).toBe('15') // Line 426
+      expect(viewData.activityEndDateMonth).toBe('6') // Line 427
+      expect(viewData.activityEndDateYear).toBe((currentYear + 1).toString()) // Line 428
+    })
+
+    test('should cover lines 423-428 with empty payload values - API error fallback', async () => {
+      // Mock the API to return an error with validation details
+      const apiPatchMock = jest.spyOn(Wreck, 'patch')
+      const apiError = new Error('API validation error')
+      apiError.data = {
+        payload: {
+          validation: {
+            details: [
+              {
+                type: 'activity-start-date-day',
+                path: ['activity-start-date-day'],
+                message: 'Start date day is invalid'
+              }
+            ]
+          }
+        }
+      }
+      apiPatchMock.mockRejectedValueOnce(apiError)
+
+      // Mock getExemptionCache to return a valid exemption
+      getExemptionCacheSpy.mockReturnValueOnce({
+        id: 'test-id',
+        projectName: 'Test Project'
+      })
+
+      const h = {
+        view: jest.fn()
+      }
+
+      // Use empty payload to test the || '' fallback logic
+      const payload = {}
+
+      const request = { payload }
+
+      // Call the handler directly to hit the catch block
+      await activityDatesSubmitController.handler(request, h)
+
+      // Verify that h.view was called with empty string fallbacks (lines 423-428)
+      const viewCall = h.view.mock.calls[0]
+      const viewData = viewCall[1]
+      expect(viewData.activityStartDateDay).toBe('') // Line 423 fallback
+      expect(viewData.activityStartDateMonth).toBe('') // Line 424 fallback
+      expect(viewData.activityStartDateYear).toBe('') // Line 425 fallback
+      expect(viewData.activityEndDateDay).toBe('') // Line 426 fallback
+      expect(viewData.activityEndDateMonth).toBe('') // Line 427 fallback
+      expect(viewData.activityEndDateYear).toBe('') // Line 428 fallback
     })
   })
 })

--- a/src/server/exemption/activity-dates/index.js
+++ b/src/server/exemption/activity-dates/index.js
@@ -1,0 +1,18 @@
+import { routes } from '~/src/server/common/constants/routes.js'
+import {
+  activityDatesController,
+  activityDatesSubmitController
+} from './controller.js'
+
+export const activityDatesRoutes = [
+  {
+    method: 'GET',
+    path: routes.ACTIVITY_DATES,
+    ...activityDatesController
+  },
+  {
+    method: 'POST',
+    path: routes.ACTIVITY_DATES,
+    ...activityDatesSubmitController
+  }
+]

--- a/src/server/exemption/activity-dates/index.njk
+++ b/src/server/exemption/activity-dates/index.njk
@@ -1,0 +1,112 @@
+{% extends 'layouts/page.njk' %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/date-input/macro.njk" import govukDateInput %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "cancel-button/macro.njk" import appCancelButton %}
+{% block beforeContent %}
+  {{ govukBackLink({
+        text: "Back",
+        href: backLink
+    }) }}
+{% endblock %}
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% if errors %}
+        {{ govukErrorSummary({
+          titleText: "There is a problem",
+          errorList: errorSummary
+        }) }}
+      {% endif %}
+      <h1 class="govuk-heading-l">{{ title }}</h1>
+      {% if projectName %}
+        <span class="govuk-caption-l">{{ projectName }}</span>
+      {% endif %}
+      {% for paragraph in descriptionParagraphs %}
+        <p class="govuk-body">{{ paragraph }}</p>
+      {% endfor %}
+      <form method="POST">
+        <input type="hidden" name="csrfToken" value="{{ csrfToken }}"/> {{ govukDateInput({
+          id: "activity-start-date",
+          namePrefix: "activity-start-date",
+          fieldset: {
+            legend: {
+              text: "Start date",
+              isPageHeading: false,
+              classes: "govuk-fieldset__legend--s"
+            }
+          },
+          hint: {
+            text: "For example, 27 5 2025"
+          },
+          errorMessage: startDateErrorMessage,
+          items: [
+            {
+              id: "activity-start-date-day",
+              name: "day",
+              classes: "govuk-input--width-2" + (" govuk-input--error" if errors['activity-start-date-day']),
+              value: activityStartDateDay if activityStartDateDay
+            },
+            {
+              id: "activity-start-date-month",
+              name: "month",
+              classes: "govuk-input--width-2" + (" govuk-input--error" if errors['activity-start-date-month']),
+              value: activityStartDateMonth if activityStartDateMonth
+            },
+            {
+              id: "activity-start-date-year",
+              name: "year",
+              classes: "govuk-input--width-4" + (" govuk-input--error" if errors['activity-start-date-year']),
+              value: activityStartDateYear if activityStartDateYear
+            }
+          ]
+        }) }}
+        {{ govukDateInput({
+          id: "activity-end-date",
+          namePrefix: "activity-end-date",
+          fieldset: {
+            legend: {
+              text: "End date",
+              isPageHeading: false,
+              classes: "govuk-fieldset__legend--s"
+            }
+          },
+          hint: {
+            text: "For example, 27 5 2025"
+          },
+          errorMessage: endDateErrorMessage,
+          items: [
+            {
+              id: "activity-end-date-day",
+              name: "day",
+              classes: "govuk-input--width-2" + (" govuk-input--error" if errors['activity-end-date-day']),
+              value: activityEndDateDay if activityEndDateDay
+            },
+            {
+              id: "activity-end-date-month",
+              name: "month",
+              classes: "govuk-input--width-2" + (" govuk-input--error" if errors['activity-end-date-month']),
+              value: activityEndDateMonth if activityEndDateMonth
+            },
+            {
+              id: "activity-end-date-year",
+              name: "year",
+              classes: "govuk-input--width-4" + (" govuk-input--error" if errors['activity-end-date-year']),
+              value: activityEndDateYear if activityEndDateYear
+            }
+          ]
+        }) }}
+        <div class="govuk-button-group">
+          {{ govukButton({
+              text: "Save and continue",
+              type: "submit"
+          }) }}
+          {{ appCancelButton({
+              cancelLink: '/exemption/task-list'
+          }) }}
+        </div>
+      </form>
+    </div>
+  </div>
+{% endblock %}

--- a/src/server/exemption/activity-dates/index.njk
+++ b/src/server/exemption/activity-dates/index.njk
@@ -103,7 +103,7 @@
               type: "submit"
           }) }}
           {{ appCancelButton({
-              cancelLink: '/exemption/task-list'
+              cancelLink: cancelLink
           }) }}
         </div>
       </form>

--- a/src/server/exemption/activity-dates/index.njk
+++ b/src/server/exemption/activity-dates/index.njk
@@ -4,6 +4,53 @@
 {% from "govuk/components/date-input/macro.njk" import govukDateInput %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "cancel-button/macro.njk" import appCancelButton %}
+{# Date input macro to reduce duplication #}
+{% macro activityDateInput(
+  id, 
+  namePrefix, 
+  legend, 
+  dayValue, 
+  monthValue, 
+  yearValue, 
+  errorMessage, 
+  errors = {}
+) %}
+  {{ govukDateInput({
+    id: id,
+    namePrefix: namePrefix,
+    fieldset: {
+      legend: {
+        text: legend,
+        isPageHeading: false,
+        classes: "govuk-fieldset__legend--s"
+      }
+    },
+    hint: {
+      text: "For example, 27 5 2025"
+    },
+    errorMessage: errorMessage,
+    items: [
+      {
+        id: namePrefix + "-day",
+        name: "day",
+        classes: "govuk-input--width-2" + (" govuk-input--error" if errors[namePrefix + '-day']),
+        value: dayValue if dayValue
+      },
+      {
+        id: namePrefix + "-month",
+        name: "month",
+        classes: "govuk-input--width-2" + (" govuk-input--error" if errors[namePrefix + '-month']),
+        value: monthValue if monthValue
+      },
+      {
+        id: namePrefix + "-year",
+        name: "year",
+        classes: "govuk-input--width-4" + (" govuk-input--error" if errors[namePrefix + '-year']),
+        value: yearValue if yearValue
+      }
+    ]
+  }) }}
+{% endmacro %}
 {% block beforeContent %}
   {{ govukBackLink({
         text: "Back",
@@ -27,76 +74,26 @@
         <p class="govuk-body">{{ paragraph }}</p>
       {% endfor %}
       <form method="POST">
-        <input type="hidden" name="csrfToken" value="{{ csrfToken }}"/> {{ govukDateInput({
-          id: "activity-start-date",
-          namePrefix: "activity-start-date",
-          fieldset: {
-            legend: {
-              text: "Start date",
-              isPageHeading: false,
-              classes: "govuk-fieldset__legend--s"
-            }
-          },
-          hint: {
-            text: "For example, 27 5 2025"
-          },
-          errorMessage: startDateErrorMessage,
-          items: [
-            {
-              id: "activity-start-date-day",
-              name: "day",
-              classes: "govuk-input--width-2" + (" govuk-input--error" if errors['activity-start-date-day']),
-              value: activityStartDateDay if activityStartDateDay
-            },
-            {
-              id: "activity-start-date-month",
-              name: "month",
-              classes: "govuk-input--width-2" + (" govuk-input--error" if errors['activity-start-date-month']),
-              value: activityStartDateMonth if activityStartDateMonth
-            },
-            {
-              id: "activity-start-date-year",
-              name: "year",
-              classes: "govuk-input--width-4" + (" govuk-input--error" if errors['activity-start-date-year']),
-              value: activityStartDateYear if activityStartDateYear
-            }
-          ]
-        }) }}
-        {{ govukDateInput({
-          id: "activity-end-date",
-          namePrefix: "activity-end-date",
-          fieldset: {
-            legend: {
-              text: "End date",
-              isPageHeading: false,
-              classes: "govuk-fieldset__legend--s"
-            }
-          },
-          hint: {
-            text: "For example, 27 5 2025"
-          },
-          errorMessage: endDateErrorMessage,
-          items: [
-            {
-              id: "activity-end-date-day",
-              name: "day",
-              classes: "govuk-input--width-2" + (" govuk-input--error" if errors['activity-end-date-day']),
-              value: activityEndDateDay if activityEndDateDay
-            },
-            {
-              id: "activity-end-date-month",
-              name: "month",
-              classes: "govuk-input--width-2" + (" govuk-input--error" if errors['activity-end-date-month']),
-              value: activityEndDateMonth if activityEndDateMonth
-            },
-            {
-              id: "activity-end-date-year",
-              name: "year",
-              classes: "govuk-input--width-4" + (" govuk-input--error" if errors['activity-end-date-year']),
-              value: activityEndDateYear if activityEndDateYear
-            }
-          ]
-        }) }}
+        <input type="hidden" name="csrfToken" value="{{ csrfToken }}"/> {{ activityDateInput(
+          "activity-start-date",
+          "activity-start-date", 
+          "Start date",
+          activityStartDateDay,
+          activityStartDateMonth,
+          activityStartDateYear,
+          startDateErrorMessage,
+          errors
+        ) }}
+        {{ activityDateInput(
+          "activity-end-date",
+          "activity-end-date", 
+          "End date",
+          activityEndDateDay,
+          activityEndDateMonth,
+          activityEndDateYear,
+          endDateErrorMessage,
+          errors
+        ) }}
         <div class="govuk-button-group">
           {{ govukButton({
               text: "Save and continue",

--- a/src/server/exemption/activity-dates/index.njk
+++ b/src/server/exemption/activity-dates/index.njk
@@ -70,9 +70,10 @@
       {% if projectName %}
         <span class="govuk-caption-l">{{ projectName }}</span>
       {% endif %}
-      {% for paragraph in descriptionParagraphs %}
-        <p class="govuk-body">{{ paragraph }}</p>
-      {% endfor %}
+      <p class="govuk-body">Enter the activity dates. Allow time for potential delays, like consents (for example, a river
+        works licence) or bad weather. If you miss the dates, you'll need to restart the process.</p>
+      <p class="govuk-body">You can enter a start date from today and begin your activity as soon as you've sent your
+        information.</p>
       <form method="POST">
         <input type="hidden" name="csrfToken" value="{{ csrfToken }}"/> {{ activityDateInput(
           "activity-start-date",

--- a/src/server/exemption/index.js
+++ b/src/server/exemption/index.js
@@ -3,6 +3,7 @@ import { publicRegisterRoutes } from '~/src/server/exemption/public-register/ind
 import { taskListRoutes } from '~/src/server/exemption/task-list/index.js'
 import { siteDetailsRoutes } from '~/src/server/exemption/site-details/index.js'
 import { activityDescriptionRoutes } from './activity-description/index.js'
+import { activityDatesRoutes } from './activity-dates/index.js'
 import { routes } from '~/src/server/common/constants/routes.js'
 
 /**
@@ -23,6 +24,7 @@ export const exemption = {
         ...taskListRoutes,
         ...siteDetailsRoutes,
         ...activityDescriptionRoutes,
+        ...activityDatesRoutes,
         {
           method: 'GET',
           path: '/exemption',

--- a/src/server/exemption/index.test.js
+++ b/src/server/exemption/index.test.js
@@ -88,6 +88,14 @@ describe('exemption route', () => {
       }),
       expect.objectContaining({
         method: 'GET',
+        path: '/exemption/activity-dates'
+      }),
+      expect.objectContaining({
+        method: 'POST',
+        path: '/exemption/activity-dates'
+      }),
+      expect.objectContaining({
+        method: 'GET',
         path: '/exemption'
       })
     ])

--- a/src/server/exemption/task-list/controller.test.js
+++ b/src/server/exemption/task-list/controller.test.js
@@ -100,10 +100,7 @@ describe('#taskListController', () => {
         {
           href: routes.ACTIVITY_DATES,
           status: {
-            tag: {
-              classes: 'govuk-tag--blue',
-              text: 'Incomplete'
-            }
+            text: 'Completed'
           },
           title: {
             text: 'Activity dates'

--- a/src/server/exemption/task-list/controller.test.js
+++ b/src/server/exemption/task-list/controller.test.js
@@ -98,6 +98,18 @@ describe('#taskListController', () => {
           }
         },
         {
+          href: routes.ACTIVITY_DATES,
+          status: {
+            tag: {
+              classes: 'govuk-tag--blue',
+              text: 'Incomplete'
+            }
+          },
+          title: {
+            text: 'Activity dates'
+          }
+        },
+        {
           href: routes.ACTIVITY_DESCRIPTION,
           status: {
             tag: {

--- a/src/server/exemption/task-list/utils.js
+++ b/src/server/exemption/task-list/utils.js
@@ -34,6 +34,13 @@ export const transformTaskList = (taskList) => {
     },
     {
       title: {
+        text: 'Activity dates'
+      },
+      href: routes.ACTIVITY_DATES,
+      status: setStatus(taskList.activityDates)
+    },
+    {
+      title: {
         text: 'Activity description'
       },
       href: routes.ACTIVITY_DESCRIPTION,

--- a/src/server/exemption/task-list/utils.test.js
+++ b/src/server/exemption/task-list/utils.test.js
@@ -12,7 +12,7 @@ describe('taskList utils', () => {
       },
       {
         href: routes.ACTIVITY_DATES,
-        status: { tag: { text: 'Incomplete', classes: 'govuk-tag--blue' } },
+        status: { text: 'Completed' },
         title: { text: 'Activity dates' }
       },
       {
@@ -47,7 +47,7 @@ describe('taskList utils', () => {
       },
       {
         href: routes.ACTIVITY_DATES,
-        status: { tag: { text: 'Incomplete', classes: 'govuk-tag--blue' } },
+        status: { text: 'Completed' },
         title: { text: 'Activity dates' }
       },
       {

--- a/src/server/exemption/task-list/utils.test.js
+++ b/src/server/exemption/task-list/utils.test.js
@@ -11,6 +11,11 @@ describe('taskList utils', () => {
         title: { text: 'Project name' }
       },
       {
+        href: routes.ACTIVITY_DATES,
+        status: { tag: { text: 'Incomplete', classes: 'govuk-tag--blue' } },
+        title: { text: 'Activity dates' }
+      },
+      {
         href: routes.ACTIVITY_DESCRIPTION,
         status: { tag: { text: 'Incomplete', classes: 'govuk-tag--blue' } },
         title: { text: 'Activity description' }
@@ -41,6 +46,11 @@ describe('taskList utils', () => {
         title: { text: 'Project name' }
       },
       {
+        href: routes.ACTIVITY_DATES,
+        status: { tag: { text: 'Incomplete', classes: 'govuk-tag--blue' } },
+        title: { text: 'Activity dates' }
+      },
+      {
         href: routes.ACTIVITY_DESCRIPTION,
         status: { tag: { text: 'Incomplete', classes: 'govuk-tag--blue' } },
         title: { text: 'Activity description' }
@@ -64,6 +74,11 @@ describe('taskList utils', () => {
         href: routes.PROJECT_NAME,
         status: { tag: { text: 'Incomplete', classes: 'govuk-tag--blue' } },
         title: { text: 'Project name' }
+      },
+      {
+        href: routes.ACTIVITY_DATES,
+        status: { tag: { text: 'Incomplete', classes: 'govuk-tag--blue' } },
+        title: { text: 'Activity dates' }
       },
       {
         href: routes.ACTIVITY_DESCRIPTION,

--- a/src/server/test-helpers/mocks.js
+++ b/src/server/test-helpers/mocks.js
@@ -3,6 +3,7 @@ import { COORDINATE_SYSTEMS } from '~/src/server/common/constants/exemptions.js'
 
 export const mockExemptionTaskList = {
   projectName: 'COMPLETED',
+  activityDates: 'COMPLETED',
   publicRegister: 'COMPLETED',
   siteDetails: 'COMPLETED'
 }


### PR DESCRIPTION
This PR adds a new page for Activity dates. It has custom validation for start and end dates. 

Also included is prompts for front end based on the AI playbook