### PR TITLE
ML-99 continue draft notification from dashboard

### DIFF
--- a/src/server/exemption/dashboard/controller.test.js
+++ b/src/server/exemption/dashboard/controller.test.js
@@ -94,7 +94,7 @@ describe('#dashboard', () => {
           },
           { text: '-' },
           {
-            html: '<a href="/exemption/task-list/abc123" class="govuk-link">Continue</a>'
+            html: '<a href="/exemption/task-list/abc123" class="govuk-link" aria-label="Continue to task list">Continue</a>'
           }
         ]
       ])

--- a/src/server/exemption/dashboard/controller.test.js
+++ b/src/server/exemption/dashboard/controller.test.js
@@ -224,9 +224,9 @@ describe('#dashboard', () => {
 
       const { document } = new JSDOM(result).window
 
-      const continueLink = Array.from(document.querySelectorAll('a')).find(
-        (el) => el.textContent.trim() === 'Continue'
-      )
+      const continueLink = Array.from(
+        document.querySelectorAll('a,button')
+      ).find((el) => el.textContent.trim() === 'Continue')
       expect(continueLink).toBeTruthy()
       expect(continueLink.getAttribute('href')).toBe(
         `/exemption/task-list/${draftExemption.id}`

--- a/src/server/exemption/dashboard/controller.test.js
+++ b/src/server/exemption/dashboard/controller.test.js
@@ -10,6 +10,7 @@ import { formatDate } from '~/src/config/nunjucks/filters/format-date.js'
 
 jest.mock('~/src/server/common/helpers/authenticated-requests.js')
 jest.mock('~/src/config/nunjucks/filters/format-date.js')
+jest.mock('~/src/server/exemption/task-list/controller.js')
 
 describe('#dashboard', () => {
   /** @type {Server} */
@@ -196,6 +197,36 @@ describe('#dashboard', () => {
         heading: 'Your projects',
         projects: []
       })
+    })
+
+    test('Should display Continue link for draft exemptions pointing to /exemption/task-list/{id}', async () => {
+      const draftExemption = {
+        projectName: 'Draft Exemption',
+        type: 'Exempt activity',
+        reference: 'ML-2024-003',
+        status: 'Draft',
+        submittedAt: null,
+        id: 'abc123'
+      }
+
+      authenticatedGetRequestMock.mockResolvedValueOnce({
+        payload: { value: [draftExemption] }
+      })
+
+      const { result } = await server.inject({
+        method: 'GET',
+        url: routes.DASHBOARD
+      })
+
+      const { document } = new JSDOM(result).window
+
+      const continueLink = document
+        .querySelectorAll('a,button')
+        .find((el) => el.textContent.trim() === 'Continue')
+      expect(continueLink).toBeTruthy()
+      expect(continueLink.getAttribute('href')).toBe(
+        `/exemption/task-list/${draftExemption.id}`
+      )
     })
   })
 })

--- a/src/server/exemption/dashboard/controller.test.js
+++ b/src/server/exemption/dashboard/controller.test.js
@@ -73,6 +73,7 @@ describe('#dashboard', () => {
 
       const projects = [
         {
+          id: 'abc123',
           projectName: 'Test Project',
           type: 'Exempt activity',
           reference: 'ML-2024-001',
@@ -91,7 +92,10 @@ describe('#dashboard', () => {
           {
             html: '<strong class="govuk-tag govuk-tag--light-blue">Draft</strong>'
           },
-          { text: '-' }
+          { text: '-' },
+          {
+            html: '<a href="/exemption/task-list/abc123" class="govuk-link">Continue</a>'
+          }
         ]
       ])
 
@@ -220,9 +224,9 @@ describe('#dashboard', () => {
 
       const { document } = new JSDOM(result).window
 
-      const continueLink = document
-        .querySelectorAll('a,button')
-        .find((el) => el.textContent.trim() === 'Continue')
+      const continueLink = Array.from(document.querySelectorAll('a')).find(
+        (el) => el.textContent.trim() === 'Continue'
+      )
       expect(continueLink).toBeTruthy()
       expect(continueLink.getAttribute('href')).toBe(
         `/exemption/task-list/${draftExemption.id}`

--- a/src/server/exemption/dashboard/index.njk
+++ b/src/server/exemption/dashboard/index.njk
@@ -46,6 +46,12 @@
               attributes: {
                 "aria-sort": "none"
               }
+            },
+            {
+              text: "Actions",
+              attributes: {
+                "aria-sort": "none"
+              }
             }
           ],
           rows: projects

--- a/src/server/exemption/dashboard/utils.js
+++ b/src/server/exemption/dashboard/utils.js
@@ -5,7 +5,7 @@ export const getActionButtons = (project) => {
   let buttons = ''
 
   if (project.status === 'Draft') {
-    buttons = `<a href="${routes.TASK_LIST}/${project.id}" class="govuk-link">Continue</a>`
+    buttons = `<a href="${routes.TASK_LIST}/${project.id}" class="govuk-link" aria-label="Continue to task list">Continue</a>`
   }
 
   return buttons

--- a/src/server/exemption/dashboard/utils.js
+++ b/src/server/exemption/dashboard/utils.js
@@ -1,4 +1,15 @@
 import { formatDate } from '~/src/config/nunjucks/filters/format-date.js'
+import { routes } from '~/src/server/common/constants/routes.js'
+
+export const getActionButtons = (project) => {
+  let buttons = ''
+
+  if (project.status === 'Draft') {
+    buttons = `<a href="${routes.TASK_LIST}/${project.id}" class="govuk-link">Continue</a>`
+  }
+
+  return buttons
+}
 
 export const formatProjectsForDisplay = (projects) =>
   projects.map((project) => {
@@ -16,6 +27,7 @@ export const formatProjectsForDisplay = (projects) =>
         text: project.submittedAt
           ? formatDate(project.submittedAt, 'd MMM yyyy')
           : '-'
-      }
+      },
+      { html: getActionButtons(project) }
     ]
   })

--- a/src/server/exemption/dashboard/utils.test.js
+++ b/src/server/exemption/dashboard/utils.test.js
@@ -40,7 +40,7 @@ describe('#formatProjectsForDisplay', () => {
         },
         { text: '15 Jan 2024' },
         {
-          html: '<a href="/exemption/task-list/abc123" class="govuk-link">Continue</a>'
+          html: '<a href="/exemption/task-list/abc123" class="govuk-link" aria-label="Continue to task list">Continue</a>'
         }
       ]
     ])
@@ -70,7 +70,7 @@ describe('#formatProjectsForDisplay', () => {
         },
         { text: '-' },
         {
-          html: '<a href="/exemption/task-list/abc123" class="govuk-link">Continue</a>'
+          html: '<a href="/exemption/task-list/abc123" class="govuk-link" aria-label="Continue to task list">Continue</a>'
         }
       ]
     ])
@@ -107,7 +107,7 @@ describe('#formatProjectsForDisplay', () => {
       },
       { text: '15 Jan 2024' },
       {
-        html: '<a href="/exemption/task-list/abc123" class="govuk-link">Continue</a>'
+        html: '<a href="/exemption/task-list/abc123" class="govuk-link" aria-label="Continue to task list">Continue</a>'
       }
     ])
     expect(result[1]).toEqual([
@@ -160,7 +160,7 @@ describe('getActionButtons', () => {
     const draft = { id: 'abc123', status: 'Draft' }
     const result = getActionButtons(draft)
     expect(result).toBe(
-      `<a href="${routes.TASK_LIST}/abc123" class="govuk-link">Continue</a>`
+      `<a href="${routes.TASK_LIST}/abc123" class="govuk-link" aria-label="Continue to task list">Continue</a>`
     )
   })
 

--- a/src/server/exemption/dashboard/utils.test.js
+++ b/src/server/exemption/dashboard/utils.test.js
@@ -1,5 +1,6 @@
 import { formatDate } from '~/src/config/nunjucks/filters/format-date.js'
-import { formatProjectsForDisplay } from './utils.js'
+import { formatProjectsForDisplay, getActionButtons } from './utils.js'
+import { routes } from '~/src/server/common/constants/routes.js'
 
 jest.mock('~/src/config/nunjucks/filters/format-date.js')
 
@@ -18,6 +19,7 @@ describe('#formatProjectsForDisplay', () => {
   test('Should format a complete project with all fields', () => {
     const projects = [
       {
+        id: 'abc123',
         projectName: 'Test Project',
         type: 'Exempt activity',
         applicationReference: 'ML-2024-001',
@@ -36,7 +38,10 @@ describe('#formatProjectsForDisplay', () => {
         {
           html: '<strong class="govuk-tag govuk-tag--light-blue">Draft</strong>'
         },
-        { text: '15 Jan 2024' }
+        { text: '15 Jan 2024' },
+        {
+          html: '<a href="/exemption/task-list/abc123" class="govuk-link">Continue</a>'
+        }
       ]
     ])
   })
@@ -44,6 +49,7 @@ describe('#formatProjectsForDisplay', () => {
   test('Should format project with missing data', () => {
     const projects = [
       {
+        id: 'abc123',
         projectName: 'Test Project',
         type: 'Exempt activity',
         applicationReference: null,
@@ -62,7 +68,10 @@ describe('#formatProjectsForDisplay', () => {
         {
           html: '<strong class="govuk-tag govuk-tag--light-blue">Draft</strong>'
         },
-        { text: '-' }
+        { text: '-' },
+        {
+          html: '<a href="/exemption/task-list/abc123" class="govuk-link">Continue</a>'
+        }
       ]
     ])
   })
@@ -70,6 +79,7 @@ describe('#formatProjectsForDisplay', () => {
   test('Should format multiple projects correctly', () => {
     const projects = [
       {
+        id: 'abc123',
         projectName: 'Project 1',
         type: 'Exempt activity',
         applicationReference: 'ML-2024-001',
@@ -95,7 +105,10 @@ describe('#formatProjectsForDisplay', () => {
       {
         html: '<strong class="govuk-tag govuk-tag--light-blue">Draft</strong>'
       },
-      { text: '15 Jan 2024' }
+      { text: '15 Jan 2024' },
+      {
+        html: '<a href="/exemption/task-list/abc123" class="govuk-link">Continue</a>'
+      }
     ])
     expect(result[1]).toEqual([
       { text: 'Project 2' },
@@ -104,7 +117,8 @@ describe('#formatProjectsForDisplay', () => {
       {
         html: '<strong class="govuk-tag govuk-tag--green">Closed</strong>'
       },
-      { text: '25 Jun 2024' }
+      { text: '25 Jun 2024' },
+      { html: '' }
     ])
   })
 
@@ -138,5 +152,21 @@ describe('#formatProjectsForDisplay', () => {
     expect(result[0][3].html).toContain('Draft')
     expect(result[1][3].html).toContain('govuk-tag--green')
     expect(result[1][3].html).toContain('Closed')
+  })
+})
+
+describe('getActionButtons', () => {
+  it('returns Continue button for draft exemption', () => {
+    const draft = { id: 'abc123', status: 'Draft' }
+    const result = getActionButtons(draft)
+    expect(result).toBe(
+      `<a href="${routes.TASK_LIST}/abc123" class="govuk-link">Continue</a>`
+    )
+  })
+
+  it('returns no html when not a draft', () => {
+    const submitted = { id: 'abc123', status: 'Closed' }
+    const result = getActionButtons(submitted)
+    expect(result).toBe('')
   })
 })

--- a/src/server/exemption/index.test.js
+++ b/src/server/exemption/index.test.js
@@ -32,6 +32,10 @@ describe('exemption route', () => {
       }),
       expect.objectContaining({
         method: 'GET',
+        path: '/exemption/task-list/{exemptionId}'
+      }),
+      expect.objectContaining({
+        method: 'GET',
         path: '/exemption/how-do-you-want-to-provide-the-coordinates'
       }),
       expect.objectContaining({

--- a/src/server/exemption/task-list/controller.js
+++ b/src/server/exemption/task-list/controller.js
@@ -54,7 +54,7 @@ export const taskListController = {
       projectName,
       publicRegister,
       siteDetails
-    } = payload?.value
+    } = payload.value
 
     const taskListTransformed = transformTaskList(taskList)
     const hasCompletedAllTasks = taskListTransformed?.every(

--- a/src/server/exemption/task-list/controller.js
+++ b/src/server/exemption/task-list/controller.js
@@ -1,6 +1,8 @@
 import {
   getExemptionCache,
-  resetExemptionSiteDetails
+  resetExemptionSiteDetails,
+  clearExemptionCache,
+  setExemptionCache
 } from '~/src/server/common/helpers/session-cache/utils.js'
 import { transformTaskList } from '~/src/server/exemption/task-list/utils.js'
 import { routes } from '~/src/server/common/constants/routes.js'
@@ -44,17 +46,48 @@ export const taskListController = {
       `/exemption/${id}`
     )
 
-    const taskList = transformTaskList(payload?.value?.taskList)
-    const hasCompletedAllTasks = taskList?.every(
+    const {
+      id: exemptionId,
+      taskList,
+      activityDates,
+      activityDescription,
+      projectName,
+      publicRegister,
+      siteDetails
+    } = payload?.value
+
+    const taskListTransformed = transformTaskList(taskList)
+    const hasCompletedAllTasks = taskListTransformed?.every(
       (task) => task.status.text === 'Completed'
     )
+
+    setExemptionCache(request, {
+      id: exemptionId,
+      activityDates,
+      activityDescription,
+      projectName,
+      publicRegister,
+      siteDetails
+    })
 
     return h.view(TASK_LIST_VIEW_ROUTE, {
       ...taskListViewSettings,
       projectName: payload.value.projectName,
-      taskList,
+      taskList: taskListTransformed,
       hasCompletedAllTasks
     })
+  }
+}
+
+/**
+ * Controller for selecting an exemption and redirecting to the task list.
+ */
+export const taskListSelectExemptionController = {
+  handler(request, h) {
+    const { exemptionId } = request.params
+    clearExemptionCache(request)
+    setExemptionCache(request, { id: exemptionId })
+    return h.redirect(routes.TASK_LIST)
   }
 }
 

--- a/src/server/exemption/task-list/index.js
+++ b/src/server/exemption/task-list/index.js
@@ -1,4 +1,7 @@
-import { taskListController } from '~/src/server/exemption/task-list/controller.js'
+import {
+  taskListController,
+  taskListSelectExemptionController
+} from '~/src/server/exemption/task-list/controller.js'
 import { routes } from '~/src/server/common/constants/routes.js'
 
 /**
@@ -14,6 +17,11 @@ export const taskListRoutes = [
     method: 'GET',
     path: routes.TASK_LIST,
     ...taskListController
+  },
+  {
+    method: 'GET',
+    path: routes.TASK_LIST + '/{exemptionId}',
+    ...taskListSelectExemptionController
   }
 ]
 

--- a/src/server/exemption/task-list/index.test.js
+++ b/src/server/exemption/task-list/index.test.js
@@ -8,5 +8,11 @@ describe('taskList routes', () => {
         path: '/exemption/task-list'
       })
     )
+    expect(taskListRoutes[1]).toEqual(
+      expect.objectContaining({
+        method: 'GET',
+        path: '/exemption/task-list/{exemptionId}'
+      })
+    )
   })
 })


### PR DESCRIPTION
- Continue button and actions column added to Dashboard
- Go to /task-list/{exemptionId} which will clear the cache before returning to the task-list page
- Use details from the existing server request to populate the cache