### PR TITLE
ML-373: Send Auth token to the back end for each request

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@hapi/inert": "^7.1.0",
         "@hapi/jwt": "^3.2.0",
         "@hapi/vision": "^7.0.3",
+        "@hapi/wreck": "^18.1.0",
         "@hapi/yar": "^11.0.2",
         "aws-embedded-metrics": "^4.2.0",
         "babel-plugin-module-resolver": "^5.0.2",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@hapi/inert": "^7.1.0",
     "@hapi/jwt": "^3.2.0",
     "@hapi/vision": "^7.0.3",
+    "@hapi/wreck": "^18.1.0",
     "@hapi/yar": "^11.0.2",
     "aws-embedded-metrics": "^4.2.0",
     "babel-plugin-module-resolver": "^5.0.2",

--- a/src/server/common/helpers/authenticated-requests.js
+++ b/src/server/common/helpers/authenticated-requests.js
@@ -1,0 +1,96 @@
+import Wreck from '@hapi/wreck'
+import { config } from '~/src/config/config.js'
+import { getUserSession } from '~/src/server/common/plugins/auth/utils.js'
+
+export const getAuthToken = async (request) => {
+  try {
+    const userSession = await getUserSession(request, {
+      sessionId: request.auth.credentials.sessionId
+    })
+    return userSession?.token || null
+  } catch (error) {
+    request.logger.error('Error getting auth token from session:', error)
+    return null
+  }
+}
+
+export const createAuthHeaders = async (request, additionalHeaders = {}) => {
+  const token = await getAuthToken(request)
+
+  const headers = {
+    'Content-Type': 'application/json',
+    ...additionalHeaders
+  }
+
+  if (token) {
+    headers.Authorization = `Bearer ${token}`
+  }
+
+  return headers
+}
+
+export const authenticatedGetRequest = async (
+  request,
+  endpoint,
+  options = {}
+) => {
+  const headers = await createAuthHeaders(request)
+  const url = `${config.get('backend').apiUrl}${endpoint}`
+
+  return Wreck.get(url, {
+    headers,
+    json: true,
+    ...options
+  })
+}
+
+export const authenticatedPostRequest = async (
+  request,
+  endpoint,
+  payload,
+  options = {}
+) => {
+  const headers = await createAuthHeaders(request)
+  const url = `${config.get('backend').apiUrl}${endpoint}`
+
+  return Wreck.post(url, {
+    payload,
+    headers,
+    json: true,
+    ...options
+  })
+}
+
+export const authenticatedPatchRequest = async (
+  request,
+  endpoint,
+  payload,
+  options = {}
+) => {
+  const headers = await createAuthHeaders(request)
+  const url = `${config.get('backend').apiUrl}${endpoint}`
+
+  return Wreck.patch(url, {
+    payload,
+    headers,
+    json: true,
+    ...options
+  })
+}
+
+export const authenticatedPutRequest = async (
+  request,
+  endpoint,
+  payload,
+  options = {}
+) => {
+  const headers = await createAuthHeaders(request)
+  const url = `${config.get('backend').apiUrl}${endpoint}`
+
+  return Wreck.put(url, {
+    payload,
+    headers,
+    json: true,
+    ...options
+  })
+}

--- a/src/server/common/helpers/authenticated-requests.test.js
+++ b/src/server/common/helpers/authenticated-requests.test.js
@@ -74,6 +74,54 @@ describe('#authenticated-requests', () => {
       expect(result).toEqual(mockResponse)
     })
 
+    test('should still send request without token if it errors when trying to find one', async () => {
+      const mockResponse = { payload: { data: 'test' } }
+      Wreck.get.mockResolvedValue(mockResponse)
+
+      getUserSessionMock.mockRejectedValueOnce(null)
+
+      const result = await authenticatedGetRequest(
+        mockRequest,
+        '/test-endpoint'
+      )
+
+      expect(getUserSessionMock).toHaveBeenCalledWith(mockRequest, {
+        sessionId: 'test-session-id'
+      })
+      expect(Wreck.get).toHaveBeenCalledWith(
+        'http://localhost:3001/test-endpoint',
+        {
+          headers: { 'Content-Type': 'application/json' },
+          json: true
+        }
+      )
+      expect(result).toEqual(mockResponse)
+    })
+
+    test('should still send request without token if it fails to find one', async () => {
+      const mockResponse = { payload: { data: 'test' } }
+      Wreck.get.mockResolvedValue(mockResponse)
+
+      getUserSessionMock.mockResolvedValueOnce({})
+
+      const result = await authenticatedGetRequest(
+        mockRequest,
+        '/test-endpoint'
+      )
+
+      expect(getUserSessionMock).toHaveBeenCalledWith(mockRequest, {
+        sessionId: 'test-session-id'
+      })
+      expect(Wreck.get).toHaveBeenCalledWith(
+        'http://localhost:3001/test-endpoint',
+        {
+          headers: { 'Content-Type': 'application/json' },
+          json: true
+        }
+      )
+      expect(result).toEqual(mockResponse)
+    })
+
     test('should include additional options', async () => {
       const additionalOptions = { timeout: 5000 }
       Wreck.get.mockResolvedValue({})

--- a/src/server/common/helpers/authenticated-requests.test.js
+++ b/src/server/common/helpers/authenticated-requests.test.js
@@ -1,0 +1,179 @@
+import Wreck from '@hapi/wreck'
+import { config } from '~/src/config/config.js'
+import {
+  authenticatedGetRequest,
+  authenticatedPostRequest,
+  authenticatedPatchRequest,
+  authenticatedPutRequest
+} from './authenticated-requests.js'
+import { getUserSession } from '~/src/server/common/plugins/auth/utils.js'
+
+jest.mock('~/src/server/common/plugins/auth/utils.js')
+jest.mock('@hapi/wreck')
+jest.mock('~/src/config/config.js')
+
+describe('#authenticated-requests', () => {
+  let mockRequest
+  let mockHeaders
+
+  const getUserSessionMock = jest.mocked(getUserSession)
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    mockRequest = {
+      state: {
+        session: {
+          sessionId: 'test-session-id'
+        }
+      },
+      auth: {
+        credentials: {
+          sessionId: 'test-session-id'
+        }
+      },
+      logger: {
+        error: jest.fn()
+      }
+    }
+
+    getUserSessionMock.mockImplementation(() => ({
+      token: 'test-token'
+    }))
+
+    mockHeaders = {
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer test-token'
+    }
+
+    config.get.mockImplementation(() => {
+      return { apiUrl: 'http://localhost:3001' }
+    })
+  })
+
+  describe('#authenticatedGetRequest', () => {
+    test('should make GET request with auth headers', async () => {
+      const mockResponse = { payload: { data: 'test' } }
+      Wreck.get.mockResolvedValue(mockResponse)
+
+      const result = await authenticatedGetRequest(
+        mockRequest,
+        '/test-endpoint'
+      )
+
+      expect(getUserSessionMock).toHaveBeenCalledWith(mockRequest, {
+        sessionId: 'test-session-id'
+      })
+      expect(Wreck.get).toHaveBeenCalledWith(
+        'http://localhost:3001/test-endpoint',
+        {
+          headers: mockHeaders,
+          json: true
+        }
+      )
+      expect(result).toEqual(mockResponse)
+    })
+
+    test('should include additional options', async () => {
+      const additionalOptions = { timeout: 5000 }
+      Wreck.get.mockResolvedValue({})
+
+      await authenticatedGetRequest(
+        mockRequest,
+        '/test-endpoint',
+        additionalOptions
+      )
+
+      expect(Wreck.get).toHaveBeenCalledWith(
+        'http://localhost:3001/test-endpoint',
+        {
+          headers: mockHeaders,
+          json: true,
+          timeout: 5000
+        }
+      )
+    })
+  })
+
+  describe('#authenticatedPostRequest', () => {
+    test('should make POST request with auth headers and payload', async () => {
+      const mockPayload = { test: 'data' }
+      const mockResponse = { payload: { success: true } }
+      Wreck.post.mockResolvedValue(mockResponse)
+
+      const result = await authenticatedPostRequest(
+        mockRequest,
+        '/test-endpoint',
+        mockPayload
+      )
+
+      expect(getUserSessionMock).toHaveBeenCalledWith(mockRequest, {
+        sessionId: 'test-session-id'
+      })
+      expect(Wreck.post).toHaveBeenCalledWith(
+        'http://localhost:3001/test-endpoint',
+        {
+          payload: mockPayload,
+          headers: mockHeaders,
+          json: true
+        }
+      )
+      expect(result).toEqual(mockResponse)
+    })
+  })
+
+  describe('#authenticatedPatchRequest', () => {
+    test('should make PATCH request with auth headers and payload', async () => {
+      const mockPayload = { test: 'data' }
+      const mockResponse = { payload: { success: true } }
+      Wreck.patch.mockResolvedValue(mockResponse)
+
+      const result = await authenticatedPatchRequest(
+        mockRequest,
+        '/test-endpoint',
+        mockPayload
+      )
+
+      expect(getUserSessionMock).toHaveBeenCalledWith(mockRequest, {
+        sessionId: 'test-session-id'
+      })
+      expect(Wreck.patch).toHaveBeenCalledWith(
+        'http://localhost:3001/test-endpoint',
+        {
+          payload: mockPayload,
+          headers: mockHeaders,
+          json: true
+        }
+      )
+      expect(result).toEqual(mockResponse)
+    })
+  })
+
+  describe('#authenticatedPutRequest', () => {
+    test('should make PUT request with auth headers and payload', async () => {
+      const mockPayload = { test: 'data' }
+      const mockResponse = { payload: { success: true } }
+      Wreck.put.mockResolvedValue(mockResponse)
+
+      const result = await authenticatedPutRequest(
+        mockRequest,
+        '/test-endpoint',
+        mockPayload
+      )
+
+      expect(getUserSessionMock).toHaveBeenCalledWith(mockRequest, {
+        sessionId: 'test-session-id'
+      })
+
+      expect(Wreck.put).toHaveBeenCalledWith(
+        'http://localhost:3001/test-endpoint',
+        {
+          payload: mockPayload,
+          headers: mockHeaders,
+          json: true
+        }
+      )
+      expect(result).toEqual(mockResponse)
+    })
+  })
+})

--- a/src/server/exemption/activity-dates/controller.js
+++ b/src/server/exemption/activity-dates/controller.js
@@ -1,4 +1,3 @@
-import Wreck from '@hapi/wreck'
 import {
   getExemptionCache,
   setExemptionCache
@@ -7,8 +6,8 @@ import {
   errorDescriptionByFieldName,
   mapErrorsForDisplay
 } from '~/src/server/common/helpers/errors.js'
-import { config } from '~/src/config/config.js'
 import { routes } from '~/src/server/common/constants/routes.js'
+import { authenticatedPatchRequest } from '~/src/server/common/helpers/authenticated-requests.js'
 import { JOI_ERRORS } from '~/src/server/common/constants/joi.js'
 import { activityDatesSchema } from '~/src/server/common/schemas/date.js'
 import { createDateISO } from '~/src/server/common/helpers/date-utils.js'
@@ -230,17 +229,11 @@ export const activityDatesSubmitController = {
         payload[FIELD_NAMES.END_DATE_DAY]
       )
 
-      await Wreck.patch(
-        `${config.get('backend').apiUrl}/exemption/activity-dates`,
-        {
-          payload: {
-            id: exemption.id,
-            start,
-            end
-          },
-          json: true
-        }
-      )
+      await authenticatedPatchRequest(request, '/exemption/activity-dates', {
+        id: exemption.id,
+        start,
+        end
+      })
 
       setExemptionCache(request, {
         ...exemption,

--- a/src/server/exemption/activity-description/controller.js
+++ b/src/server/exemption/activity-description/controller.js
@@ -1,4 +1,3 @@
-import { config } from '~/src/config/config.js'
 import {
   errorDescriptionByFieldName,
   mapErrorsForDisplay
@@ -8,7 +7,7 @@ import {
   setExemptionCache
 } from '~/src/server/common/helpers/session-cache/utils.js'
 import { routes } from '~/src/server/common/constants/routes.js'
-import Wreck from '@hapi/wreck'
+import { authenticatedPatchRequest } from '~/src/server/common/helpers/authenticated-requests.js'
 import joi from 'joi'
 
 export const ACTIVITY_DESCRIPTION_VIEW_ROUTE =
@@ -90,12 +89,10 @@ export const activityDescriptionSubmitController = {
     const { payload } = request
     try {
       const exemption = getExemptionCache(request)
-      const { payload: responsePayload } = await Wreck.patch(
-        `${config.get('backend').apiUrl}/exemption/activity-description`,
-        {
-          payload: { ...payload, id: exemption.id },
-          json: true
-        }
+      const { payload: responsePayload } = await authenticatedPatchRequest(
+        request,
+        '/exemption/activity-description',
+        { ...payload, id: exemption.id }
       )
 
       setExemptionCache(request, {

--- a/src/server/exemption/check-your-answers/controller.js
+++ b/src/server/exemption/check-your-answers/controller.js
@@ -1,7 +1,9 @@
 import Boom from '@hapi/boom'
-import Wreck from '@hapi/wreck'
-import { config } from '~/src/config/config.js'
 import { getExemptionCache } from '~/src/server/common/helpers/session-cache/utils.js'
+import {
+  authenticatedGetRequest,
+  authenticatedPostRequest
+} from '~/src/server/common/helpers/authenticated-requests.js'
 import {
   getCoordinateSystemText,
   getCoordinateDisplayText,
@@ -25,11 +27,9 @@ export const checkYourAnswersController = {
       throw Boom.notFound(`Exemption not found`, { id })
     }
 
-    const { payload } = await Wreck.get(
-      `${config.get('backend').apiUrl}/exemption/${id}`,
-      {
-        json: true
-      }
+    const { payload } = await authenticatedGetRequest(
+      request,
+      `/exemption/${id}`
     )
 
     if (!payload?.value?.taskList) {
@@ -68,12 +68,10 @@ export const checkYourAnswersSubmitController = {
     }
 
     try {
-      const { payload: response } = await Wreck.post(
-        `${config.get('backend').apiUrl}/exemption/submit`,
-        {
-          payload: { id },
-          json: true
-        }
+      const { payload: response } = await authenticatedPostRequest(
+        request,
+        '/exemption/submit',
+        { id }
       )
 
       if (response?.message === 'success' && response?.value) {

--- a/src/server/exemption/project-name/controller.js
+++ b/src/server/exemption/project-name/controller.js
@@ -1,4 +1,3 @@
-import { config } from '~/src/config/config.js'
 import {
   errorDescriptionByFieldName,
   mapErrorsForDisplay
@@ -7,9 +6,12 @@ import {
   getExemptionCache,
   setExemptionCache
 } from '~/src/server/common/helpers/session-cache/utils.js'
+import {
+  authenticatedPostRequest,
+  authenticatedPatchRequest
+} from '~/src/server/common/helpers/authenticated-requests.js'
 import { routes } from '~/src/server/common/constants/routes.js'
 
-import Wreck from '@hapi/wreck'
 import joi from 'joi'
 
 const errorMessages = {
@@ -86,19 +88,14 @@ export const projectNameSubmitController = {
       const isUpdate = !!exemption.id
 
       const { payload: responsePayload } = isUpdate
-        ? await Wreck.patch(
-            `${config.get('backend').apiUrl}/exemption/project-name`,
-            {
-              payload: { ...payload, id: exemption.id },
-              json: true
-            }
-          )
-        : await Wreck.post(
-            `${config.get('backend').apiUrl}/exemption/project-name`,
-            {
-              payload,
-              json: true
-            }
+        ? await authenticatedPatchRequest(request, '/exemption/project-name', {
+            ...payload,
+            id: exemption.id
+          })
+        : await authenticatedPostRequest(
+            request,
+            '/exemption/project-name',
+            payload
           )
 
       setExemptionCache(request, {

--- a/src/server/exemption/public-register/controller.js
+++ b/src/server/exemption/public-register/controller.js
@@ -2,14 +2,13 @@ import {
   getExemptionCache,
   setExemptionCache
 } from '~/src/server/common/helpers/session-cache/utils.js'
-import { config } from '~/src/config/config.js'
 import {
   errorDescriptionByFieldName,
   mapErrorsForDisplay
 } from '~/src/server/common/helpers/errors.js'
 import { routes } from '~/src/server/common/constants/routes.js'
+import { authenticatedPatchRequest } from '~/src/server/common/helpers/authenticated-requests.js'
 
-import Wreck from '@hapi/wreck'
 import joi from 'joi'
 
 export const PUBLIC_REGISTER_VIEW_ROUTE = 'exemption/public-register/index'
@@ -104,17 +103,11 @@ export const publicRegisterSubmitController = {
     try {
       const isAnswerYes = payload.consent === 'yes'
 
-      await Wreck.patch(
-        `${config.get('backend').apiUrl}/exemption/public-register`,
-        {
-          payload: {
-            consent: payload.consent,
-            ...(isAnswerYes && { reason: payload.reason }),
-            id: exemption.id
-          },
-          json: true
-        }
-      )
+      await authenticatedPatchRequest(request, '/exemption/public-register', {
+        consent: payload.consent,
+        ...(isAnswerYes && { reason: payload.reason }),
+        id: exemption.id
+      })
 
       setExemptionCache(request, {
         ...exemption,

--- a/src/server/exemption/site-details/review-site-details/controller.js
+++ b/src/server/exemption/site-details/review-site-details/controller.js
@@ -3,15 +3,14 @@ import {
   getExemptionCache
 } from '~/src/server/common/helpers/session-cache/utils.js'
 import { routes } from '~/src/server/common/constants/routes.js'
-import { config } from '~/src/config/config.js'
 import {
   getCoordinateSystemText,
   getReviewSummaryText,
   getCoordinateDisplayText,
   getSiteDetailsBackLink
 } from './utils.js'
+import { authenticatedPatchRequest } from '~/src/server/common/helpers/authenticated-requests.js'
 import Boom from '@hapi/boom'
-import Wreck from '@hapi/wreck'
 
 export const REVIEW_SITE_DETAILS_VIEW_ROUTE =
   'exemption/site-details/review-site-details/index'
@@ -61,16 +60,10 @@ export const reviewSiteDetailsSubmitController = {
     const exemption = getExemptionCache(request)
 
     try {
-      await Wreck.patch(
-        `${config.get('backend').apiUrl}/exemption/site-details`,
-        {
-          payload: {
-            siteDetails: exemption.siteDetails,
-            id: exemption.id
-          },
-          json: true
-        }
-      )
+      await authenticatedPatchRequest(request, '/exemption/site-details', {
+        siteDetails: exemption.siteDetails,
+        id: exemption.id
+      })
 
       return h.redirect(routes.TASK_LIST)
     } catch (e) {

--- a/src/server/exemption/site-details/review-site-details/controller.test.js
+++ b/src/server/exemption/site-details/review-site-details/controller.test.js
@@ -11,7 +11,7 @@ import { statusCodes } from '~/src/server/common/constants/status-codes.js'
 import { config } from '~/src/config/config.js'
 import { JSDOM } from 'jsdom'
 import { routes } from '~/src/server/common/constants/routes.js'
-import Wreck from '@hapi/wreck'
+import * as authRequests from '~/src/server/common/helpers/authenticated-requests.js'
 
 jest.mock('~/src/server/common/helpers/session-cache/utils.js')
 
@@ -37,7 +37,7 @@ describe('#reviewSiteDetails', () => {
   beforeEach(() => {
     jest.resetAllMocks()
 
-    jest.spyOn(Wreck, 'patch').mockReturnValue({
+    jest.spyOn(authRequests, 'authenticatedPatchRequest').mockResolvedValue({
       payload: {
         id: mockExemption.id,
         siteDetails: mockExemption.siteDetails
@@ -221,14 +221,12 @@ describe('#reviewSiteDetails', () => {
         }
       })
 
-      expect(Wreck.patch).toHaveBeenCalledWith(
-        `${config.get('backend').apiUrl}/exemption/site-details`,
+      expect(authRequests.authenticatedPatchRequest).toHaveBeenCalledWith(
+        expect.any(Object),
+        '/exemption/site-details',
         {
-          payload: {
-            siteDetails: mockExemption.siteDetails,
-            id: mockExemption.id
-          },
-          json: true
+          siteDetails: mockExemption.siteDetails,
+          id: mockExemption.id
         }
       )
 
@@ -246,7 +244,7 @@ describe('#reviewSiteDetails', () => {
     })
 
     test('Should show error page with validation errors from backend', async () => {
-      const apiPatchMock = jest.spyOn(Wreck, 'patch')
+      const apiPatchMock = jest.spyOn(authRequests, 'authenticatedPatchRequest')
       apiPatchMock.mockRejectedValueOnce({
         res: { statusCode: 400 },
         data: {
@@ -285,7 +283,7 @@ describe('#reviewSiteDetails', () => {
     })
 
     test('Should pass error to global catchAll behaviour if it contains no validation data', async () => {
-      const apiPatchMock = jest.spyOn(Wreck, 'patch')
+      const apiPatchMock = jest.spyOn(authRequests, 'authenticatedPatchRequest')
       apiPatchMock.mockRejectedValueOnce({
         res: { statusCode: 500 },
         data: {}

--- a/src/server/exemption/task-list/controller.js
+++ b/src/server/exemption/task-list/controller.js
@@ -1,12 +1,11 @@
-import { config } from '~/src/config/config.js'
 import {
   getExemptionCache,
   resetExemptionSiteDetails
 } from '~/src/server/common/helpers/session-cache/utils.js'
 import { transformTaskList } from '~/src/server/exemption/task-list/utils.js'
 import { routes } from '~/src/server/common/constants/routes.js'
+import { authenticatedGetRequest } from '~/src/server/common/helpers/authenticated-requests.js'
 
-import Wreck from '@hapi/wreck'
 import Boom from '@hapi/boom'
 
 export const TASK_LIST_VIEW_ROUTE = 'exemption/task-list/index'
@@ -40,11 +39,9 @@ export const taskListController = {
       return h.redirect(routes.TASK_LIST)
     }
 
-    const { payload } = await Wreck.get(
-      `${config.get('backend').apiUrl}/exemption/${id}`,
-      {
-        json: true
-      }
+    const { payload } = await authenticatedGetRequest(
+      request,
+      `/exemption/${id}`
     )
 
     const taskList = transformTaskList(payload?.value?.taskList)

--- a/src/server/exemption/task-list/controller.test.js
+++ b/src/server/exemption/task-list/controller.test.js
@@ -9,8 +9,7 @@ import {
 } from '~/src/server/exemption/task-list/controller.js'
 import { mockExemption } from '~/src/server/test-helpers/mocks.js'
 import { routes } from '~/src/server/common/constants/routes.js'
-
-import Wreck from '@hapi/wreck'
+import * as authRequests from '~/src/server/common/helpers/authenticated-requests.js'
 
 describe('#taskListController', () => {
   /** @type {Server} */
@@ -28,8 +27,8 @@ describe('#taskListController', () => {
     jest.resetAllMocks()
 
     jest
-      .spyOn(Wreck, 'get')
-      .mockReturnValue({ payload: { value: mockExemption } })
+      .spyOn(authRequests, 'authenticatedGetRequest')
+      .mockResolvedValue({ payload: { value: mockExemption } })
 
     getExemptionCacheSpy = jest
       .spyOn(cacheUtils, 'getExemptionCache')
@@ -78,9 +77,9 @@ describe('#taskListController', () => {
 
     await taskListController.handler({}, h)
 
-    expect(Wreck.get).toHaveBeenCalledWith(
-      `${config.get('backend').apiUrl}/exemption/${mockExemption.id}`,
-      { json: true }
+    expect(authRequests.authenticatedGetRequest).toHaveBeenCalledWith(
+      expect.any(Object),
+      `/exemption/${mockExemption.id}`
     )
 
     expect(h.view).toHaveBeenCalledWith(TASK_LIST_VIEW_ROUTE, {


### PR DESCRIPTION
- Add a helper that reads the auth token from the cache and appends to every request
- Use helper to replace the standard Wreck requests