### PR TITLE
ML-277:  Manage defra account header link

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -30,28 +30,28 @@ services:
         aliases:
           - localhost
 
-  marine-licensing-frontend:
-    build: ./
-    ports:
-      - '3000:3000'
-    env_file:
-      - 'compose/aws.env'
-    environment:
-      PORT: 3000
-      DEFRA_ID_ENABLED: true
-      NODE_ENV: development
-      USE_SINGLE_INSTANCE_CACHE: true
-      MARINE_LICENSING_BACKEND_API_URL: http://marine-licensing-backend:3001
-    volumes:
-      - ./user-stub.json:/user-stub.json
-    command: 'sh -c "curl -X POST -H \"Content-Type: application/json\" -d @/user-stub.json \"http://defra-id-stub:3200/cdp-defra-id-stub/API/register\" & node ."'
-    depends_on:
-      defra-id-stub:
-        condition: service_healthy
-    networks:
-      - cdp-tenant
-    extra_hosts:
-      - 'localhost:host-gateway'
+  # marine-licensing-frontend:
+  #   build: ./
+  #   ports:
+  #     - '3000:3000'
+  #   env_file:
+  #     - 'compose/aws.env'
+  #   environment:
+  #     PORT: 3000
+  #     DEFRA_ID_ENABLED: true
+  #     NODE_ENV: development
+  #     USE_SINGLE_INSTANCE_CACHE: true
+  #     MARINE_LICENSING_BACKEND_API_URL: http://marine-licensing-backend:3001
+  #   volumes:
+  #     - ./user-stub.json:/user-stub.json
+  #   command: 'sh -c "curl -X POST -H \"Content-Type: application/json\" -d @/user-stub.json \"http://defra-id-stub:3200/cdp-defra-id-stub/API/register\" & node ."'
+  #   depends_on:
+  #     defra-id-stub:
+  #       condition: service_healthy
+  #   networks:
+  #     - cdp-tenant
+  #   extra_hosts:
+  #     - 'localhost:host-gateway'
 
 networks:
   cdp-tenant:

--- a/compose.yml
+++ b/compose.yml
@@ -30,28 +30,28 @@ services:
         aliases:
           - localhost
 
-  # marine-licensing-frontend:
-  #   build: ./
-  #   ports:
-  #     - '3000:3000'
-  #   env_file:
-  #     - 'compose/aws.env'
-  #   environment:
-  #     PORT: 3000
-  #     DEFRA_ID_ENABLED: true
-  #     NODE_ENV: development
-  #     USE_SINGLE_INSTANCE_CACHE: true
-  #     MARINE_LICENSING_BACKEND_API_URL: http://marine-licensing-backend:3001
-  #   volumes:
-  #     - ./user-stub.json:/user-stub.json
-  #   command: 'sh -c "curl -X POST -H \"Content-Type: application/json\" -d @/user-stub.json \"http://defra-id-stub:3200/cdp-defra-id-stub/API/register\" & node ."'
-  #   depends_on:
-  #     defra-id-stub:
-  #       condition: service_healthy
-  #   networks:
-  #     - cdp-tenant
-  #   extra_hosts:
-  #     - 'localhost:host-gateway'
+  marine-licensing-frontend:
+    build: ./
+    ports:
+      - '3000:3000'
+    env_file:
+      - 'compose/aws.env'
+    environment:
+      PORT: 3000
+      DEFRA_ID_ENABLED: true
+      NODE_ENV: development
+      USE_SINGLE_INSTANCE_CACHE: true
+      MARINE_LICENSING_BACKEND_API_URL: http://marine-licensing-backend:3001
+    volumes:
+      - ./user-stub.json:/user-stub.json
+    command: 'sh -c "curl -X POST -H \"Content-Type: application/json\" -d @/user-stub.json \"http://defra-id-stub:3200/cdp-defra-id-stub/API/register\" & node ."'
+    depends_on:
+      defra-id-stub:
+        condition: service_healthy
+    networks:
+      - cdp-tenant
+    extra_hosts:
+      - 'localhost:host-gateway'
 
 networks:
   cdp-tenant:

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -240,6 +240,12 @@ export const config = convict({
     }
   },
   defraId: {
+    accountManagementUrl: {
+      doc: 'Defra ID account management portal URL',
+      format: String,
+      env: 'DEFRA_ID_ACCOUNT_MANAGEMENT_URL',
+      default: '#'
+    },
     authEnabled: {
       doc: 'DEFRA ID Auth enabled',
       format: Boolean,

--- a/src/config/nunjucks/context/build-navigation.js
+++ b/src/config/nunjucks/context/build-navigation.js
@@ -1,14 +1,29 @@
+import { getUserSession } from '~/src/server/common/plugins/auth/utils.js'
+import { config } from '~/src/config/config.js'
+
 /**
  * @param {Partial<Request> | null} request
  */
-export function buildNavigation(request) {
-  return [
+export const buildNavigation = async (request) => {
+  const { accountManagementUrl } = config.get('defraId')
+  const authedUser = await getUserSession(request)
+
+  const navigation = [
     {
       text: 'Home',
       url: '/',
       isActive: request?.path === '/'
     }
   ]
+
+  if (authedUser?.strategy === 'defraId') {
+    navigation.push({
+      text: 'Manage account',
+      url: accountManagementUrl
+    })
+  }
+
+  return navigation
 }
 
 /**

--- a/src/config/nunjucks/context/build-navigation.js
+++ b/src/config/nunjucks/context/build-navigation.js
@@ -19,7 +19,7 @@ export const buildNavigation = async (request) => {
 
   if (authedUser?.strategy === 'defraId') {
     navigation.push({
-      text: 'Manage account',
+      text: 'Defra account',
       href: accountManagementUrl
     })
   }

--- a/src/config/nunjucks/context/build-navigation.test.js
+++ b/src/config/nunjucks/context/build-navigation.test.js
@@ -8,9 +8,9 @@ function mockRequest(options) {
 }
 
 describe('#buildNavigation', () => {
-  test('Should provide expected navigation details', () => {
+  test('Should provide expected navigation details', async () => {
     expect(
-      buildNavigation(mockRequest({ path: '/non-existent-path' }))
+      await buildNavigation(mockRequest({ path: '/non-existent-path' }))
     ).toEqual([
       {
         isActive: false,
@@ -20,8 +20,8 @@ describe('#buildNavigation', () => {
     ])
   })
 
-  test('Should provide expected highlighted navigation details', () => {
-    expect(buildNavigation(mockRequest({ path: '/' }))).toEqual([
+  test('Should provide expected highlighted navigation details', async () => {
+    expect(await buildNavigation(mockRequest({ path: '/' }))).toEqual([
       {
         isActive: true,
         text: 'Home',

--- a/src/config/nunjucks/context/context.js
+++ b/src/config/nunjucks/context/context.js
@@ -19,7 +19,7 @@ let webpackManifest
 /**
  * @param {Request | null} request
  */
-export function context(request) {
+export async function context(request) {
   if (!webpackManifest) {
     try {
       webpackManifest = JSON.parse(readFileSync(manifestPath, 'utf-8'))
@@ -28,13 +28,15 @@ export function context(request) {
     }
   }
 
+  const navigation = await buildNavigation(request)
+
   return {
     assetPath: `${assetPath}/assets`,
     serviceName: config.get('serviceName'),
     serviceUrl: '/',
     signOutUrl: routes.SIGN_OUT,
     breadcrumbs: [],
-    navigation: buildNavigation(request),
+    navigation,
 
     /**
      * @param {string} asset

--- a/src/config/nunjucks/context/context.test.js
+++ b/src/config/nunjucks/context/context.test.js
@@ -90,7 +90,7 @@ describe('#context', () => {
             href: '/home'
           },
           {
-            text: 'Manage account',
+            text: 'Defra account',
             href: '#'
           }
         ])

--- a/src/server/common/templates/layouts/page.njk
+++ b/src/server/common/templates/layouts/page.njk
@@ -14,6 +14,11 @@
   <link href="{{ getAssetPath('stylesheets/application.scss') }}" rel="stylesheet">
 {% endblock %}
 
+{% set navigationLinks = navigation.concat({
+      text: 'Sign out',
+      href: signOutUrl
+}) %}
+
 {% block header %}
   {{ govukHeader({
     homepageUrl: "https://www.gov.uk/",
@@ -24,10 +29,7 @@
 
   {{ govukServiceNavigation({
     serviceName: serviceName,
-    navigation: [{
-      text: 'Sign out',
-      href: signOutUrl
-    }]
+    navigation: navigationLinks
   }) }}
 {% endblock %}
 

--- a/user-stub.json
+++ b/user-stub.json
@@ -1,6 +1,7 @@
 {
   "userId": "05e8abef-790c-48a9-a266-97de0b1da1e4",
   "email": "05e8abef-790c-48a9-a266-97de0b1da1e4@example.com",
+  "contactId": "06b68b07-9296-4f7c-b74d-5fd59ef2a513",
   "firstName": "John",
   "lastName": "Doe",
   "loa": "1",


### PR DESCRIPTION
- Add a header link 'Defra account' that links to the Defra account management page
- Only enabled when using real Defra ID

**General Improvements**
- Add contactId to stub to prevent new ID's being generated each time the containers are started. This is useful to persist exemption data while developing.