### PR TITLE
Feature/ml 74 review site details

### DIFF
--- a/.cursor/rules/javascript.mdc
+++ b/.cursor/rules/javascript.mdc
@@ -103,3 +103,6 @@ globs: *.js
 - Bind controller methods when used as route handlers
 - Follow template inheritance patterns from gov-uk-standards
 - Keep templates close to their feature modules
+
+## SonarQube
+- do not assign to undefined; use null

--- a/src/config/nunjucks/filters/filters.js
+++ b/src/config/nunjucks/filters/filters.js
@@ -1,2 +1,3 @@
 export { formatDate } from '~/src/config/nunjucks/filters/format-date.js'
 export { formatCurrency } from '~/src/config/nunjucks/filters/format-currency.js'
+export { sanitiseFilename } from '~/src/config/nunjucks/filters/sanitise-filename.js'

--- a/src/config/nunjucks/filters/sanitise-filename.js
+++ b/src/config/nunjucks/filters/sanitise-filename.js
@@ -1,0 +1,43 @@
+/**
+ * Sanitises and truncates a filename for safe display
+ * @param {string | null | undefined} value - The filename to sanitise
+ * @param {number} maxLength - Maximum length before truncation (default: 64)
+ * @returns {string} The sanitised and potentially truncated filename
+ */
+export function sanitiseFilename(value, maxLength = 64) {
+  const truncationToken = '...'
+  const truncationTokenLength = truncationToken.length
+  const wordBoundarySearchLength = 8
+
+  // Handle null, undefined, or empty values
+  if (!value || typeof value !== 'string') {
+    return ''
+  }
+
+  // Remove control characters and potentially dangerous characters
+  // Keep alphanumeric, spaces, dots, hyphens, underscores, and basic punctuation
+  const sanitised = value
+    .replace(/[^ -~]/g, '') // e.g. allow space through to tilde
+    .replace(/[<>:"/\\|?*]/g, '') // Remove characters dangerous in filenames/HTML
+    .replace(/\s+/g, ' ') // Normalise whitespace
+    .trim()
+
+  // Handle truncation
+  if (sanitised.length <= maxLength) {
+    return sanitised
+  }
+
+  // Truncate and add ellipsis, ensuring we don't break in the middle of a word if possible
+  const truncated = sanitised.substring(0, maxLength - truncationTokenLength)
+  const lastSpaceIndex = truncated.lastIndexOf(' ')
+
+  // If there's a space within the last 8 characters, break at the word boundary
+  if (
+    lastSpaceIndex >
+    maxLength - (wordBoundarySearchLength + truncationTokenLength)
+  ) {
+    return truncated.substring(0, lastSpaceIndex) + truncationToken
+  }
+
+  return truncated + truncationToken
+}

--- a/src/config/nunjucks/filters/sanitise-filename.test.js
+++ b/src/config/nunjucks/filters/sanitise-filename.test.js
@@ -1,0 +1,123 @@
+import { sanitiseFilename } from '~/src/config/nunjucks/filters/sanitise-filename.js'
+
+describe('#sanitiseFilename', () => {
+  describe('With normal filenames', () => {
+    test('Should return short filename unchanged', () => {
+      expect(sanitiseFilename('document.pdf')).toBe('document.pdf')
+    })
+
+    test('Should return filename with spaces unchanged when under limit', () => {
+      expect(sanitiseFilename('my document file.pdf')).toBe(
+        'my document file.pdf'
+      )
+    })
+  })
+
+  describe('With long filenames', () => {
+    test('Should truncate long filename and add ellipsis', () => {
+      const longFilename =
+        'this-is-a-very-very-very-long-filename-that-exceeds-the-limit.pdf'
+      const result = sanitiseFilename(longFilename)
+      expect(result).toBe(
+        'this-is-a-very-very-very-long-filename-that-exceeds-the-limit...'
+      )
+      expect(result).toHaveLength(64)
+    })
+
+    test('Should break at word boundary when possible', () => {
+      const filename =
+        'my very very very long document file name write a short letter to grandma that is too big.pdf'
+      const result = sanitiseFilename(filename)
+      expect(result).toMatch(/\.\.\.$/)
+      expect(result.length).toBeLessThanOrEqual(64)
+      expect(result).not.toMatch(/\s\.\.\.$/) // Should not end with space before ellipsis
+    })
+  })
+
+  describe('With dangerous characters', () => {
+    test('Should remove HTML/XML dangerous characters', () => {
+      expect(sanitiseFilename('file<script>alert("xss")</script>.pdf')).toBe(
+        'filescriptalert(xss)script.pdf'
+      )
+    })
+
+    test('Should remove path traversal characters', () => {
+      expect(sanitiseFilename('../../../etc/passwd')).toBe('......etcpasswd')
+    })
+
+    test('Should remove control characters', () => {
+      expect(sanitiseFilename('file\x00\x01\x1f.pdf')).toBe('file.pdf')
+    })
+
+    test('Should remove filesystem dangerous characters', () => {
+      expect(sanitiseFilename('file:name|with*dangerous?chars.pdf')).toBe(
+        'filenamewithdangerouschars.pdf'
+      )
+    })
+  })
+
+  describe('With whitespace issues', () => {
+    test('Should normalise multiple spaces', () => {
+      expect(sanitiseFilename('file    with    spaces.pdf')).toBe(
+        'file with spaces.pdf'
+      )
+    })
+
+    test('Should trim leading and trailing spaces', () => {
+      expect(sanitiseFilename('  spaced file.pdf  ')).toBe('spaced file.pdf')
+    })
+  })
+
+  describe('With edge cases', () => {
+    test('Should handle null input', () => {
+      expect(sanitiseFilename(null)).toBe('')
+    })
+
+    test('Should handle undefined input', () => {
+      expect(sanitiseFilename(undefined)).toBe('')
+    })
+
+    test('Should handle empty string', () => {
+      expect(sanitiseFilename('')).toBe('')
+    })
+
+    test('Should handle non-string input', () => {
+      expect(sanitiseFilename(123)).toBe('')
+    })
+
+    test('Should handle string of only dangerous characters', () => {
+      expect(sanitiseFilename('<>:"/\\|?*')).toBe('')
+    })
+  })
+
+  describe('With custom maxLength', () => {
+    test('Should respect custom maxLength parameter', () => {
+      const filename = 'this is a long filename'
+      const result = sanitiseFilename(filename, 10)
+      expect(result).toBe('this...')
+      expect(result).toHaveLength(7)
+    })
+
+    test('Should not truncate when filename is shorter than custom maxLength', () => {
+      const filename = 'short.pdf'
+      const result = sanitiseFilename(filename, 50)
+      expect(result).toBe('short.pdf')
+    })
+  })
+
+  describe('Word boundary handling', () => {
+    test('Should break at word boundary when space is near end', () => {
+      // Create a filename where breaking at word boundary makes sense
+      const filename = 'document name that is quite long indeed.pdf'
+      const result = sanitiseFilename(filename, 25)
+      expect(result).toMatch(/^document name that is...$/)
+    })
+
+    test('Should hard truncate when no good word boundary exists', () => {
+      const filename = 'verylongfilenamewithnospacesorwordbreaks.pdf'
+      const result = sanitiseFilename(filename, 20)
+      expect(result).toBe('verylongfilenamew...')
+      expect(result).toHaveLength(20)
+    })
+  })
+})

--- a/src/server/common/helpers/coordinate-utils.js
+++ b/src/server/common/helpers/coordinate-utils.js
@@ -1,0 +1,22 @@
+/**
+ * Extract coordinate data from GeoJSON for display purposes
+ * @param {object} geoJSON - GeoJSON object containing features
+ * @returns {Array} Array of extracted coordinates with type and coordinates properties
+ */
+export function extractCoordinatesFromGeoJSON(geoJSON) {
+  if (!geoJSON?.features) {
+    return []
+  }
+
+  const extractedCoordinates = []
+  for (const feature of geoJSON.features) {
+    if (feature.geometry?.coordinates) {
+      extractedCoordinates.push({
+        type: feature.geometry.type,
+        coordinates: feature.geometry.coordinates
+      })
+    }
+  }
+
+  return extractedCoordinates
+}

--- a/src/server/common/helpers/coordinate-utils.test.js
+++ b/src/server/common/helpers/coordinate-utils.test.js
@@ -1,0 +1,224 @@
+import { extractCoordinatesFromGeoJSON } from '~/src/server/common/helpers/coordinate-utils.js'
+
+describe('coordinate-utils', () => {
+  describe('extractCoordinatesFromGeoJSON', () => {
+    test('should extract coordinates from valid GeoJSON with Polygon feature', () => {
+      const geoJSON = {
+        type: 'FeatureCollection',
+        features: [
+          {
+            type: 'Feature',
+            geometry: {
+              type: 'Polygon',
+              coordinates: [
+                [
+                  [-1.3995, 55.019889],
+                  [-1.399, 55.019889],
+                  [-1.399, 55.02],
+                  [-1.3995, 55.02],
+                  [-1.3995, 55.019889]
+                ]
+              ]
+            }
+          }
+        ]
+      }
+
+      const result = extractCoordinatesFromGeoJSON(geoJSON)
+
+      expect(result).toEqual([
+        {
+          type: 'Polygon',
+          coordinates: [
+            [
+              [-1.3995, 55.019889],
+              [-1.399, 55.019889],
+              [-1.399, 55.02],
+              [-1.3995, 55.02],
+              [-1.3995, 55.019889]
+            ]
+          ]
+        }
+      ])
+    })
+
+    test('should extract coordinates from GeoJSON with Point feature', () => {
+      const geoJSON = {
+        type: 'FeatureCollection',
+        features: [
+          {
+            type: 'Feature',
+            geometry: {
+              type: 'Point',
+              coordinates: [-1.3995, 55.019889]
+            }
+          }
+        ]
+      }
+
+      const result = extractCoordinatesFromGeoJSON(geoJSON)
+
+      expect(result).toEqual([
+        {
+          type: 'Point',
+          coordinates: [-1.3995, 55.019889]
+        }
+      ])
+    })
+
+    test('should extract coordinates from GeoJSON with multiple features', () => {
+      const geoJSON = {
+        type: 'FeatureCollection',
+        features: [
+          {
+            type: 'Feature',
+            geometry: {
+              type: 'Point',
+              coordinates: [-1.3995, 55.019889]
+            }
+          },
+          {
+            type: 'Feature',
+            geometry: {
+              type: 'LineString',
+              coordinates: [
+                [-1.3995, 55.019889],
+                [-1.399, 55.02]
+              ]
+            }
+          }
+        ]
+      }
+
+      const result = extractCoordinatesFromGeoJSON(geoJSON)
+
+      expect(result).toEqual([
+        {
+          type: 'Point',
+          coordinates: [-1.3995, 55.019889]
+        },
+        {
+          type: 'LineString',
+          coordinates: [
+            [-1.3995, 55.019889],
+            [-1.399, 55.02]
+          ]
+        }
+      ])
+    })
+
+    test('should skip features without geometry', () => {
+      const geoJSON = {
+        type: 'FeatureCollection',
+        features: [
+          {
+            type: 'Feature',
+            properties: { name: 'Feature without geometry' }
+          },
+          {
+            type: 'Feature',
+            geometry: {
+              type: 'Point',
+              coordinates: [-1.3995, 55.019889]
+            }
+          }
+        ]
+      }
+
+      const result = extractCoordinatesFromGeoJSON(geoJSON)
+
+      expect(result).toEqual([
+        {
+          type: 'Point',
+          coordinates: [-1.3995, 55.019889]
+        }
+      ])
+    })
+
+    test('should skip features without coordinates', () => {
+      const geoJSON = {
+        type: 'FeatureCollection',
+        features: [
+          {
+            type: 'Feature',
+            geometry: {
+              type: 'Point'
+              // missing coordinates
+            }
+          },
+          {
+            type: 'Feature',
+            geometry: {
+              type: 'Point',
+              coordinates: [-1.3995, 55.019889]
+            }
+          }
+        ]
+      }
+
+      const result = extractCoordinatesFromGeoJSON(geoJSON)
+
+      expect(result).toEqual([
+        {
+          type: 'Point',
+          coordinates: [-1.3995, 55.019889]
+        }
+      ])
+    })
+
+    test('should return empty array for null or undefined geoJSON', () => {
+      expect(extractCoordinatesFromGeoJSON(null)).toEqual([])
+      expect(extractCoordinatesFromGeoJSON(undefined)).toEqual([])
+    })
+
+    test('should return empty array for geoJSON without features', () => {
+      const geoJSON = {
+        type: 'FeatureCollection'
+        // missing features
+      }
+
+      const result = extractCoordinatesFromGeoJSON(geoJSON)
+
+      expect(result).toEqual([])
+    })
+
+    test('should return empty array for geoJSON with empty features array', () => {
+      const geoJSON = {
+        type: 'FeatureCollection',
+        features: []
+      }
+
+      const result = extractCoordinatesFromGeoJSON(geoJSON)
+
+      expect(result).toEqual([])
+    })
+
+    test('should handle features with null geometry', () => {
+      const geoJSON = {
+        type: 'FeatureCollection',
+        features: [
+          {
+            type: 'Feature',
+            geometry: null
+          },
+          {
+            type: 'Feature',
+            geometry: {
+              type: 'Point',
+              coordinates: [-1.3995, 55.019889]
+            }
+          }
+        ]
+      }
+
+      const result = extractCoordinatesFromGeoJSON(geoJSON)
+
+      expect(result).toEqual([
+        {
+          type: 'Point',
+          coordinates: [-1.3995, 55.019889]
+        }
+      ])
+    })
+  })
+})

--- a/src/server/common/helpers/session-cache/utils.js
+++ b/src/server/common/helpers/session-cache/utils.js
@@ -35,7 +35,7 @@ export const setExemptionCache = (request, value) => {
 export const updateExemptionSiteDetails = (request, key, value) => {
   const existingCache = getExemptionCache(request)
   const existingSiteDetails = existingCache.siteDetails
-  const cacheValue = value || undefined
+  const cacheValue = value ?? null
 
   request.yar.set(EXEMPTION_CACHE_KEY, {
     ...existingCache,
@@ -68,4 +68,26 @@ export const getCoordinateSystem = (request) => {
       : COORDINATE_SYSTEMS.WGS84
 
   return { coordinateSystem }
+}
+
+/**
+ * @param { Request } request
+ * @param { object } updates - Object containing key-value pairs to update in siteDetails
+ */
+export const updateExemptionSiteDetailsBatch = (request, updates) => {
+  const existingCache = getExemptionCache(request)
+  const existingSiteDetails = existingCache.siteDetails || {}
+
+  // Apply all updates in a single operation
+  const updatedSiteDetails = {
+    ...existingSiteDetails,
+    ...updates
+  }
+
+  request.yar.set(EXEMPTION_CACHE_KEY, {
+    ...existingCache,
+    siteDetails: updatedSiteDetails
+  })
+
+  return updatedSiteDetails
 }

--- a/src/server/exemption/site-details/file-upload/controller.js
+++ b/src/server/exemption/site-details/file-upload/controller.js
@@ -96,7 +96,7 @@ export const fileUploadController = {
       errors = errorDisplay.errors
 
       // Clear error from session after retrieving
-      updateExemptionSiteDetails(request, 'uploadError', undefined)
+      updateExemptionSiteDetails(request, 'uploadError', null)
 
       request.logger.debug('Displaying upload error from session', {
         message: uploadError.message,

--- a/src/server/exemption/site-details/file-upload/controller.test.js
+++ b/src/server/exemption/site-details/file-upload/controller.test.js
@@ -284,7 +284,7 @@ describe('#fileUpload', () => {
         expect(updateExemptionSiteDetailsSpy).toHaveBeenCalledWith(
           mockRequest,
           'uploadError',
-          undefined
+          null
         )
 
         expect(mockRequest.logger.debug).toHaveBeenCalledWith(

--- a/src/server/exemption/site-details/review-site-details/controller.js
+++ b/src/server/exemption/site-details/review-site-details/controller.js
@@ -5,12 +5,13 @@ import {
 } from '~/src/server/common/helpers/session-cache/utils.js'
 import { routes } from '~/src/server/common/constants/routes.js'
 import {
-  getCoordinateSystemText,
-  getReviewSummaryText,
-  getCoordinateDisplayText,
   getSiteDetailsBackLink,
   getFileUploadSummaryData,
-  getFileUploadBackLink
+  getFileUploadBackLink,
+  buildManualCoordinateSummaryData,
+  loadSiteDetailsFromMongoDB,
+  prepareFileUploadDataForSave,
+  prepareManualCoordinateDataForSave
 } from './utils.js'
 import {
   authenticatedPatchRequest,
@@ -37,30 +38,11 @@ export const reviewSiteDetailsController = {
   async handler(request, h) {
     const previousPage = request.headers?.referer
     const exemption = getExemptionCache(request)
-    let siteDetails = exemption.siteDetails ?? {}
-
-    // If we have an exemption ID but incomplete site details, load from MongoDB
-    if (exemption.id && exemption.siteDetails === undefined) {
-      try {
-        const { payload } = await authenticatedGetRequest(
-          request,
-          `/exemption/${exemption.id}`
-        )
-        if (payload?.value?.siteDetails) {
-          siteDetails = payload.value.siteDetails
-          request.logger.info('Loaded site details from MongoDB for display', {
-            exemptionId: exemption.id,
-            coordinatesType: siteDetails.coordinatesType
-          })
-        }
-      } catch (error) {
-        request.logger.error('Failed to load exemption data from MongoDB', {
-          error: error.message,
-          exemptionId: exemption.id
-        })
-        // Continue with session data even if MongoDB load fails
-      }
-    }
+    const siteDetails = await loadSiteDetailsFromMongoDB(
+      request,
+      exemption,
+      authenticatedGetRequest
+    )
 
     if (siteDetails.coordinatesType === 'file') {
       const fileUploadSummaryData = getFileUploadSummaryData({
@@ -78,14 +60,10 @@ export const reviewSiteDetailsController = {
 
     // Manual coordinate entry flow
     const { coordinateSystem } = getCoordinateSystem(request)
-    const { circleWidth } = siteDetails
-
-    const summaryData = {
-      method: getReviewSummaryText(siteDetails),
-      coordinateSystem: getCoordinateSystemText(coordinateSystem),
-      coordinates: getCoordinateDisplayText(siteDetails, coordinateSystem),
-      width: circleWidth ? `${circleWidth} metres` : ''
-    }
+    const summaryData = buildManualCoordinateSummaryData(
+      siteDetails,
+      coordinateSystem
+    )
 
     return h.view(REVIEW_SITE_DETAILS_VIEW_ROUTE, {
       ...reviewSiteDetailsPageData,
@@ -106,42 +84,10 @@ export const reviewSiteDetailsSubmitController = {
     const siteDetails = exemption.siteDetails ?? {}
 
     try {
-      let dataToSave
-
-      if (siteDetails.coordinatesType === 'file') {
-        const uploadedFile = siteDetails.uploadedFile
-        const geoJSON = siteDetails.geoJSON
-        const featureCount = siteDetails.featureCount || 0
-
-        dataToSave = {
-          coordinatesType: 'file',
-          fileUploadType: siteDetails.fileUploadType,
-          geoJSON,
-          featureCount,
-          uploadedFile: {
-            filename: uploadedFile.filename // Save filename for display
-          },
-          s3Location: {
-            s3Bucket: uploadedFile.s3Location.s3Bucket,
-            s3Key: uploadedFile.s3Location.s3Key,
-            checksumSha256: uploadedFile.s3Location.checksumSha256
-          }
-        }
-
-        request.logger.info('Saving file upload site details', {
-          fileType: siteDetails.fileUploadType,
-          featureCount,
-          filename: uploadedFile.filename
-        })
-      } else {
-        // Manual coordinate entry flow - use existing data structure
-        dataToSave = exemption.siteDetails
-
-        request.logger.info('Saving manual coordinate site details', {
-          coordinatesType: siteDetails.coordinatesType,
-          coordinatesEntry: siteDetails.coordinatesEntry
-        })
-      }
+      const dataToSave =
+        siteDetails.coordinatesType === 'file'
+          ? prepareFileUploadDataForSave(siteDetails, request)
+          : prepareManualCoordinateDataForSave(exemption, request)
 
       await authenticatedPatchRequest(request, '/exemption/site-details', {
         siteDetails: dataToSave,

--- a/src/server/exemption/site-details/review-site-details/controller.js
+++ b/src/server/exemption/site-details/review-site-details/controller.js
@@ -1,23 +1,20 @@
 import {
-  getCoordinateSystem,
   getExemptionCache,
   resetExemptionSiteDetails
 } from '~/src/server/common/helpers/session-cache/utils.js'
 import { routes } from '~/src/server/common/constants/routes.js'
 import {
-  getSiteDetailsBackLink,
-  getFileUploadSummaryData,
-  getFileUploadBackLink,
-  buildManualCoordinateSummaryData,
   loadSiteDetailsFromMongoDB,
   prepareFileUploadDataForSave,
-  prepareManualCoordinateDataForSave
+  prepareManualCoordinateDataForSave,
+  renderFileUploadReview,
+  renderManualCoordinateReview,
+  handleSubmissionError
 } from './utils.js'
 import {
   authenticatedPatchRequest,
   authenticatedGetRequest
 } from '~/src/server/common/helpers/authenticated-requests.js'
-import Boom from '@hapi/boom'
 
 export const REVIEW_SITE_DETAILS_VIEW_ROUTE =
   'exemption/site-details/review-site-details/index'
@@ -44,33 +41,22 @@ export const reviewSiteDetailsController = {
       authenticatedGetRequest
     )
 
-    if (siteDetails.coordinatesType === 'file') {
-      const fileUploadSummaryData = getFileUploadSummaryData({
-        ...exemption,
-        siteDetails
-      })
-
-      return h.view(FILE_UPLOAD_REVIEW_VIEW_ROUTE, {
-        ...reviewSiteDetailsPageData,
-        backLink: getFileUploadBackLink(previousPage),
-        projectName: exemption.projectName,
-        fileUploadSummaryData
-      })
-    }
-
-    // Manual coordinate entry flow
-    const { coordinateSystem } = getCoordinateSystem(request)
-    const summaryData = buildManualCoordinateSummaryData(
-      siteDetails,
-      coordinateSystem
-    )
-
-    return h.view(REVIEW_SITE_DETAILS_VIEW_ROUTE, {
-      ...reviewSiteDetailsPageData,
-      backLink: getSiteDetailsBackLink(previousPage),
-      projectName: exemption.projectName,
-      summaryData
-    })
+    return siteDetails.coordinatesType === 'file'
+      ? renderFileUploadReview(
+          h,
+          exemption,
+          siteDetails,
+          previousPage,
+          reviewSiteDetailsPageData
+        )
+      : renderManualCoordinateReview(
+          h,
+          request,
+          exemption,
+          siteDetails,
+          previousPage,
+          reviewSiteDetailsPageData
+        )
   }
 }
 
@@ -96,13 +82,13 @@ export const reviewSiteDetailsSubmitController = {
 
       resetExemptionSiteDetails(request)
       return h.redirect(routes.TASK_LIST)
-    } catch (e) {
-      request.logger.error('Error submitting site review', {
-        error: e.message,
-        exemptionId: exemption.id,
-        coordinatesType: siteDetails.coordinatesType
-      })
-      throw Boom.badRequest(`Error submitting site review`, e)
+    } catch (error) {
+      throw handleSubmissionError(
+        request,
+        error,
+        exemption.id,
+        siteDetails.coordinatesType
+      )
     }
   }
 }

--- a/src/server/exemption/site-details/review-site-details/controller.js
+++ b/src/server/exemption/site-details/review-site-details/controller.js
@@ -1,19 +1,28 @@
 import {
   getCoordinateSystem,
-  getExemptionCache
+  getExemptionCache,
+  resetExemptionSiteDetails
 } from '~/src/server/common/helpers/session-cache/utils.js'
 import { routes } from '~/src/server/common/constants/routes.js'
 import {
   getCoordinateSystemText,
   getReviewSummaryText,
   getCoordinateDisplayText,
-  getSiteDetailsBackLink
+  getSiteDetailsBackLink,
+  getFileUploadSummaryData,
+  getFileUploadBackLink
 } from './utils.js'
-import { authenticatedPatchRequest } from '~/src/server/common/helpers/authenticated-requests.js'
+import {
+  authenticatedPatchRequest,
+  authenticatedGetRequest
+} from '~/src/server/common/helpers/authenticated-requests.js'
 import Boom from '@hapi/boom'
 
 export const REVIEW_SITE_DETAILS_VIEW_ROUTE =
   'exemption/site-details/review-site-details/index'
+
+export const FILE_UPLOAD_REVIEW_VIEW_ROUTE =
+  'exemption/site-details/review-site-details/file-upload-review'
 
 const reviewSiteDetailsPageData = {
   pageTitle: 'Review site details',
@@ -25,14 +34,50 @@ const reviewSiteDetailsPageData = {
  * @satisfies {Partial<ServerRoute>}
  */
 export const reviewSiteDetailsController = {
-  handler(request, h) {
+  async handler(request, h) {
     const previousPage = request.headers?.referer
-
     const exemption = getExemptionCache(request)
+    let siteDetails = exemption.siteDetails ?? {}
+
+    // If we have an exemption ID but incomplete site details, load from MongoDB
+    if (exemption.id && exemption.siteDetails === undefined) {
+      try {
+        const { payload } = await authenticatedGetRequest(
+          request,
+          `/exemption/${exemption.id}`
+        )
+        if (payload?.value?.siteDetails) {
+          siteDetails = payload.value.siteDetails
+          request.logger.info('Loaded site details from MongoDB for display', {
+            exemptionId: exemption.id,
+            coordinatesType: siteDetails.coordinatesType
+          })
+        }
+      } catch (error) {
+        request.logger.error('Failed to load exemption data from MongoDB', {
+          error: error.message,
+          exemptionId: exemption.id
+        })
+        // Continue with session data even if MongoDB load fails
+      }
+    }
+
+    if (siteDetails.coordinatesType === 'file') {
+      const fileUploadSummaryData = getFileUploadSummaryData({
+        ...exemption,
+        siteDetails
+      })
+
+      return h.view(FILE_UPLOAD_REVIEW_VIEW_ROUTE, {
+        ...reviewSiteDetailsPageData,
+        backLink: getFileUploadBackLink(previousPage),
+        projectName: exemption.projectName,
+        fileUploadSummaryData
+      })
+    }
+
+    // Manual coordinate entry flow
     const { coordinateSystem } = getCoordinateSystem(request)
-
-    const siteDetails = exemption.siteDetails ?? {}
-
     const { circleWidth } = siteDetails
 
     const summaryData = {
@@ -58,15 +103,59 @@ export const reviewSiteDetailsController = {
 export const reviewSiteDetailsSubmitController = {
   async handler(request, h) {
     const exemption = getExemptionCache(request)
+    const siteDetails = exemption.siteDetails ?? {}
 
     try {
+      let dataToSave
+
+      if (siteDetails.coordinatesType === 'file') {
+        const uploadedFile = siteDetails.uploadedFile
+        const geoJSON = siteDetails.geoJSON
+        const featureCount = siteDetails.featureCount || 0
+
+        dataToSave = {
+          coordinatesType: 'file',
+          fileUploadType: siteDetails.fileUploadType,
+          geoJSON,
+          featureCount,
+          uploadedFile: {
+            filename: uploadedFile.filename // Save filename for display
+          },
+          s3Location: {
+            s3Bucket: uploadedFile.s3Location.s3Bucket,
+            s3Key: uploadedFile.s3Location.s3Key,
+            checksumSha256: uploadedFile.s3Location.checksumSha256
+          }
+        }
+
+        request.logger.info('Saving file upload site details', {
+          fileType: siteDetails.fileUploadType,
+          featureCount,
+          filename: uploadedFile.filename
+        })
+      } else {
+        // Manual coordinate entry flow - use existing data structure
+        dataToSave = exemption.siteDetails
+
+        request.logger.info('Saving manual coordinate site details', {
+          coordinatesType: siteDetails.coordinatesType,
+          coordinatesEntry: siteDetails.coordinatesEntry
+        })
+      }
+
       await authenticatedPatchRequest(request, '/exemption/site-details', {
-        siteDetails: exemption.siteDetails,
+        siteDetails: dataToSave,
         id: exemption.id
       })
 
+      resetExemptionSiteDetails(request)
       return h.redirect(routes.TASK_LIST)
     } catch (e) {
+      request.logger.error('Error submitting site review', {
+        error: e.message,
+        exemptionId: exemption.id,
+        coordinatesType: siteDetails.coordinatesType
+      })
       throw Boom.badRequest(`Error submitting site review`, e)
     }
   }

--- a/src/server/exemption/site-details/review-site-details/controller.test.js
+++ b/src/server/exemption/site-details/review-site-details/controller.test.js
@@ -526,17 +526,14 @@ describe('#reviewSiteDetails', () => {
     })
 
     test('Should handle exemption with undefined siteDetails and assign empty object', async () => {
-      // Create an exemption where siteDetails is undefined (triggering the ?? {} fallback)
       const exemptionWithUndefinedSiteDetails = {
         ...mockExemption,
         siteDetails: undefined // This will trigger the ?? {} fallback
       }
 
-      // Mock the exemption cache to return the exemption without siteDetails
       const originalGetExemptionCache = cacheUtils.getExemptionCache
       let capturedSiteDetails
 
-      // Spy on the cache call to capture what siteDetails becomes after the nullish coalescing
       jest.spyOn(cacheUtils, 'getExemptionCache').mockImplementation(() => {
         const exemption = exemptionWithUndefinedSiteDetails
         // This simulates the line: const siteDetails = exemption.siteDetails ?? {}
@@ -561,7 +558,6 @@ describe('#reviewSiteDetails', () => {
       // Verify that the nullish coalescing operator worked correctly
       expect(capturedSiteDetails).toEqual({})
 
-      // Restore the original implementation
       cacheUtils.getExemptionCache.mockImplementation(originalGetExemptionCache)
     })
 

--- a/src/server/exemption/site-details/review-site-details/controller.test.js
+++ b/src/server/exemption/site-details/review-site-details/controller.test.js
@@ -375,7 +375,7 @@ describe('#reviewSiteDetails', () => {
       expect(
         document
           .querySelector(
-            '.govuk-link[href="/exemption/task-list?cancel=site-details"'
+            '.govuk-link[href="/exemption/task-list?cancel=site-details"]'
           )
           .textContent.trim()
       ).toBe('Cancel')

--- a/src/server/exemption/site-details/review-site-details/controller.test.js
+++ b/src/server/exemption/site-details/review-site-details/controller.test.js
@@ -525,6 +525,46 @@ describe('#reviewSiteDetails', () => {
       expect(h.redirect).toHaveBeenCalledWith(routes.TASK_LIST)
     })
 
+    test('Should handle exemption with undefined siteDetails and assign empty object', async () => {
+      // Create an exemption where siteDetails is undefined (triggering the ?? {} fallback)
+      const exemptionWithUndefinedSiteDetails = {
+        ...mockExemption,
+        siteDetails: undefined // This will trigger the ?? {} fallback
+      }
+
+      // Mock the exemption cache to return the exemption without siteDetails
+      const originalGetExemptionCache = cacheUtils.getExemptionCache
+      let capturedSiteDetails
+
+      // Spy on the cache call to capture what siteDetails becomes after the nullish coalescing
+      jest.spyOn(cacheUtils, 'getExemptionCache').mockImplementation(() => {
+        const exemption = exemptionWithUndefinedSiteDetails
+        // This simulates the line: const siteDetails = exemption.siteDetails ?? {}
+        capturedSiteDetails = exemption.siteDetails ?? {}
+        return exemption
+      })
+
+      const request = {
+        logger: {
+          info: jest.fn(),
+          error: jest.fn()
+        }
+      }
+      const h = { redirect: jest.fn() }
+
+      try {
+        await reviewSiteDetailsSubmitController.handler(request, h)
+      } catch (error) {
+        // Expected to fail since the function expects real siteDetails data
+      }
+
+      // Verify that the nullish coalescing operator worked correctly
+      expect(capturedSiteDetails).toEqual({})
+
+      // Restore the original implementation
+      cacheUtils.getExemptionCache.mockImplementation(originalGetExemptionCache)
+    })
+
     test('Should show error page with validation errors from backend', async () => {
       const apiPatchMock = jest.spyOn(authRequests, 'authenticatedPatchRequest')
       apiPatchMock.mockRejectedValueOnce({

--- a/src/server/exemption/site-details/review-site-details/controller.test.js
+++ b/src/server/exemption/site-details/review-site-details/controller.test.js
@@ -2,7 +2,8 @@ import { createServer } from '~/src/server/index.js'
 import {
   reviewSiteDetailsController,
   reviewSiteDetailsSubmitController,
-  REVIEW_SITE_DETAILS_VIEW_ROUTE
+  REVIEW_SITE_DETAILS_VIEW_ROUTE,
+  FILE_UPLOAD_REVIEW_VIEW_ROUTE
 } from '~/src/server/exemption/site-details/review-site-details/controller.js'
 import { COORDINATE_SYSTEMS } from '~/src/server/common/constants/exemptions.js'
 import * as cacheUtils from '~/src/server/common/helpers/session-cache/utils.js'
@@ -20,6 +21,7 @@ describe('#reviewSiteDetails', () => {
   let server
   let getExemptionCacheSpy
   let getCoordinateSystemSpy
+  let resetExemptionSiteDetailsSpy
 
   const mockCoordinates = {
     [COORDINATE_SYSTEMS.WGS84]: {
@@ -44,12 +46,21 @@ describe('#reviewSiteDetails', () => {
       }
     })
 
+    jest.spyOn(authRequests, 'authenticatedGetRequest').mockResolvedValue({
+      payload: {
+        value: mockExemption
+      }
+    })
+
     getExemptionCacheSpy = jest
       .spyOn(cacheUtils, 'getExemptionCache')
       .mockReturnValue(mockExemption)
     getCoordinateSystemSpy = jest
       .spyOn(cacheUtils, 'getCoordinateSystem')
       .mockReturnValue({ coordinateSystem: COORDINATE_SYSTEMS.WGS84 })
+    resetExemptionSiteDetailsSpy = jest
+      .spyOn(cacheUtils, 'resetExemptionSiteDetails')
+      .mockReturnValue({ siteDetails: null })
   })
 
   afterAll(async () => {
@@ -57,13 +68,21 @@ describe('#reviewSiteDetails', () => {
   })
 
   describe('#reviewSiteDetailsController', () => {
-    test('reviewSiteDetailsController handler should render with correct context with no existing data', () => {
+    test('reviewSiteDetailsController handler should render with correct context with no existing data', async () => {
       getExemptionCacheSpy.mockReturnValueOnce({})
       getCoordinateSystemSpy.mockReturnValueOnce({})
 
       const h = { view: jest.fn() }
+      const mockRequest = {
+        logger: {
+          info: jest.fn(),
+          error: jest.fn(),
+          warn: jest.fn(),
+          debug: jest.fn()
+        }
+      }
 
-      reviewSiteDetailsController.handler({}, h)
+      await reviewSiteDetailsController.handler(mockRequest, h)
 
       expect(h.view).toHaveBeenCalledWith(REVIEW_SITE_DETAILS_VIEW_ROUTE, {
         heading: 'Review site details',
@@ -79,10 +98,157 @@ describe('#reviewSiteDetails', () => {
       })
     })
 
-    test('reviewSiteDetailsController handler should render with correct context for WGS84', () => {
-      const h = { view: jest.fn() }
+    test('reviewSiteDetailsController handler should load data from MongoDB when session has ID but no siteDetails', async () => {
+      const exemptionWithoutSiteDetails = {
+        id: 'test-id',
+        projectName: 'Test Project'
+        // siteDetails is undefined
+      }
 
-      reviewSiteDetailsController.handler({}, h)
+      const completeMongoData = {
+        id: 'test-id',
+        projectName: 'Test Project',
+        siteDetails: {
+          coordinatesType: 'file',
+          fileUploadType: 'kml',
+          uploadedFile: {
+            filename: 'test-site.kml'
+          },
+          geoJSON: {
+            type: 'FeatureCollection',
+            features: [
+              {
+                type: 'Feature',
+                geometry: {
+                  type: 'Point',
+                  coordinates: [51.5074, -0.1278]
+                }
+              }
+            ]
+          }
+        }
+      }
+
+      getExemptionCacheSpy.mockReturnValueOnce(exemptionWithoutSiteDetails)
+      jest
+        .spyOn(authRequests, 'authenticatedGetRequest')
+        .mockResolvedValueOnce({
+          payload: {
+            value: completeMongoData
+          }
+        })
+
+      const h = { view: jest.fn() }
+      const mockRequest = {
+        logger: {
+          info: jest.fn(),
+          error: jest.fn(),
+          warn: jest.fn(),
+          debug: jest.fn()
+        }
+      }
+
+      await reviewSiteDetailsController.handler(mockRequest, h)
+
+      expect(authRequests.authenticatedGetRequest).toHaveBeenCalledWith(
+        mockRequest,
+        '/exemption/test-id'
+      )
+      expect(mockRequest.logger.info).toHaveBeenCalledWith(
+        'Loaded site details from MongoDB for display',
+        {
+          exemptionId: 'test-id',
+          coordinatesType: 'file'
+        }
+      )
+      expect(h.view).toHaveBeenCalledWith(FILE_UPLOAD_REVIEW_VIEW_ROUTE, {
+        heading: 'Review site details',
+        pageTitle: 'Review site details',
+        backLink: routes.FILE_UPLOAD,
+        projectName: 'Test Project',
+        fileUploadSummaryData: {
+          method: 'Upload a file with the coordinates of the site',
+          fileType: 'KML',
+          filename: 'test-site.kml',
+          coordinates: [
+            {
+              type: 'Point',
+              coordinates: [51.5074, -0.1278]
+            }
+          ]
+        }
+      })
+    })
+
+    test('reviewSiteDetailsController handler should render file upload template for file upload flow', async () => {
+      const mockFileUploadExemption = {
+        ...mockExemption,
+        siteDetails: {
+          coordinatesType: 'file',
+          fileUploadType: 'kml',
+          uploadedFile: {
+            filename: 'test-site.kml'
+          },
+          geoJSON: {
+            type: 'FeatureCollection',
+            features: [
+              {
+                type: 'Feature',
+                geometry: {
+                  type: 'Point',
+                  coordinates: [51.5074, -0.1278]
+                }
+              }
+            ]
+          }
+        }
+      }
+
+      getExemptionCacheSpy.mockReturnValueOnce(mockFileUploadExemption)
+
+      const h = { view: jest.fn() }
+      const mockRequest = {
+        logger: {
+          info: jest.fn(),
+          error: jest.fn(),
+          warn: jest.fn(),
+          debug: jest.fn()
+        }
+      }
+
+      await reviewSiteDetailsController.handler(mockRequest, h)
+
+      expect(h.view).toHaveBeenCalledWith(FILE_UPLOAD_REVIEW_VIEW_ROUTE, {
+        heading: 'Review site details',
+        pageTitle: 'Review site details',
+        backLink: routes.FILE_UPLOAD,
+        projectName: 'Test Project',
+        fileUploadSummaryData: {
+          method: 'Upload a file with the coordinates of the site',
+          fileType: 'KML',
+          filename: 'test-site.kml',
+          coordinates: [
+            {
+              type: 'Point',
+              coordinates: [51.5074, -0.1278]
+            }
+          ]
+        }
+      })
+    })
+
+    test('reviewSiteDetailsController handler should render with correct context for WGS84', async () => {
+      const h = { view: jest.fn() }
+      const mockRequest = {
+        logger: {
+          info: jest.fn(),
+          error: jest.fn(),
+          warn: jest.fn(),
+          debug: jest.fn()
+        }
+      }
+
+      await reviewSiteDetailsController.handler(mockRequest, h)
 
       expect(h.view).toHaveBeenCalledWith(REVIEW_SITE_DETAILS_VIEW_ROUTE, {
         heading: 'Review site details',
@@ -100,8 +266,16 @@ describe('#reviewSiteDetails', () => {
       })
     })
 
-    test('reviewSiteDetailsController handler should render with correct context for OSGB36', () => {
+    test('reviewSiteDetailsController handler should render with correct context for OSGB36', async () => {
       const h = { view: jest.fn() }
+      const mockRequest = {
+        logger: {
+          info: jest.fn(),
+          error: jest.fn(),
+          warn: jest.fn(),
+          debug: jest.fn()
+        }
+      }
 
       getExemptionCacheSpy.mockReturnValueOnce({
         ...mockExemption,
@@ -115,7 +289,7 @@ describe('#reviewSiteDetails', () => {
         coordinateSystem: COORDINATE_SYSTEMS.OSGB36
       })
 
-      reviewSiteDetailsController.handler({}, h)
+      await reviewSiteDetailsController.handler(mockRequest, h)
 
       expect(h.view).toHaveBeenCalledWith(REVIEW_SITE_DETAILS_VIEW_ROUTE, {
         heading: 'Review site details',
@@ -194,7 +368,7 @@ describe('#reviewSiteDetails', () => {
 
       expect(
         document
-          .querySelector('.govuk-back-link[href="/exemption/width-of-site')
+          .querySelector('.govuk-back-link[href="/exemption/width-of-site"]')
           .textContent.trim()
       ).toBe('Back')
 
@@ -234,8 +408,116 @@ describe('#reviewSiteDetails', () => {
       expect(statusCode).toBe(statusCodes.redirect)
     })
 
+    test('Should call resetExemptionSiteDetails after saving to MongoDB', async () => {
+      const request = {
+        logger: {
+          info: jest.fn(),
+          error: jest.fn()
+        }
+      }
+      const h = { redirect: jest.fn() }
+
+      await reviewSiteDetailsSubmitController.handler(request, h)
+
+      expect(authRequests.authenticatedPatchRequest).toHaveBeenCalledWith(
+        expect.any(Object),
+        '/exemption/site-details',
+        {
+          siteDetails: mockExemption.siteDetails,
+          id: mockExemption.id
+        }
+      )
+
+      expect(resetExemptionSiteDetailsSpy).toHaveBeenCalledWith(request)
+      expect(h.redirect).toHaveBeenCalledWith(routes.TASK_LIST)
+    })
+
+    test('Should save file upload data with display metadata for file upload flow', async () => {
+      const mockFileUploadExemption = {
+        ...mockExemption,
+        siteDetails: {
+          coordinatesType: 'file',
+          fileUploadType: 'kml',
+          uploadedFile: {
+            filename: 'test-site.kml',
+            s3Location: {
+              s3Bucket: 'test-bucket',
+              s3Key: 'test-key',
+              checksumSha256: 'test-checksum'
+            }
+          },
+          geoJSON: {
+            type: 'FeatureCollection',
+            features: [
+              {
+                type: 'Feature',
+                geometry: {
+                  type: 'Point',
+                  coordinates: [51.5074, -0.1278]
+                }
+              }
+            ]
+          },
+          featureCount: 1
+        }
+      }
+
+      getExemptionCacheSpy.mockReturnValueOnce(mockFileUploadExemption)
+
+      const request = {
+        logger: {
+          info: jest.fn(),
+          error: jest.fn()
+        }
+      }
+      const h = { redirect: jest.fn() }
+
+      await reviewSiteDetailsSubmitController.handler(request, h)
+
+      expect(authRequests.authenticatedPatchRequest).toHaveBeenCalledWith(
+        expect.any(Object),
+        '/exemption/site-details',
+        {
+          siteDetails: {
+            coordinatesType: 'file',
+            fileUploadType: 'kml',
+            geoJSON: {
+              type: 'FeatureCollection',
+              features: [
+                {
+                  type: 'Feature',
+                  geometry: {
+                    type: 'Point',
+                    coordinates: [51.5074, -0.1278]
+                  }
+                }
+              ]
+            },
+            featureCount: 1,
+            uploadedFile: {
+              filename: 'test-site.kml'
+            },
+            s3Location: {
+              s3Bucket: 'test-bucket',
+              s3Key: 'test-key',
+              checksumSha256: 'test-checksum'
+            }
+          },
+          id: mockExemption.id
+        }
+      )
+
+      expect(resetExemptionSiteDetailsSpy).toHaveBeenCalledWith(request)
+      expect(h.redirect).toHaveBeenCalledWith(routes.TASK_LIST)
+    })
+
     test('Should redirect to task list for successful POST request', async () => {
-      const request = {}
+      const request = {
+        logger: {
+          info: jest.fn(),
+          error: jest.fn()
+        }
+      }
       const h = { redirect: jest.fn() }
 
       await reviewSiteDetailsSubmitController.handler(request, h)

--- a/src/server/exemption/site-details/review-site-details/file-upload-review.njk
+++ b/src/server/exemption/site-details/review-site-details/file-upload-review.njk
@@ -1,0 +1,83 @@
+{% extends 'layouts/page.njk' %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "cancel-button/macro.njk" import appCancelButton %}
+
+{% block pageTitle %}
+  Review site details - {{ serviceName }}
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: backLink
+  }) }}
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+
+      <span class="govuk-caption-l">{{ projectName }}</span>
+      <h1 class="govuk-heading-l">Review site details</h1>
+
+      {% if fileUploadSummaryData %}
+        {% set rows = [] %}
+        {% set _ = rows.push({
+          key: { text: "Method of providing site location" },
+          value: { text: fileUploadSummaryData.method | default('') }
+        }) %}
+        {% set _ = rows.push({
+          key: { text: "File type" },
+          value: { text: fileUploadSummaryData.fileType | default('') }
+        }) %}
+        {% set _ = rows.push({
+          key: { text: "File uploaded" },
+          value: { text: fileUploadSummaryData.filename | sanitiseFilename }
+        }) %}
+
+        {% if fileUploadSummaryData.coordinates %}
+          {% for coordinate in fileUploadSummaryData.coordinates %}
+            {% set _ = rows.push({
+              key: { text: "Extracted " + (coordinate.type | default('')) },
+              value: { text: (coordinate.coordinates | default([]) | dump) }
+            }) %}
+          {% endfor %}
+        {% endif %}
+
+        {%  set _ = rows.push({
+          key: { text: "Map view" },
+          value: { text: "" }
+        }) %}
+
+        {{ govukSummaryList({
+          card: {
+            title: {
+              text: "Site details"
+            }
+          },
+          rows: rows
+        }) }}
+      {% endif %}
+
+      <form method="POST">
+        <input type="hidden" name="csrfToken" value="{{ csrfToken }}">
+
+        <div class="govuk-button-group">
+          {{ govukButton({
+            text: "Save and continue",
+            attributes: {
+              id: "continue"
+            }
+          }) }}
+
+          {{ appCancelButton({
+            cancelLink: "/exemption/task-list?cancel=site-details"
+          }) }}
+        </div>
+      </form>
+
+    </div>
+  </div>
+{% endblock %}

--- a/src/server/exemption/site-details/review-site-details/utils.js
+++ b/src/server/exemption/site-details/review-site-details/utils.js
@@ -61,13 +61,21 @@ export const getFileUploadSummaryData = (exemption) => {
   const uploadedFile = siteDetails.uploadedFile || {}
   const geoJSON = siteDetails.geoJSON || {}
 
-  // Parse coordinates from geoJSON instead of using extractedCoordinates
+  // Parse coordinates from geoJSON, only including features with valid geometry
   let coordinates = []
   if (geoJSON.features && Array.isArray(geoJSON.features)) {
-    coordinates = geoJSON.features.map((feature) => ({
-      type: feature.geometry?.type || '',
-      coordinates: feature.geometry?.coordinates || []
-    }))
+    coordinates = geoJSON.features
+      .filter(
+        (feature) =>
+          feature.geometry?.type &&
+          feature.geometry?.coordinates &&
+          Array.isArray(feature.geometry.coordinates) &&
+          feature.geometry.coordinates.length > 0
+      )
+      .map((feature) => ({
+        type: feature.geometry.type,
+        coordinates: feature.geometry.coordinates
+      }))
   }
 
   // Determine file type display text
@@ -83,7 +91,7 @@ export const getFileUploadSummaryData = (exemption) => {
   return {
     method: 'Upload a file with the coordinates of the site',
     fileType: fileTypeText,
-    filename: uploadedFile.filename || '',
+    filename: uploadedFile.filename,
     coordinates
   }
 }
@@ -152,13 +160,17 @@ export const loadSiteDetailsFromMongoDB = async (
           exemptionId: exemption.id,
           coordinatesType: siteDetails.coordinatesType
         })
+      } else {
+        request.logger.warn('No site details found in MongoDB response', {
+          exemptionId: exemption.id
+        })
+        // Continue with session data when no site details found
       }
     } catch (error) {
       request.logger.error('Failed to load exemption data from MongoDB', {
         error: error.message,
         exemptionId: exemption.id
       })
-      // Continue with session data even if MongoDB load fails
     }
   }
 

--- a/src/server/exemption/site-details/review-site-details/utils.js
+++ b/src/server/exemption/site-details/review-site-details/utils.js
@@ -96,3 +96,116 @@ export const getFileUploadBackLink = (previousPage) => {
   // Otherwise, return to file upload page
   return routes.FILE_UPLOAD
 }
+
+/**
+ * Builds summary data for manual coordinate entry display
+ * @param {object} siteDetails - Site details from exemption
+ * @param {string} coordinateSystem - Selected coordinate system
+ * @returns {object} Summary data for template
+ */
+export const buildManualCoordinateSummaryData = (
+  siteDetails,
+  coordinateSystem
+) => {
+  const { circleWidth } = siteDetails
+
+  return {
+    method: getReviewSummaryText(siteDetails),
+    coordinateSystem: getCoordinateSystemText(coordinateSystem),
+    coordinates: getCoordinateDisplayText(siteDetails, coordinateSystem),
+    width: circleWidth ? `${circleWidth} metres` : ''
+  }
+}
+
+/**
+ * Loads site details from MongoDB when session data is incomplete
+ * @param {object} request - Hapi request object
+ * @param {object} exemption - Current exemption from session
+ * @param {Function} authenticatedGetRequest - Function to make authenticated API calls
+ * @returns {Promise<object>} Site details object
+ */
+export const loadSiteDetailsFromMongoDB = async (
+  request,
+  exemption,
+  authenticatedGetRequest
+) => {
+  let siteDetails = exemption.siteDetails ?? {}
+
+  // If we have an exemption ID but incomplete site details, load from MongoDB
+  if (exemption.id && exemption.siteDetails === undefined) {
+    try {
+      const { payload } = await authenticatedGetRequest(
+        request,
+        `/exemption/${exemption.id}`
+      )
+      if (payload?.value?.siteDetails) {
+        siteDetails = payload.value.siteDetails
+        request.logger.info('Loaded site details from MongoDB for display', {
+          exemptionId: exemption.id,
+          coordinatesType: siteDetails.coordinatesType
+        })
+      }
+    } catch (error) {
+      request.logger.error('Failed to load exemption data from MongoDB', {
+        error: error.message,
+        exemptionId: exemption.id
+      })
+      // Continue with session data even if MongoDB load fails
+    }
+  }
+
+  return siteDetails
+}
+
+/**
+ * Prepares file upload data for saving to MongoDB
+ * @param {object} siteDetails - Site details from exemption
+ * @param {object} request - Hapi request object for logging
+ * @returns {object} Formatted data for API submission
+ */
+export const prepareFileUploadDataForSave = (siteDetails, request) => {
+  const uploadedFile = siteDetails.uploadedFile
+  const geoJSON = siteDetails.geoJSON
+  const featureCount = siteDetails.featureCount || 0
+
+  const dataToSave = {
+    coordinatesType: 'file',
+    fileUploadType: siteDetails.fileUploadType,
+    geoJSON,
+    featureCount,
+    uploadedFile: {
+      filename: uploadedFile.filename // Save filename for display
+    },
+    s3Location: {
+      s3Bucket: uploadedFile.s3Location.s3Bucket,
+      s3Key: uploadedFile.s3Location.s3Key,
+      checksumSha256: uploadedFile.s3Location.checksumSha256
+    }
+  }
+
+  request.logger.info('Saving file upload site details', {
+    fileType: siteDetails.fileUploadType,
+    featureCount,
+    filename: uploadedFile.filename
+  })
+
+  return dataToSave
+}
+
+/**
+ * Prepares manual coordinate data for saving to MongoDB
+ * @param {object} exemption - Current exemption from session
+ * @param {object} request - Hapi request object for logging
+ * @returns {object} Formatted data for API submission
+ */
+export const prepareManualCoordinateDataForSave = (exemption, request) => {
+  const siteDetails = exemption.siteDetails
+
+  request.logger.info('Saving manual coordinate site details', {
+    coordinatesType: siteDetails.coordinatesType,
+    coordinatesEntry: siteDetails.coordinatesEntry
+  })
+
+  // Manual coordinate entry flow - use existing data structure
+  return exemption.siteDetails
+}

--- a/src/server/exemption/site-details/review-site-details/utils.js
+++ b/src/server/exemption/site-details/review-site-details/utils.js
@@ -1,5 +1,13 @@
 import { COORDINATE_SYSTEMS } from '~/src/server/common/constants/exemptions.js'
 import { routes } from '~/src/server/common/constants/routes.js'
+import { getCoordinateSystem } from '~/src/server/common/helpers/session-cache/utils.js'
+import Boom from '@hapi/boom'
+
+const REVIEW_SITE_DETAILS_VIEW_ROUTE =
+  'exemption/site-details/review-site-details/index'
+
+const FILE_UPLOAD_REVIEW_VIEW_ROUTE =
+  'exemption/site-details/review-site-details/file-upload-review'
 
 export const getSiteDetailsBackLink = (previousPage) => {
   if (!previousPage || !URL.canParse(previousPage)) {
@@ -208,4 +216,87 @@ export const prepareManualCoordinateDataForSave = (exemption, request) => {
 
   // Manual coordinate entry flow - use existing data structure
   return exemption.siteDetails
+}
+
+/**
+ * Handles file upload review view rendering
+ * @param {object} h - Hapi response toolkit
+ * @param {object} exemption - Current exemption from session
+ * @param {object} siteDetails - Site details object
+ * @param {string} previousPage - Previous page URL for back link
+ * @param {object} reviewSiteDetailsPageData - Common page data
+ * @returns {object} Rendered view response
+ */
+export const renderFileUploadReview = (
+  h,
+  exemption,
+  siteDetails,
+  previousPage,
+  reviewSiteDetailsPageData
+) => {
+  const fileUploadSummaryData = getFileUploadSummaryData({
+    ...exemption,
+    siteDetails
+  })
+
+  return h.view(FILE_UPLOAD_REVIEW_VIEW_ROUTE, {
+    ...reviewSiteDetailsPageData,
+    backLink: getFileUploadBackLink(previousPage),
+    projectName: exemption.projectName,
+    fileUploadSummaryData
+  })
+}
+
+/**
+ * Handles manual coordinate review view rendering
+ * @param {object} h - Hapi response toolkit
+ * @param {object} request - Hapi request object
+ * @param {object} exemption - Current exemption from session
+ * @param {object} siteDetails - Site details object
+ * @param {string} previousPage - Previous page URL for back link
+ * @param {object} reviewSiteDetailsPageData - Common page data
+ * @returns {object} Rendered view response
+ */
+export const renderManualCoordinateReview = (
+  h,
+  request,
+  exemption,
+  siteDetails,
+  previousPage,
+  reviewSiteDetailsPageData
+) => {
+  const { coordinateSystem } = getCoordinateSystem(request)
+  const summaryData = buildManualCoordinateSummaryData(
+    siteDetails,
+    coordinateSystem
+  )
+
+  return h.view(REVIEW_SITE_DETAILS_VIEW_ROUTE, {
+    ...reviewSiteDetailsPageData,
+    backLink: getSiteDetailsBackLink(previousPage),
+    projectName: exemption.projectName,
+    summaryData
+  })
+}
+
+/**
+ * Handles errors during site details submission
+ * @param {object} request - Hapi request object
+ * @param {Error} error - The error that occurred
+ * @param {string} exemptionId - ID of the exemption
+ * @param {string} coordinatesType - Type of coordinates being saved
+ * @returns {Boom} Standardized error response
+ */
+export const handleSubmissionError = (
+  request,
+  error,
+  exemptionId,
+  coordinatesType
+) => {
+  request.logger.error('Error submitting site review', {
+    error: error.message,
+    exemptionId,
+    coordinatesType
+  })
+  return Boom.badRequest('Error submitting site review', error)
 }

--- a/src/server/exemption/site-details/review-site-details/utils.js
+++ b/src/server/exemption/site-details/review-site-details/utils.js
@@ -47,3 +47,52 @@ export const getCoordinateDisplayText = (siteDetails, coordinateSystem) => {
     ? `${coordinates.latitude}, ${coordinates.longitude}`
     : `${coordinates.eastings}, ${coordinates.northings}`
 }
+
+export const getFileUploadSummaryData = (exemption) => {
+  const siteDetails = exemption.siteDetails || {}
+  const uploadedFile = siteDetails.uploadedFile || {}
+  const geoJSON = siteDetails.geoJSON || {}
+
+  // Parse coordinates from geoJSON instead of using extractedCoordinates
+  let coordinates = []
+  if (geoJSON.features && Array.isArray(geoJSON.features)) {
+    coordinates = geoJSON.features.map((feature) => ({
+      type: feature.geometry?.type || '',
+      coordinates: feature.geometry?.coordinates || []
+    }))
+  }
+
+  // Determine file type display text
+  let fileTypeText = ''
+  if (siteDetails.fileUploadType === 'kml') {
+    fileTypeText = 'KML'
+  } else if (siteDetails.fileUploadType === 'shapefile') {
+    fileTypeText = 'Shapefile'
+  } else {
+    throw new Error('Unsupported file type for site details')
+  }
+
+  return {
+    method: 'Upload a file with the coordinates of the site',
+    fileType: fileTypeText,
+    filename: uploadedFile.filename || '',
+    coordinates
+  }
+}
+
+export const getFileUploadBackLink = (previousPage) => {
+  if (!previousPage || !URL.canParse(previousPage)) {
+    return routes.FILE_UPLOAD
+  }
+
+  const url = new URL(previousPage)
+  const previousPath = url.pathname
+
+  // If coming from task list, return to task list
+  if (previousPath === routes.TASK_LIST) {
+    return routes.TASK_LIST
+  }
+
+  // Otherwise, return to file upload page
+  return routes.FILE_UPLOAD
+}

--- a/src/server/exemption/site-details/review-site-details/utils.test.js
+++ b/src/server/exemption/site-details/review-site-details/utils.test.js
@@ -2,7 +2,8 @@ import {
   getReviewSummaryText,
   getCoordinateSystemText,
   getCoordinateDisplayText,
-  getSiteDetailsBackLink
+  getSiteDetailsBackLink,
+  getFileUploadSummaryData
 } from '~/src/server/exemption/site-details/review-site-details/utils.js'
 import { COORDINATE_SYSTEMS } from '~/src/server/common/constants/exemptions.js'
 import { mockExemption } from '~/src/server/test-helpers/mocks.js'
@@ -24,6 +25,165 @@ describe('siteDetails utils', () => {
 
     test('getSiteDetailsBackLink correctly returns fallback option', () => {
       expect(getSiteDetailsBackLink(undefined)).toBe(routes.TASK_LIST)
+    })
+  })
+
+  describe('getFileUploadSummaryData util', () => {
+    test('getFileUploadSummaryData correctly parses coordinates from geoJSON for KML', () => {
+      const exemption = {
+        siteDetails: {
+          fileUploadType: 'kml',
+          uploadedFile: {
+            filename: 'test-site.kml'
+          },
+          geoJSON: {
+            type: 'FeatureCollection',
+            features: [
+              {
+                type: 'Feature',
+                geometry: {
+                  type: 'Point',
+                  coordinates: [51.5074, -0.1278]
+                }
+              },
+              {
+                type: 'Feature',
+                geometry: {
+                  type: 'Polygon',
+                  coordinates: [
+                    [
+                      [0, 0],
+                      [1, 0],
+                      [1, 1],
+                      [0, 1],
+                      [0, 0]
+                    ]
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      }
+
+      const result = getFileUploadSummaryData(exemption)
+
+      expect(result).toEqual({
+        method: 'Upload a file with the coordinates of the site',
+        fileType: 'KML',
+        filename: 'test-site.kml',
+        coordinates: [
+          {
+            type: 'Point',
+            coordinates: [51.5074, -0.1278]
+          },
+          {
+            type: 'Polygon',
+            coordinates: [
+              [
+                [0, 0],
+                [1, 0],
+                [1, 1],
+                [0, 1],
+                [0, 0]
+              ]
+            ]
+          }
+        ]
+      })
+    })
+
+    test('getFileUploadSummaryData correctly parses coordinates from geoJSON for Shapefile', () => {
+      const exemption = {
+        siteDetails: {
+          fileUploadType: 'shapefile',
+          uploadedFile: {
+            filename: 'test-site.shp'
+          },
+          geoJSON: {
+            type: 'FeatureCollection',
+            features: [
+              {
+                type: 'Feature',
+                geometry: {
+                  type: 'LineString',
+                  coordinates: [
+                    [0, 0],
+                    [1, 1],
+                    [2, 2]
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      }
+
+      const result = getFileUploadSummaryData(exemption)
+
+      expect(result).toEqual({
+        method: 'Upload a file with the coordinates of the site',
+        fileType: 'Shapefile',
+        filename: 'test-site.shp',
+        coordinates: [
+          {
+            type: 'LineString',
+            coordinates: [
+              [0, 0],
+              [1, 1],
+              [2, 2]
+            ]
+          }
+        ]
+      })
+    })
+
+    test('getFileUploadSummaryData handles empty or missing geoJSON', () => {
+      const exemption = {
+        siteDetails: {
+          fileUploadType: 'kml',
+          uploadedFile: {
+            filename: 'test-site.kml'
+          },
+          geoJSON: {}
+        }
+      }
+
+      const result = getFileUploadSummaryData(exemption)
+
+      expect(result).toEqual({
+        method: 'Upload a file with the coordinates of the site',
+        fileType: 'KML',
+        filename: 'test-site.kml',
+        coordinates: []
+      })
+    })
+
+    test('getFileUploadSummaryData handles missing site details', () => {
+      const exemption = {}
+
+      expect(() => getFileUploadSummaryData(exemption)).toThrow(
+        'Unsupported file type for site details'
+      )
+    })
+
+    test('getFileUploadSummaryData handles invalid file type', () => {
+      const exemption = {
+        siteDetails: {
+          fileUploadType: 'invalid',
+          uploadedFile: {
+            filename: 'test-site.xyz'
+          },
+          geoJSON: {
+            type: 'FeatureCollection',
+            features: []
+          }
+        }
+      }
+
+      expect(() => getFileUploadSummaryData(exemption)).toThrow(
+        'Unsupported file type for site details'
+      )
     })
   })
 

--- a/src/server/exemption/site-details/review-site-details/utils.test.js
+++ b/src/server/exemption/site-details/review-site-details/utils.test.js
@@ -1,13 +1,29 @@
 import {
-  getReviewSummaryText,
-  getCoordinateSystemText,
+  buildManualCoordinateSummaryData,
   getCoordinateDisplayText,
+  getCoordinateSystemText,
+  getFileUploadBackLink,
+  getFileUploadSummaryData,
+  getReviewSummaryText,
   getSiteDetailsBackLink,
-  getFileUploadSummaryData
+  handleSubmissionError,
+  loadSiteDetailsFromMongoDB,
+  prepareFileUploadDataForSave,
+  prepareManualCoordinateDataForSave,
+  renderFileUploadReview,
+  renderManualCoordinateReview
 } from '~/src/server/exemption/site-details/review-site-details/utils.js'
 import { COORDINATE_SYSTEMS } from '~/src/server/common/constants/exemptions.js'
 import { mockExemption } from '~/src/server/test-helpers/mocks.js'
 import { routes } from '~/src/server/common/constants/routes.js'
+import Boom from '@hapi/boom'
+
+import { getCoordinateSystem } from '~/src/server/common/helpers/session-cache/utils.js'
+
+// Mock the getCoordinateSystem helper
+jest.mock('~/src/server/common/helpers/session-cache/utils.js', () => ({
+  getCoordinateSystem: jest.fn()
+}))
 
 describe('siteDetails utils', () => {
   describe('getSiteDetailsBackLink util', () => {
@@ -249,6 +265,497 @@ describe('siteDetails utils', () => {
 
     test('getCoordinateDisplayText correctly returns blank otherwise', () => {
       expect(getCoordinateDisplayText({})).toBe('')
+    })
+  })
+
+  describe('getFileUploadBackLink util', () => {
+    test('getFileUploadBackLink correctly returns task list when coming from the task list', () => {
+      expect(getFileUploadBackLink(`http://hostname${routes.TASK_LIST}`)).toBe(
+        routes.TASK_LIST
+      )
+    })
+
+    test('getFileUploadBackLink correctly returns file upload when coming from other pages', () => {
+      expect(
+        getFileUploadBackLink(`http://hostname${routes.WIDTH_OF_SITE}`)
+      ).toBe(routes.FILE_UPLOAD)
+    })
+
+    test('getFileUploadBackLink correctly returns file upload as fallback', () => {
+      expect(getFileUploadBackLink(undefined)).toBe(routes.FILE_UPLOAD)
+    })
+
+    test('getFileUploadBackLink correctly handles invalid URLs', () => {
+      expect(getFileUploadBackLink('invalid-url')).toBe(routes.FILE_UPLOAD)
+    })
+  })
+
+  describe('buildManualCoordinateSummaryData util', () => {
+    test('buildManualCoordinateSummaryData correctly builds summary data with all fields', () => {
+      const siteDetails = {
+        coordinatesEntry: 'single',
+        coordinatesType: 'coordinates',
+        coordinates: {
+          latitude: '51.5074',
+          longitude: '-0.1278'
+        },
+        circleWidth: '100'
+      }
+      const coordinateSystem = COORDINATE_SYSTEMS.WGS84
+
+      const result = buildManualCoordinateSummaryData(
+        siteDetails,
+        coordinateSystem
+      )
+
+      expect(result).toEqual({
+        method:
+          'Manually enter one set of coordinates and a width to create a circular site',
+        coordinateSystem:
+          'WGS84 (World Geodetic System 1984)\nLatitude and longitude',
+        coordinates: '51.5074, -0.1278',
+        width: '100 metres'
+      })
+    })
+
+    test('buildManualCoordinateSummaryData correctly handles OSGB36 coordinates', () => {
+      const siteDetails = {
+        coordinatesEntry: 'single',
+        coordinatesType: 'coordinates',
+        coordinates: {
+          eastings: '425053',
+          northings: '564180'
+        },
+        circleWidth: '200'
+      }
+      const coordinateSystem = COORDINATE_SYSTEMS.OSGB36
+
+      const result = buildManualCoordinateSummaryData(
+        siteDetails,
+        coordinateSystem
+      )
+
+      expect(result).toEqual({
+        method:
+          'Manually enter one set of coordinates and a width to create a circular site',
+        coordinateSystem: 'OSGB36 (National Grid)\nEastings and Northings',
+        coordinates: '425053, 564180',
+        width: '200 metres'
+      })
+    })
+
+    test('buildManualCoordinateSummaryData correctly handles missing width', () => {
+      const siteDetails = {
+        coordinatesEntry: 'single',
+        coordinatesType: 'coordinates',
+        coordinates: {
+          latitude: '51.5074',
+          longitude: '-0.1278'
+        }
+      }
+      const coordinateSystem = COORDINATE_SYSTEMS.WGS84
+
+      const result = buildManualCoordinateSummaryData(
+        siteDetails,
+        coordinateSystem
+      )
+
+      expect(result.width).toBe('')
+    })
+  })
+
+  describe('loadSiteDetailsFromMongoDB util', () => {
+    const mockRequest = {
+      logger: {
+        info: jest.fn(),
+        error: jest.fn()
+      }
+    }
+    const mockAuthenticatedGetRequest = jest.fn()
+
+    beforeEach(() => {
+      jest.clearAllMocks()
+    })
+
+    test('loadSiteDetailsFromMongoDB returns existing site details when available', async () => {
+      const exemption = {
+        id: 'test-exemption-id',
+        siteDetails: {
+          coordinatesType: 'coordinates',
+          coordinates: { latitude: '51.5074', longitude: '-0.1278' }
+        }
+      }
+
+      const result = await loadSiteDetailsFromMongoDB(
+        mockRequest,
+        exemption,
+        mockAuthenticatedGetRequest
+      )
+
+      expect(result).toEqual(exemption.siteDetails)
+      expect(mockAuthenticatedGetRequest).not.toHaveBeenCalled()
+    })
+
+    test('loadSiteDetailsFromMongoDB loads from MongoDB when site details undefined', async () => {
+      const exemption = {
+        id: 'test-exemption-id',
+        siteDetails: undefined
+      }
+
+      const mockMongoResponse = {
+        payload: {
+          value: {
+            siteDetails: {
+              coordinatesType: 'file',
+              fileUploadType: 'kml'
+            }
+          }
+        }
+      }
+
+      mockAuthenticatedGetRequest.mockResolvedValue(mockMongoResponse)
+
+      const result = await loadSiteDetailsFromMongoDB(
+        mockRequest,
+        exemption,
+        mockAuthenticatedGetRequest
+      )
+
+      expect(result).toEqual(mockMongoResponse.payload.value.siteDetails)
+      expect(mockAuthenticatedGetRequest).toHaveBeenCalledWith(
+        mockRequest,
+        '/exemption/test-exemption-id'
+      )
+      expect(mockRequest.logger.info).toHaveBeenCalledWith(
+        'Loaded site details from MongoDB for display',
+        {
+          exemptionId: 'test-exemption-id',
+          coordinatesType: 'file'
+        }
+      )
+    })
+
+    test('loadSiteDetailsFromMongoDB handles MongoDB load failure gracefully', async () => {
+      const exemption = {
+        id: 'test-exemption-id',
+        siteDetails: undefined
+      }
+
+      const mockError = new Error('MongoDB connection failed')
+      mockAuthenticatedGetRequest.mockRejectedValue(mockError)
+
+      const result = await loadSiteDetailsFromMongoDB(
+        mockRequest,
+        exemption,
+        mockAuthenticatedGetRequest
+      )
+
+      expect(result).toEqual({})
+      expect(mockRequest.logger.error).toHaveBeenCalledWith(
+        'Failed to load exemption data from MongoDB',
+        {
+          error: 'MongoDB connection failed',
+          exemptionId: 'test-exemption-id'
+        }
+      )
+    })
+
+    test('loadSiteDetailsFromMongoDB returns empty object when no exemption ID', async () => {
+      const exemption = {}
+
+      const result = await loadSiteDetailsFromMongoDB(
+        mockRequest,
+        exemption,
+        mockAuthenticatedGetRequest
+      )
+
+      expect(result).toEqual({})
+      expect(mockAuthenticatedGetRequest).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('prepareFileUploadDataForSave util', () => {
+    const mockRequest = {
+      logger: {
+        info: jest.fn()
+      }
+    }
+
+    beforeEach(() => {
+      jest.clearAllMocks()
+    })
+
+    test('prepareFileUploadDataForSave correctly formats data for API submission', () => {
+      const siteDetails = {
+        fileUploadType: 'kml',
+        geoJSON: {
+          type: 'FeatureCollection',
+          features: [
+            {
+              type: 'Feature',
+              geometry: {
+                type: 'Point',
+                coordinates: [51.5074, -0.1278]
+              }
+            }
+          ]
+        },
+        featureCount: 1,
+        uploadedFile: {
+          filename: 'test-site.kml',
+          s3Location: {
+            s3Bucket: 'test-bucket',
+            s3Key: 'test-key',
+            checksumSha256: 'test-checksum'
+          }
+        }
+      }
+
+      const result = prepareFileUploadDataForSave(siteDetails, mockRequest)
+
+      expect(result).toEqual({
+        coordinatesType: 'file',
+        fileUploadType: 'kml',
+        geoJSON: siteDetails.geoJSON,
+        featureCount: 1,
+        uploadedFile: {
+          filename: 'test-site.kml'
+        },
+        s3Location: {
+          s3Bucket: 'test-bucket',
+          s3Key: 'test-key',
+          checksumSha256: 'test-checksum'
+        }
+      })
+
+      expect(mockRequest.logger.info).toHaveBeenCalledWith(
+        'Saving file upload site details',
+        {
+          fileType: 'kml',
+          featureCount: 1,
+          filename: 'test-site.kml'
+        }
+      )
+    })
+
+    test('prepareFileUploadDataForSave handles missing featureCount', () => {
+      const siteDetails = {
+        fileUploadType: 'shapefile',
+        geoJSON: { type: 'FeatureCollection', features: [] },
+        uploadedFile: {
+          filename: 'test.shp',
+          s3Location: {
+            s3Bucket: 'bucket',
+            s3Key: 'key',
+            checksumSha256: 'checksum'
+          }
+        }
+      }
+
+      const result = prepareFileUploadDataForSave(siteDetails, mockRequest)
+
+      expect(result.featureCount).toBe(0)
+    })
+  })
+
+  describe('prepareManualCoordinateDataForSave util', () => {
+    const mockRequest = {
+      logger: {
+        info: jest.fn()
+      }
+    }
+
+    beforeEach(() => {
+      jest.clearAllMocks()
+    })
+
+    test('prepareManualCoordinateDataForSave returns site details and logs correctly', () => {
+      const exemption = {
+        siteDetails: {
+          coordinatesType: 'coordinates',
+          coordinatesEntry: 'single',
+          coordinates: {
+            latitude: '51.5074',
+            longitude: '-0.1278'
+          },
+          circleWidth: '100'
+        }
+      }
+
+      const result = prepareManualCoordinateDataForSave(exemption, mockRequest)
+
+      expect(result).toEqual(exemption.siteDetails)
+      expect(mockRequest.logger.info).toHaveBeenCalledWith(
+        'Saving manual coordinate site details',
+        {
+          coordinatesType: 'coordinates',
+          coordinatesEntry: 'single'
+        }
+      )
+    })
+  })
+
+  describe('renderFileUploadReview util', () => {
+    const mockH = {
+      view: jest.fn()
+    }
+
+    beforeEach(() => {
+      jest.clearAllMocks()
+    })
+
+    test('renderFileUploadReview renders correct view with data', () => {
+      const exemption = {
+        projectName: 'Test Project'
+      }
+      const siteDetails = {
+        fileUploadType: 'kml',
+        uploadedFile: {
+          filename: 'test-site.kml'
+        },
+        geoJSON: {
+          type: 'FeatureCollection',
+          features: [
+            {
+              type: 'Feature',
+              geometry: {
+                type: 'Point',
+                coordinates: [51.5074, -0.1278]
+              }
+            }
+          ]
+        }
+      }
+      const previousPage = `http://hostname${routes.FILE_UPLOAD}`
+      const reviewSiteDetailsPageData = {
+        pageTitle: 'Review site details'
+      }
+
+      renderFileUploadReview(
+        mockH,
+        exemption,
+        siteDetails,
+        previousPage,
+        reviewSiteDetailsPageData
+      )
+
+      expect(mockH.view).toHaveBeenCalledWith(
+        'exemption/site-details/review-site-details/file-upload-review',
+        {
+          pageTitle: 'Review site details',
+          backLink: routes.FILE_UPLOAD,
+          projectName: 'Test Project',
+          fileUploadSummaryData: {
+            method: 'Upload a file with the coordinates of the site',
+            fileType: 'KML',
+            filename: 'test-site.kml',
+            coordinates: [
+              {
+                type: 'Point',
+                coordinates: [51.5074, -0.1278]
+              }
+            ]
+          }
+        }
+      )
+    })
+  })
+
+  describe('renderManualCoordinateReview util', () => {
+    const mockH = {
+      view: jest.fn()
+    }
+    const mockRequest = {}
+
+    beforeEach(() => {
+      jest.clearAllMocks()
+      // Mock the getCoordinateSystem helper
+      getCoordinateSystem.mockReturnValue({
+        coordinateSystem: COORDINATE_SYSTEMS.WGS84
+      })
+    })
+
+    test('renderManualCoordinateReview renders correct view with data', () => {
+      const exemption = {
+        projectName: 'Test Project'
+      }
+      const siteDetails = {
+        coordinatesEntry: 'single',
+        coordinatesType: 'coordinates',
+        coordinates: {
+          latitude: '51.5074',
+          longitude: '-0.1278'
+        },
+        circleWidth: '100'
+      }
+      const previousPage = `http://hostname${routes.WIDTH_OF_SITE}`
+      const reviewSiteDetailsPageData = {
+        pageTitle: 'Review site details'
+      }
+
+      renderManualCoordinateReview(
+        mockH,
+        mockRequest,
+        exemption,
+        siteDetails,
+        previousPage,
+        reviewSiteDetailsPageData
+      )
+
+      expect(mockH.view).toHaveBeenCalledWith(
+        'exemption/site-details/review-site-details/index',
+        {
+          pageTitle: 'Review site details',
+          backLink: routes.WIDTH_OF_SITE,
+          projectName: 'Test Project',
+          summaryData: {
+            method:
+              'Manually enter one set of coordinates and a width to create a circular site',
+            coordinateSystem:
+              'WGS84 (World Geodetic System 1984)\nLatitude and longitude',
+            coordinates: '51.5074, -0.1278',
+            width: '100 metres'
+          }
+        }
+      )
+    })
+  })
+
+  describe('handleSubmissionError util', () => {
+    const mockRequest = {
+      logger: {
+        error: jest.fn()
+      }
+    }
+
+    beforeEach(() => {
+      jest.clearAllMocks()
+    })
+
+    test('handleSubmissionError logs error and returns Boom error', () => {
+      const error = new Error('Test error message')
+      const exemptionId = 'test-exemption-id'
+      const coordinatesType = 'coordinates'
+
+      const result = handleSubmissionError(
+        mockRequest,
+        error,
+        exemptionId,
+        coordinatesType
+      )
+
+      expect(mockRequest.logger.error).toHaveBeenCalledWith(
+        'Error submitting site review',
+        {
+          error: 'Test error message',
+          exemptionId: 'test-exemption-id',
+          coordinatesType: 'coordinates'
+        }
+      )
+
+      expect(Boom.isBoom(result)).toBe(true)
+      expect(result.output.statusCode).toBe(400)
+      expect(result.message).toBe('Error submitting site review')
     })
   })
 })

--- a/src/server/exemption/site-details/review-site-details/utils.test.js
+++ b/src/server/exemption/site-details/review-site-details/utils.test.js
@@ -460,6 +460,51 @@ describe('siteDetails utils', () => {
       )
     })
 
+    test('loadSiteDetailsFromMongoDB logs warning when MongoDB response has no site details', async () => {
+      const exemption = {
+        id: 'test-exemption-id',
+        siteDetails: undefined
+      }
+
+      const mockRequest = {
+        logger: {
+          info: jest.fn(),
+          error: jest.fn(),
+          warn: jest.fn()
+        }
+      }
+
+      const mockMongoResponse = {
+        payload: {
+          value: {
+            // No siteDetails property in response
+            otherData: 'some data'
+          }
+        }
+      }
+
+      mockAuthenticatedGetRequest.mockResolvedValue(mockMongoResponse)
+
+      const result = await loadSiteDetailsFromMongoDB(
+        mockRequest,
+        exemption,
+        mockAuthenticatedGetRequest
+      )
+
+      expect(result).toEqual({})
+      expect(mockAuthenticatedGetRequest).toHaveBeenCalledWith(
+        mockRequest,
+        '/exemption/test-exemption-id'
+      )
+      expect(mockRequest.logger.warn).toHaveBeenCalledWith(
+        'No site details found in MongoDB response',
+        {
+          exemptionId: 'test-exemption-id'
+        }
+      )
+      expect(mockRequest.logger.info).not.toHaveBeenCalled()
+    })
+
     test('loadSiteDetailsFromMongoDB returns empty object when no exemption ID', async () => {
       const exemption = {}
 

--- a/src/server/exemption/site-details/upload-and-wait/controller.js
+++ b/src/server/exemption/site-details/upload-and-wait/controller.js
@@ -1,6 +1,7 @@
 import {
   getExemptionCache,
-  updateExemptionSiteDetails
+  updateExemptionSiteDetails,
+  updateExemptionSiteDetailsBatch
 } from '~/src/server/common/helpers/session-cache/utils.js'
 import { getCdpUploadService } from '~/src/services/cdp-upload-service/index.js'
 import { getFileValidationService } from '~/src/services/file-validation/index.js'
@@ -192,7 +193,7 @@ function handleCdpRejectionError(request, status, fileType) {
  * @param {object} request - Hapi request object
  */
 function clearUploadSession(request) {
-  updateExemptionSiteDetails(request, 'uploadConfig', undefined)
+  updateExemptionSiteDetails(request, 'uploadConfig', null)
 }
 
 /**
@@ -225,32 +226,22 @@ function storeSuccessfulUpload(
   s3Bucket,
   s3Key
 ) {
-  // Store uploaded file details in session
-  updateExemptionSiteDetails(request, 'uploadedFile', {
-    ...status,
-    s3Location: {
-      s3Bucket,
-      s3Key,
-      fileId: status.s3Location.fileId,
-      s3Url: status.s3Location.s3Url,
-      checksumSha256: status.s3Location.checksumSha256
-    }
+  updateExemptionSiteDetailsBatch(request, {
+    uploadedFile: {
+      ...status,
+      s3Location: {
+        s3Bucket,
+        s3Key,
+        fileId: status.s3Location.fileId,
+        s3Url: status.s3Location.s3Url,
+        checksumSha256: status.s3Location.checksumSha256
+      }
+    },
+    extractedCoordinates: coordinateData.extractedCoordinates,
+    geoJSON: coordinateData.geoJSON,
+    featureCount: coordinateData.featureCount,
+    uploadConfig: null // Clear upload config
   })
-
-  // Store extracted coordinates for review page
-  updateExemptionSiteDetails(
-    request,
-    'extractedCoordinates',
-    coordinateData.extractedCoordinates
-  )
-  updateExemptionSiteDetails(request, 'geoJSON', coordinateData.geoJSON)
-  updateExemptionSiteDetails(
-    request,
-    'featureCount',
-    coordinateData.featureCount
-  )
-
-  clearUploadSession(request)
 }
 
 /**
@@ -442,7 +433,7 @@ export const uploadAndWaitController = {
       })
 
       // Clear upload config and redirect to file type selection
-      updateExemptionSiteDetails(request, 'uploadConfig', undefined)
+      updateExemptionSiteDetails(request, 'uploadConfig', null)
       return h.redirect(routes.CHOOSE_FILE_UPLOAD_TYPE)
     }
   }

--- a/src/server/exemption/site-details/upload-and-wait/controller.js
+++ b/src/server/exemption/site-details/upload-and-wait/controller.js
@@ -39,7 +39,6 @@ const transformCdpErrorToValidationError = (message, fileType) => {
   } else if (message.includes('smaller than')) {
     errorMessage = 'The selected file must be smaller than 50 MB'
   } else if (message.includes('must be a')) {
-    // Contextualize file type error based on selected type
     if (fileType === 'kml') {
       errorMessage = 'The selected file must be a KML file'
     } else if (fileType === 'shapefile') {
@@ -107,7 +106,6 @@ async function extractCoordinatesFromFile(request, s3Bucket, s3Key, fileType) {
       throw new Error('Invalid GeoJSON structure')
     }
 
-    // Extract coordinate array from GeoJSON for display using utility function
     const extractedCoordinates = extractCoordinatesFromGeoJSON(geoJSON)
 
     request.logger.info('Successfully extracted coordinates', {
@@ -252,7 +250,6 @@ function storeSuccessfulUpload(
     coordinateData.featureCount
   )
 
-  // Clear upload config from session
   clearUploadSession(request)
 }
 
@@ -264,7 +261,7 @@ function storeSuccessfulUpload(
  * @returns {object} Hapi response (view with processing status)
  */
 function handleProcessingStatus(status, exemption, h) {
-  // Still processing - show waiting page with meta refresh
+  // Show waiting page with meta refresh
   return h.view(UPLOAD_AND_WAIT_VIEW_ROUTE, {
     ...pageSettings,
     projectName: exemption.projectName,
@@ -292,7 +289,6 @@ async function handleReadyStatus(status, uploadConfig, request, h) {
   )
 
   if (!validation.isValid) {
-    // File failed our validation - handle error and redirect
     handleValidationError(request, validation, uploadConfig.fileType)
     return h.redirect(routes.FILE_UPLOAD)
   }
@@ -422,12 +418,10 @@ export const uploadAndWaitController = {
     const { uploadConfig } = exemption.siteDetails || {}
 
     if (!uploadConfig) {
-      // No upload session, redirect back to file type selection
       return h.redirect(routes.CHOOSE_FILE_UPLOAD_TYPE)
     }
 
     try {
-      // Check upload status
       const cdpService = getCdpUploadService()
       const status = await cdpService.getStatus(
         uploadConfig.uploadId,

--- a/src/server/exemption/site-details/upload-and-wait/controller.js
+++ b/src/server/exemption/site-details/upload-and-wait/controller.js
@@ -5,6 +5,9 @@ import {
 import { getCdpUploadService } from '~/src/services/cdp-upload-service/index.js'
 import { getFileValidationService } from '~/src/services/file-validation/index.js'
 import { routes } from '~/src/server/common/constants/routes.js'
+import { authenticatedPostRequest } from '~/src/server/common/helpers/authenticated-requests.js'
+import { config } from '~/src/config/config.js'
+import { extractCoordinatesFromGeoJSON } from '~/src/server/common/helpers/coordinate-utils.js'
 
 export const UPLOAD_AND_WAIT_VIEW_ROUTE =
   'exemption/site-details/upload-and-wait/index'
@@ -73,15 +76,311 @@ function getAllowedExtensions(fileType) {
 }
 
 /**
+ * Extract coordinates from uploaded file using geo-parser API
+ * @param {Request} request - Hapi request object
+ * @param {string} s3Bucket - S3 bucket name
+ * @param {string} s3Key - S3 object key
+ * @param {string} fileType - File type ('kml' or 'shapefile')
+ * @returns {Promise<object>} Extracted coordinates and GeoJSON
+ */
+async function extractCoordinatesFromFile(request, s3Bucket, s3Key, fileType) {
+  try {
+    request.logger.info('Calling geo-parser API', { s3Bucket, s3Key, fileType })
+
+    const response = await authenticatedPostRequest(
+      request,
+      '/geo-parser/extract',
+      {
+        s3Bucket,
+        s3Key,
+        fileType
+      }
+    )
+
+    const { payload } = response
+    if (!payload || payload.message !== 'success') {
+      throw new Error('Invalid geo-parser response')
+    }
+
+    const geoJSON = payload.value
+    if (!geoJSON?.features) {
+      throw new Error('Invalid GeoJSON structure')
+    }
+
+    // Extract coordinate array from GeoJSON for display using utility function
+    const extractedCoordinates = extractCoordinatesFromGeoJSON(geoJSON)
+
+    request.logger.info('Successfully extracted coordinates', {
+      featureCount: geoJSON.features.length,
+      coordinateCount: extractedCoordinates.length
+    })
+
+    return {
+      geoJSON,
+      extractedCoordinates,
+      featureCount: geoJSON.features.length
+    }
+  } catch (error) {
+    request.logger.error('Failed to extract coordinates from file', {
+      error: error.message,
+      s3Bucket,
+      s3Key,
+      fileType
+    })
+    throw error
+  }
+}
+
+/**
+ * Handle file validation errors
+ * @param {object} request - Hapi request object
+ * @param {object} validation - Validation result object
+ * @param {string} fileType - File type for contextualized errors
+ * @returns {object} Error details for redirection
+ */
+function handleValidationError(request, validation, fileType) {
+  const errorDetails = transformCdpErrorToValidationError(
+    validation.errorMessage,
+    fileType
+  )
+  storeUploadError(request, errorDetails, fileType)
+  return { redirect: routes.FILE_UPLOAD }
+}
+
+/**
+ * Handle geo-parser processing errors
+ * @param {object} request - Hapi request object
+ * @param {Error} error - The caught error
+ * @param {string} filename - Upload filename for logging
+ * @param {string} fileType - File type for contextualized errors
+ * @returns {object} Error details for redirection
+ */
+function handleGeoParserError(request, error, filename, fileType) {
+  const errorDetails = {
+    message: 'The selected file could not be processed – try again',
+    fieldName: 'file',
+    fileType
+  }
+
+  storeUploadError(request, errorDetails, fileType)
+
+  request.logger.error('Failed to extract coordinates from uploaded file', {
+    error: error.message,
+    filename,
+    fileType
+  })
+
+  return { redirect: routes.FILE_UPLOAD }
+}
+
+/**
+ * Handle CDP rejection or error statuses
+ * @param {object} request - Hapi request object
+ * @param {object} status - Upload status response from CDP
+ * @param {string} fileType - File type for contextualized errors
+ * @returns {object} Error details for redirection
+ */
+function handleCdpRejectionError(request, status, fileType) {
+  const errorDetails = transformCdpErrorToValidationError(
+    status.message,
+    fileType
+  )
+  storeUploadError(request, errorDetails, fileType)
+  return { redirect: routes.FILE_UPLOAD }
+}
+
+/**
+ * Clear upload configuration from session
+ * @param {object} request - Hapi request object
+ */
+function clearUploadSession(request) {
+  updateExemptionSiteDetails(request, 'uploadConfig', undefined)
+}
+
+/**
+ * Store upload error details in session and clear upload config
+ * @param {object} request - Hapi request object
+ * @param {object} errorDetails - Error details with message and fieldName
+ * @param {string} fileType - File type for contextualized errors
+ */
+function storeUploadError(request, errorDetails, fileType) {
+  updateExemptionSiteDetails(request, 'uploadError', {
+    message: errorDetails.message,
+    fieldName: errorDetails.fieldName,
+    fileType
+  })
+  clearUploadSession(request)
+}
+
+/**
+ * Store successful upload data and coordinate extraction results in session
+ * @param {object} request - Hapi request object
+ * @param {object} status - Upload status response from CDP
+ * @param {object} coordinateData - Extracted coordinate data
+ * @param {string} s3Bucket - S3 bucket name
+ * @param {string} s3Key - S3 object key
+ */
+function storeSuccessfulUpload(
+  request,
+  status,
+  coordinateData,
+  s3Bucket,
+  s3Key
+) {
+  // Store uploaded file details in session
+  updateExemptionSiteDetails(request, 'uploadedFile', {
+    ...status,
+    s3Location: {
+      s3Bucket,
+      s3Key,
+      fileId: status.s3Location.fileId,
+      s3Url: status.s3Location.s3Url,
+      checksumSha256: status.s3Location.checksumSha256
+    }
+  })
+
+  // Store extracted coordinates for review page
+  updateExemptionSiteDetails(
+    request,
+    'extractedCoordinates',
+    coordinateData.extractedCoordinates
+  )
+  updateExemptionSiteDetails(request, 'geoJSON', coordinateData.geoJSON)
+  updateExemptionSiteDetails(
+    request,
+    'featureCount',
+    coordinateData.featureCount
+  )
+
+  // Clear upload config from session
+  clearUploadSession(request)
+}
+
+/**
+ * Handle upload status when file is still being processed
+ * @param {object} status - Upload status response from CDP
+ * @param {object} exemption - Exemption data from session
+ * @param {object} h - Hapi response toolkit
+ * @returns {object} Hapi response (view with processing status)
+ */
+function handleProcessingStatus(status, exemption, h) {
+  // Still processing - show waiting page with meta refresh
+  return h.view(UPLOAD_AND_WAIT_VIEW_ROUTE, {
+    ...pageSettings,
+    projectName: exemption.projectName,
+    isProcessing: true,
+    filename: status.filename
+  })
+}
+
+/**
+ * Handle upload status when file is ready for processing
+ * @param {object} status - Upload status response from CDP
+ * @param {object} uploadConfig - Upload configuration from session
+ * @param {object} request - Hapi request object
+ * @param {object} h - Hapi response toolkit
+ * @returns {Promise<object>} Hapi response (redirect)
+ */
+async function handleReadyStatus(status, uploadConfig, request, h) {
+  // Apply our business validation to files that passed CDP checks
+  const fileValidationService = getFileValidationService(request.logger)
+  const allowedExtensions = getAllowedExtensions(uploadConfig.fileType)
+
+  const validation = fileValidationService.validateFileExtension(
+    status.filename,
+    allowedExtensions
+  )
+
+  if (!validation.isValid) {
+    // File failed our validation - handle error and redirect
+    handleValidationError(request, validation, uploadConfig.fileType)
+    return h.redirect(routes.FILE_UPLOAD)
+  }
+
+  // File passed all validations - extract coordinates and store details
+  try {
+    // Get S3 details for geo-parser API call
+    const cdpUploadConfig = config.get('cdpUploader')
+    const s3Bucket = cdpUploadConfig.s3Bucket
+    const s3Key = status.s3Location.s3Key
+
+    // Extract coordinates using geo-parser API
+    const coordinateData = await extractCoordinatesFromFile(
+      request,
+      s3Bucket,
+      s3Key,
+      uploadConfig.fileType
+    )
+
+    // Store all successful upload data in session
+    storeSuccessfulUpload(request, status, coordinateData, s3Bucket, s3Key)
+
+    request.logger.info(
+      'File upload and coordinate extraction completed successfully',
+      {
+        filename: status.filename,
+        fileType: uploadConfig.fileType,
+        featureCount: coordinateData.featureCount
+      }
+    )
+
+    // Redirect to review site details page
+    return h.redirect(routes.REVIEW_SITE_DETAILS)
+  } catch (error) {
+    // Handle geo-parser errors and redirect
+    handleGeoParserError(request, error, status.filename, uploadConfig.fileType)
+    return h.redirect(routes.FILE_UPLOAD)
+  }
+}
+
+/**
+ * Handle upload status when file is rejected or has an error
+ * @param {object} status - Upload status response from CDP
+ * @param {object} uploadConfig - Upload configuration from session
+ * @param {object} request - Hapi request object
+ * @param {object} h - Hapi response toolkit
+ * @returns {object} Hapi response (redirect)
+ */
+function handleRejectedStatus(status, uploadConfig, request, h) {
+  // Handle CDP rejection/error and redirect
+  handleCdpRejectionError(request, status, uploadConfig.fileType)
+  return h.redirect(routes.FILE_UPLOAD)
+}
+
+/**
+ * Handle unknown upload status
+ * @param {object} request - Hapi request object
+ * @param {object} uploadConfig - Upload configuration from session
+ * @param {object} status - Upload status response from CDP
+ * @param {object} h - Hapi response toolkit
+ * @returns {object} Hapi response (redirect)
+ */
+function handleUnknownStatus(request, uploadConfig, status, h) {
+  // Unknown status - redirect to file type selection
+  request.logger.warn('Unknown upload status', {
+    uploadId: uploadConfig.uploadId,
+    status: status.status
+  })
+
+  return h.redirect(routes.CHOOSE_FILE_UPLOAD_TYPE)
+}
+
+/**
  * Process upload status and handle appropriate response
  * @param {object} status - Upload status response from CDP
  * @param {object} uploadConfig - Upload configuration from session
  * @param {object} request - Hapi request object
  * @param {object} h - Hapi response toolkit
  * @param {object} exemption - Exemption data from session
- * @returns {object} Hapi response (view or redirect)
+ * @returns {Promise<object>} Hapi response (view or redirect)
  */
-function processUploadStatus(status, uploadConfig, request, h, exemption) {
+async function processUploadStatus(
+  status,
+  uploadConfig,
+  request,
+  h,
+  exemption
+) {
   request.logger.debug(
     `Upload status check:  ${JSON.stringify(
       {
@@ -95,84 +394,19 @@ function processUploadStatus(status, uploadConfig, request, h, exemption) {
   )
 
   if (status.status === 'pending' || status.status === 'scanning') {
-    // Still processing - show waiting page with meta refresh
-    return h.view(UPLOAD_AND_WAIT_VIEW_ROUTE, {
-      ...pageSettings,
-      projectName: exemption.projectName,
-      isProcessing: true,
-      filename: status.filename
-    })
+    return handleProcessingStatus(status, exemption, h)
   }
 
   if (status.status === 'ready') {
-    // Apply our business validation to files that passed CDP checks
-    const fileValidationService = getFileValidationService(request.logger)
-    const allowedExtensions = getAllowedExtensions(uploadConfig.fileType)
-
-    const validation = fileValidationService.validateFileExtension(
-      status.filename,
-      allowedExtensions
-    )
-
-    if (!validation.isValid) {
-      // File failed our validation - treat as rejection
-      const errorDetails = transformCdpErrorToValidationError(
-        validation.errorMessage,
-        uploadConfig.fileType
-      )
-
-      // Store error details in session for file-upload controller to handle
-      updateExemptionSiteDetails(request, 'uploadError', {
-        message: errorDetails.message,
-        fieldName: errorDetails.fieldName,
-        fileType: uploadConfig.fileType
-      })
-
-      // Clear upload config from session
-      updateExemptionSiteDetails(request, 'uploadConfig', undefined)
-
-      // Redirect to file-upload route to handle error display and new session creation
-      return h.redirect(routes.FILE_UPLOAD)
-    }
-
-    // File passed all validations - store file details in session
-    updateExemptionSiteDetails(request, 'uploadedFile', status)
-
-    // Clear upload config from session
-    updateExemptionSiteDetails(request, 'uploadConfig', undefined)
-
-    // Change this to next page when built
-    return h.redirect(routes.FILE_UPLOAD)
+    return handleReadyStatus(status, uploadConfig, request, h)
   }
 
   if (status.status === 'rejected' || status.status === 'error') {
-    // File rejected or error - store error details in session and redirect
-    const errorDetails = transformCdpErrorToValidationError(
-      status.message,
-      uploadConfig.fileType
-    )
-
-    // Store error details in session for file-upload controller to handle
-    updateExemptionSiteDetails(request, 'uploadError', {
-      message: errorDetails.message,
-      fieldName: errorDetails.fieldName,
-      fileType: uploadConfig.fileType
-    })
-
-    // Clear upload config from session
-    updateExemptionSiteDetails(request, 'uploadConfig', undefined)
-
-    // Redirect to file-upload route to handle error display and new session creation
-    return h.redirect(routes.FILE_UPLOAD)
+    return handleRejectedStatus(status, uploadConfig, request, h)
   }
 
-  // Unknown status - redirect to file type selection
-  request.logger.warn('Unknown upload status', {
-    uploadId: uploadConfig.uploadId,
-    status: status.status
-  })
-
-  return h.redirect(routes.CHOOSE_FILE_UPLOAD_TYPE)
+  // Unknown status
+  return handleUnknownStatus(request, uploadConfig, status, h)
 }
 
 /**
@@ -200,7 +434,13 @@ export const uploadAndWaitController = {
         uploadConfig.statusUrl
       )
 
-      return processUploadStatus(status, uploadConfig, request, h, exemption)
+      return await processUploadStatus(
+        status,
+        uploadConfig,
+        request,
+        h,
+        exemption
+      )
     } catch (error) {
       request.logger.error('Failed to check upload status', {
         error: error.message,

--- a/src/server/exemption/site-details/upload-and-wait/controller.test.js
+++ b/src/server/exemption/site-details/upload-and-wait/controller.test.js
@@ -1,4 +1,3 @@
-import { createServer } from '~/src/server/index.js'
 import {
   uploadAndWaitController,
   UPLOAD_AND_WAIT_VIEW_ROUTE
@@ -10,16 +9,12 @@ import * as authenticatedRequests from '~/src/server/common/helpers/authenticate
 import { mockExemption } from '~/src/server/test-helpers/mocks.js'
 import { routes } from '~/src/server/common/constants/routes.js'
 import { config } from '~/src/config/config.js'
-import path from 'path'
-import hapi from '@hapi/hapi'
 
 jest.mock('~/src/server/common/helpers/session-cache/utils.js')
 jest.mock('~/src/services/cdp-upload-service/index.js')
 jest.mock('~/src/services/file-validation/index.js')
 jest.mock('~/src/server/common/helpers/authenticated-requests.js')
 jest.mock('~/src/config/config.js')
-jest.mock('path')
-jest.mock('@hapi/hapi')
 
 // Mock logger configuration
 jest.mock('~/src/server/common/helpers/logging/logger-options.js', () => ({
@@ -41,56 +36,6 @@ jest.mock('~/src/server/common/helpers/logging/logger.js', () => ({
     debug: jest.fn()
   })
 }))
-
-// Mock path.join to return a fixed path
-path.join.mockImplementation((...args) => args.join('/'))
-
-// Mock manifest file
-jest.mock('~/src/config/nunjucks/context/context.js', () => ({
-  getContext: jest.fn().mockReturnValue({})
-}))
-
-// Mock session configuration
-jest.mock('~/src/server/common/helpers/session-cache/session-cache.js', () => ({
-  sessionConfig: {
-    cache: {
-      name: 'test-cache',
-      ttl: 24 * 60 * 60 * 1000
-    }
-  }
-}))
-
-// Mock cache engine
-jest.mock('~/src/server/common/helpers/session-cache/cache-engine.js', () => ({
-  getCacheEngine: jest.fn().mockReturnValue({
-    start: jest.fn(),
-    stop: jest.fn(),
-    isReady: jest.fn().mockReturnValue(true),
-    validateSegmentName: jest.fn(),
-    get: jest.fn(),
-    set: jest.fn(),
-    drop: jest.fn()
-  })
-}))
-
-// Mock server cache
-const mockServerCache = {
-  get: jest.fn(),
-  set: jest.fn(),
-  drop: jest.fn()
-}
-
-// Mock Hapi server
-const mockServer = {
-  app: {},
-  cache: jest.fn().mockReturnValue(mockServerCache),
-  register: jest.fn(),
-  ext: jest.fn(),
-  initialize: jest.fn(),
-  stop: jest.fn()
-}
-
-hapi.server.mockReturnValue(mockServer)
 
 // Test Data Factories
 const createMockUploadConfig = (overrides = {}) => ({
@@ -159,49 +104,11 @@ const createMockResponseHandler = () => ({
 // Mock Configuration Setup
 const setupMockConfig = () => {
   config.get.mockImplementation((key) => {
-    const configMap = {
-      cdpUploader: { s3Bucket: 'test-bucket' },
-      root: '/test/root',
-      assetPath: '/test/assets',
-      env: 'test',
-      isDev: false,
-      isTest: true,
-      isProd: false,
-      serviceName: 'test-service',
-      serviceUrl: 'http://test-service',
-      port: 3000,
-      staticCacheControl: 'public, max-age=86400',
-      cookieOptions: {
-        ttl: 24 * 60 * 60 * 1000,
-        encoding: 'base64json',
-        isSecure: true,
-        isHttpOnly: true,
-        clearInvalid: true,
-        strictHeader: true
-      },
-      sessionCookieName: 'test-session',
-      redisHost: 'localhost',
-      redisPort: 6379,
-      redisPassword: '',
-      redisPrefix: 'test:',
-      redisTls: false,
-      redisDb: 0,
-      redisTimeout: 2000,
-      sessionTtl: 24 * 60 * 60 * 1000,
-      trustStorePath: '/test/trust-store',
-      trustStoreType: 'test',
-      trustStorePassword: 'test',
-      trustStoreCerts: [],
-      trustStoreEnabled: false,
-      'session.cache.name': 'test-cache',
-      'session.cache.engine': 'memory',
-      'session.cookie.password': 'test-password',
-      'session.cookie.ttl': 24 * 60 * 60 * 1000,
-      'session.cookie.secure': false,
-      'redis.ttl': 24 * 60 * 60 * 1000,
-      log: { enabled: true, redact: [] }
+    if (key === 'cdpUploader') {
+      return { s3Bucket: 'test-bucket' }
     }
-    return configMap[key]
+    // Return undefined for any other keys - will cause test to fail if something unexpected is accessed
+    return undefined
   })
 }
 
@@ -384,19 +291,12 @@ const expectFileValidationFailure = async (
 }
 
 describe('#uploadAndWait', () => {
-  /** @type {Server} */
-  let server
   let getExemptionCacheSpy
   let updateExemptionSiteDetailsSpy
   let updateExemptionSiteDetailsBatchSpy
   let mockCdpService
   let mockFileValidationService
   let authenticatedPostRequestSpy
-
-  beforeAll(async () => {
-    server = await createServer()
-    await server.initialize()
-  })
 
   beforeEach(() => {
     jest.resetAllMocks()
@@ -415,12 +315,6 @@ describe('#uploadAndWait', () => {
     mockFileValidationService = services.mockFileValidationService
 
     authenticatedPostRequestSpy = setupAuthenticatedRequestSpy()
-  })
-
-  afterAll(async () => {
-    if (server) {
-      await server.stop({ timeout: 0 })
-    }
   })
 
   describe('#uploadAndWaitController', () => {

--- a/src/server/exemption/site-details/upload-and-wait/controller.test.js
+++ b/src/server/exemption/site-details/upload-and-wait/controller.test.js
@@ -416,7 +416,6 @@ describe('#uploadAndWait', () => {
 
   describe('#uploadAndWaitController', () => {
     const mockRequest = createMockRequest()
-    // const mockUploadConfig = createMockUploadConfig()
 
     describe('when no upload config exists', () => {
       /* eslint-disable jest/expect-expect */

--- a/src/server/exemption/site-details/upload-and-wait/controller.test.js
+++ b/src/server/exemption/site-details/upload-and-wait/controller.test.js
@@ -419,6 +419,7 @@ describe('#uploadAndWait', () => {
     // const mockUploadConfig = createMockUploadConfig()
 
     describe('when no upload config exists', () => {
+      /* eslint-disable jest/expect-expect */
       test('should redirect to CHOOSE_FILE_UPLOAD_TYPE', async () => {
         // Given no upload config exists
         getExemptionCacheSpy.mockReturnValue({})
@@ -461,6 +462,7 @@ describe('#uploadAndWait', () => {
         })
       })
 
+      /* eslint-disable jest/expect-expect */
       test('should show waiting page when status is scanning', async () => {
         // Given exemption with upload config and scanning status
         getExemptionCacheSpy.mockReturnValue(createMockExemption())
@@ -615,6 +617,7 @@ describe('#uploadAndWait', () => {
     })
 
     describe('when file validation fails', () => {
+      /* eslint-disable jest/expect-expect */
       test('should redirect to file upload with error for wrong extension', async () => {
         await expectFileValidationFailure(
           mockRequest,
@@ -629,6 +632,7 @@ describe('#uploadAndWait', () => {
         )
       })
 
+      /* eslint-disable jest/expect-expect */
       test('should handle unknown file type in getAllowedExtensions default case', async () => {
         await expectFileValidationFailure(
           mockRequest,
@@ -645,6 +649,7 @@ describe('#uploadAndWait', () => {
     })
 
     describe('when upload is rejected', () => {
+      /* eslint-disable jest/expect-expect */
       test('should redirect to file upload with virus error message', async () => {
         await expectRejectedStatusHandling(
           mockRequest,
@@ -656,6 +661,7 @@ describe('#uploadAndWait', () => {
         )
       })
 
+      /* eslint-disable jest/expect-expect */
       test('should handle error status the same as rejected status', async () => {
         // Given exemption with upload config and error status
         getExemptionCacheSpy.mockReturnValue(createMockExemption())
@@ -683,6 +689,7 @@ describe('#uploadAndWait', () => {
         expectRedirectTo(h, routes.FILE_UPLOAD)
       })
 
+      /* eslint-disable jest/expect-expect */
       test('should handle different error message types correctly', async () => {
         const testCases = [
           { message: 'file is empty', expected: 'The selected file is empty' },
@@ -716,6 +723,7 @@ describe('#uploadAndWait', () => {
         }
       })
 
+      /* eslint-disable jest/expect-expect */
       test('should handle unknown file type message correctly', async () => {
         await expectRejectedStatusHandling(
           mockRequest,
@@ -728,6 +736,7 @@ describe('#uploadAndWait', () => {
         )
       })
 
+      /* eslint-disable jest/expect-expect */
       test('should handle shapefile error message correctly', async () => {
         await expectRejectedStatusHandling(
           mockRequest,
@@ -800,6 +809,7 @@ describe('#uploadAndWait', () => {
         expectRedirectTo(h, routes.FILE_UPLOAD)
       })
 
+      /* eslint-disable jest/expect-expect */
       test('should handle geo-parser API returning invalid response', async () => {
         // Given exemption with upload config and ready status
         getExemptionCacheSpy.mockReturnValue(createMockExemption())
@@ -837,6 +847,7 @@ describe('#uploadAndWait', () => {
         expectRedirectTo(h, routes.FILE_UPLOAD)
       })
 
+      /* eslint-disable jest/expect-expect */
       test('should handle geo-parser API returning unsuccessful response', async () => {
         // Given exemption with upload config and ready status
         getExemptionCacheSpy.mockReturnValue(createMockExemption())
@@ -875,6 +886,7 @@ describe('#uploadAndWait', () => {
         expectRedirectTo(h, routes.FILE_UPLOAD)
       })
 
+      /* eslint-disable jest/expect-expect */
       test('should handle geo-parser API returning invalid GeoJSON structure', async () => {
         // Given exemption with upload config and ready status
         getExemptionCacheSpy.mockReturnValue(createMockExemption())
@@ -1004,6 +1016,7 @@ describe('#uploadAndWait', () => {
     })
 
     describe('edge cases', () => {
+      /* eslint-disable jest/expect-expect */
       test('should handle missing s3Location in status response', async () => {
         // Given exemption with upload config and ready status without s3Location
         getExemptionCacheSpy.mockReturnValue(createMockExemption())
@@ -1034,6 +1047,7 @@ describe('#uploadAndWait', () => {
         expectRedirectTo(h, routes.FILE_UPLOAD)
       })
 
+      /* eslint-disable jest/expect-expect */
       test('should handle empty filename in status response', async () => {
         // Given exemption with upload config and status with empty filename
         getExemptionCacheSpy.mockReturnValue(createMockExemption())

--- a/src/server/exemption/site-details/upload-and-wait/controller.test.js
+++ b/src/server/exemption/site-details/upload-and-wait/controller.test.js
@@ -92,6 +92,291 @@ const mockServer = {
 
 hapi.server.mockReturnValue(mockServer)
 
+// Test Data Factories
+const createMockUploadConfig = (overrides = {}) => ({
+  uploadId: 'test-upload-id',
+  statusUrl: 'test-status-url',
+  fileType: 'kml',
+  ...overrides
+})
+
+const createMockStatusResponse = (status, overrides = {}) => ({
+  status,
+  filename: 'test.kml',
+  fileSize: 1024,
+  completedAt: '2025-01-01T00:00:00.000Z',
+  ...(status === 'ready' && {
+    s3Location: {
+      s3Bucket: 'test-bucket',
+      s3Key: 'test-key',
+      fileId: 'test-id',
+      s3Url: 'test-url',
+      checksumSha256: 'test-checksum'
+    }
+  }),
+  ...overrides
+})
+
+const createMockExemption = (overrides = {}) => ({
+  projectName: 'Test Project',
+  siteDetails: { uploadConfig: createMockUploadConfig() },
+  ...overrides
+})
+
+const createMockRequest = () => ({
+  logger: {
+    debug: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn()
+  }
+})
+
+const createMockGeoJsonResponse = () => ({
+  statusCode: 200,
+  payload: {
+    message: 'success',
+    value: {
+      type: 'FeatureCollection',
+      features: [
+        {
+          type: 'Feature',
+          geometry: {
+            type: 'Point',
+            coordinates: [1, 2] // Simple test coordinates
+          }
+        }
+      ]
+    }
+  }
+})
+
+const createMockResponseHandler = () => ({
+  view: jest.fn(),
+  redirect: jest.fn()
+})
+
+// Mock Configuration Setup
+const setupMockConfig = () => {
+  config.get.mockImplementation((key) => {
+    const configMap = {
+      cdpUploader: { s3Bucket: 'test-bucket' },
+      root: '/test/root',
+      assetPath: '/test/assets',
+      env: 'test',
+      isDev: false,
+      isTest: true,
+      isProd: false,
+      serviceName: 'test-service',
+      serviceUrl: 'http://test-service',
+      port: 3000,
+      staticCacheControl: 'public, max-age=86400',
+      cookieOptions: {
+        ttl: 24 * 60 * 60 * 1000,
+        encoding: 'base64json',
+        isSecure: true,
+        isHttpOnly: true,
+        clearInvalid: true,
+        strictHeader: true
+      },
+      sessionCookieName: 'test-session',
+      redisHost: 'localhost',
+      redisPort: 6379,
+      redisPassword: '',
+      redisPrefix: 'test:',
+      redisTls: false,
+      redisDb: 0,
+      redisTimeout: 2000,
+      sessionTtl: 24 * 60 * 60 * 1000,
+      trustStorePath: '/test/trust-store',
+      trustStoreType: 'test',
+      trustStorePassword: 'test',
+      trustStoreCerts: [],
+      trustStoreEnabled: false,
+      'session.cache.name': 'test-cache',
+      'session.cache.engine': 'memory',
+      'session.cookie.password': 'test-password',
+      'session.cookie.ttl': 24 * 60 * 60 * 1000,
+      'session.cookie.secure': false,
+      'redis.ttl': 24 * 60 * 60 * 1000,
+      log: { enabled: true, redact: [] }
+    }
+    return configMap[key]
+  })
+}
+
+// Assertion Helpers
+const expectCacheUpdateWith = (spy, request, key, value) => {
+  expect(spy).toHaveBeenCalledWith(request, key, value)
+}
+
+const expectRedirectTo = (h, route) => {
+  expect(h.redirect).toHaveBeenCalledWith(route)
+}
+
+const expectViewCalledWith = (h, viewRoute, viewData) => {
+  expect(h.view).toHaveBeenCalledWith(viewRoute, viewData)
+}
+
+const expectUploadErrorSet = (spy, request, message, fileType = 'kml') => {
+  expectCacheUpdateWith(spy, request, 'uploadError', {
+    message,
+    fieldName: 'file',
+    fileType
+  })
+}
+
+const expectUploadConfigCleared = (spy, request) => {
+  expectCacheUpdateWith(spy, request, 'uploadConfig', undefined)
+}
+
+const expectSuccessfulFileProcessing = (spy, request) => {
+  // Verify essential data is stored (not testing exact structure)
+  expect(spy).toHaveBeenCalledWith(request, 'uploadedFile', expect.any(Object))
+  expect(spy).toHaveBeenCalledWith(
+    request,
+    'extractedCoordinates',
+    expect.any(Array)
+  )
+  expect(spy).toHaveBeenCalledWith(request, 'geoJSON', expect.any(Object))
+  expect(spy).toHaveBeenCalledWith(request, 'featureCount', expect.any(Number))
+
+  // Verify upload config is cleared (this behavior matters)
+  expectUploadConfigCleared(spy, request)
+}
+
+// Service Mock Setup Helpers
+const setupMockServices = () => {
+  const mockCdpService = {
+    getStatus: jest.fn()
+  }
+
+  const mockFileValidationService = {
+    validateFileExtension: jest.fn()
+  }
+
+  jest
+    .spyOn(cdpUploadService, 'getCdpUploadService')
+    .mockReturnValue(mockCdpService)
+  jest
+    .spyOn(fileValidationService, 'getFileValidationService')
+    .mockReturnValue(mockFileValidationService)
+
+  return { mockCdpService, mockFileValidationService }
+}
+
+const setupCacheSpies = () => {
+  const getExemptionCacheSpy = jest
+    .spyOn(cacheUtils, 'getExemptionCache')
+    .mockReturnValue(mockExemption)
+
+  const updateExemptionSiteDetailsSpy = jest
+    .spyOn(cacheUtils, 'updateExemptionSiteDetails')
+    .mockImplementation()
+
+  return { getExemptionCacheSpy, updateExemptionSiteDetailsSpy }
+}
+
+const setupAuthenticatedRequestSpy = () => {
+  return jest
+    .spyOn(authenticatedRequests, 'authenticatedPostRequest')
+    .mockResolvedValue(createMockGeoJsonResponse())
+}
+
+// Error Testing Helpers
+const expectRejectedStatusHandling = async (
+  mockRequest,
+  getExemptionCacheSpy,
+  mockCdpService,
+  updateExemptionSiteDetailsSpy,
+  rejectedMessage,
+  expectedErrorMessage,
+  fileType = 'kml'
+) => {
+  // Given exemption with upload config and rejected status
+  getExemptionCacheSpy.mockReturnValue(
+    createMockExemption({
+      siteDetails: { uploadConfig: createMockUploadConfig({ fileType }) }
+    })
+  )
+  mockCdpService.getStatus.mockResolvedValue({
+    status: 'rejected',
+    message: rejectedMessage
+  })
+
+  const h = createMockResponseHandler()
+
+  // When handler is called
+  await uploadAndWaitController.handler(mockRequest, h)
+
+  // Then expected error handling occurs
+  expectUploadErrorSet(
+    updateExemptionSiteDetailsSpy,
+    mockRequest,
+    expectedErrorMessage,
+    fileType
+  )
+  expectUploadConfigCleared(updateExemptionSiteDetailsSpy, mockRequest)
+  expectRedirectTo(h, routes.FILE_UPLOAD)
+}
+
+const expectFileValidationFailure = async (
+  mockRequest,
+  getExemptionCacheSpy,
+  mockCdpService,
+  mockFileValidationService,
+  updateExemptionSiteDetailsSpy,
+  filename,
+  fileType,
+  allowedExtensions,
+  errorMessage
+) => {
+  // Given exemption with upload config and ready status
+  getExemptionCacheSpy.mockReturnValue(
+    createMockExemption({
+      siteDetails: { uploadConfig: createMockUploadConfig({ fileType }) }
+    })
+  )
+
+  const statusResponse = createMockStatusResponse('ready', { filename })
+  mockCdpService.getStatus.mockResolvedValue(statusResponse)
+
+  // And failed file validation
+  mockFileValidationService.validateFileExtension.mockReturnValue({
+    isValid: false,
+    extension: filename.split('.').pop(),
+    errorMessage
+  })
+
+  const h = createMockResponseHandler()
+
+  // When handler is called
+  await uploadAndWaitController.handler(mockRequest, h)
+
+  // Then file validation is performed
+  expect(mockFileValidationService.validateFileExtension).toHaveBeenCalledWith(
+    filename,
+    allowedExtensions
+  )
+
+  // And error handling occurs
+  expectUploadErrorSet(
+    updateExemptionSiteDetailsSpy,
+    mockRequest,
+    errorMessage,
+    fileType
+  )
+  expectUploadConfigCleared(updateExemptionSiteDetailsSpy, mockRequest)
+  expectRedirectTo(h, routes.FILE_UPLOAD)
+
+  // And uploaded file should not be stored when validation fails
+  expect(updateExemptionSiteDetailsSpy).not.toHaveBeenCalledWith(
+    mockRequest,
+    'uploadedFile',
+    expect.anything()
+  )
+}
+
 describe('#uploadAndWait', () => {
   /** @type {Server} */
   let server
@@ -102,91 +387,6 @@ describe('#uploadAndWait', () => {
   let authenticatedPostRequestSpy
 
   beforeAll(async () => {
-    config.get.mockImplementation((key) => {
-      switch (key) {
-        case 'cdpUploader':
-          return {
-            s3Bucket: 'test-bucket'
-          }
-        case 'root':
-          return '/test/root'
-        case 'assetPath':
-          return '/test/assets'
-        case 'env':
-          return 'test'
-        case 'isDev':
-          return false
-        case 'isTest':
-          return true
-        case 'isProd':
-          return false
-        case 'serviceName':
-          return 'test-service'
-        case 'serviceUrl':
-          return 'http://test-service'
-        case 'port':
-          return 3000
-        case 'staticCacheControl':
-          return 'public, max-age=86400'
-        case 'cookieOptions':
-          return {
-            ttl: 24 * 60 * 60 * 1000,
-            encoding: 'base64json',
-            isSecure: true,
-            isHttpOnly: true,
-            clearInvalid: true,
-            strictHeader: true
-          }
-        case 'sessionCookieName':
-          return 'test-session'
-        case 'redisHost':
-          return 'localhost'
-        case 'redisPort':
-          return 6379
-        case 'redisPassword':
-          return ''
-        case 'redisPrefix':
-          return 'test:'
-        case 'redisTls':
-          return false
-        case 'redisDb':
-          return 0
-        case 'redisTimeout':
-          return 2000
-        case 'sessionTtl':
-          return 24 * 60 * 60 * 1000
-        case 'trustStorePath':
-          return '/test/trust-store'
-        case 'trustStoreType':
-          return 'test'
-        case 'trustStorePassword':
-          return 'test'
-        case 'trustStoreCerts':
-          return []
-        case 'trustStoreEnabled':
-          return false
-        case 'session.cache.name':
-          return 'test-cache'
-        case 'session.cache.engine':
-          return 'memory'
-        case 'session.cookie.password':
-          return 'test-password'
-        case 'session.cookie.ttl':
-          return 24 * 60 * 60 * 1000
-        case 'session.cookie.secure':
-          return false
-        case 'redis.ttl':
-          return 24 * 60 * 60 * 1000
-        case 'log':
-          return {
-            enabled: true,
-            redact: []
-          }
-        default:
-          return undefined
-      }
-    })
-
     server = await createServer()
     await server.initialize()
   })
@@ -194,50 +394,18 @@ describe('#uploadAndWait', () => {
   beforeEach(() => {
     jest.resetAllMocks()
 
-    getExemptionCacheSpy = jest
-      .spyOn(cacheUtils, 'getExemptionCache')
-      .mockReturnValue(mockExemption)
+    // Setup config after reset to ensure it's available
+    setupMockConfig()
 
-    updateExemptionSiteDetailsSpy = jest
-      .spyOn(cacheUtils, 'updateExemptionSiteDetails')
-      .mockImplementation()
+    const cacheSpies = setupCacheSpies()
+    getExemptionCacheSpy = cacheSpies.getExemptionCacheSpy
+    updateExemptionSiteDetailsSpy = cacheSpies.updateExemptionSiteDetailsSpy
 
-    mockCdpService = {
-      getStatus: jest.fn()
-    }
+    const services = setupMockServices()
+    mockCdpService = services.mockCdpService
+    mockFileValidationService = services.mockFileValidationService
 
-    mockFileValidationService = {
-      validateFileExtension: jest.fn()
-    }
-
-    authenticatedPostRequestSpy = jest
-      .spyOn(authenticatedRequests, 'authenticatedPostRequest')
-      .mockResolvedValue({
-        statusCode: 200,
-        payload: {
-          message: 'success',
-          value: {
-            type: 'FeatureCollection',
-            features: [
-              {
-                type: 'Feature',
-                geometry: {
-                  type: 'Point',
-                  coordinates: [0, 0]
-                }
-              }
-            ]
-          }
-        }
-      })
-
-    jest
-      .spyOn(cdpUploadService, 'getCdpUploadService')
-      .mockReturnValue(mockCdpService)
-
-    jest
-      .spyOn(fileValidationService, 'getFileValidationService')
-      .mockReturnValue(mockFileValidationService)
+    authenticatedPostRequestSpy = setupAuthenticatedRequestSpy()
   })
 
   afterAll(async () => {
@@ -247,651 +415,648 @@ describe('#uploadAndWait', () => {
   })
 
   describe('#uploadAndWaitController', () => {
-    const mockRequest = {
-      logger: {
-        debug: jest.fn(),
-        warn: jest.fn(),
-        error: jest.fn(),
-        info: jest.fn()
-      }
-    }
-
-    const mockUploadConfig = {
-      uploadId: 'test-upload-id',
-      statusUrl: 'test-status-url',
-      fileType: 'kml'
-    }
-
-    test('should redirect to CHOOSE_FILE_UPLOAD_TYPE when no upload config exists', async () => {
-      getExemptionCacheSpy.mockReturnValue({})
-      const h = { redirect: jest.fn() }
-
-      await uploadAndWaitController.handler(mockRequest, h)
-
-      expect(h.redirect).toHaveBeenCalledWith(routes.CHOOSE_FILE_UPLOAD_TYPE)
-    })
-
-    test('should show waiting page when status is pending', async () => {
-      getExemptionCacheSpy.mockReturnValue({
-        projectName: 'Test Project',
-        siteDetails: { uploadConfig: mockUploadConfig }
-      })
-
-      mockCdpService.getStatus.mockResolvedValue({
-        status: 'pending',
-        filename: 'test.kml'
-      })
-
-      const h = { view: jest.fn() }
-
-      await uploadAndWaitController.handler(mockRequest, h)
-
-      expect(mockCdpService.getStatus).toHaveBeenCalledWith(
-        'test-upload-id',
-        'test-status-url'
-      )
-
-      expect(h.view).toHaveBeenCalledWith(UPLOAD_AND_WAIT_VIEW_ROUTE, {
-        pageTitle: 'Checking your file...',
-        heading: 'Checking your file...',
-        projectName: 'Test Project',
-        isProcessing: true,
-        pageRefreshTimeInSeconds: 2,
-        filename: 'test.kml'
-      })
-    })
-
-    test('should show waiting page when status is scanning', async () => {
-      getExemptionCacheSpy.mockReturnValue({
-        projectName: 'Test Project',
-        siteDetails: { uploadConfig: mockUploadConfig }
-      })
-
-      mockCdpService.getStatus.mockResolvedValue({
-        status: 'scanning',
-        filename: 'test.kml'
-      })
-
-      const h = { view: jest.fn() }
-
-      await uploadAndWaitController.handler(mockRequest, h)
-
-      expect(h.view).toHaveBeenCalledWith(UPLOAD_AND_WAIT_VIEW_ROUTE, {
-        pageTitle: 'Checking your file...',
-        heading: 'Checking your file...',
-        projectName: 'Test Project',
-        isProcessing: true,
-        pageRefreshTimeInSeconds: 2,
-        filename: 'test.kml'
-      })
-    })
-
-    test('should redirect to REVIEW_SITE_DETAILS when status is ready and file validation passes', async () => {
-      getExemptionCacheSpy.mockReturnValue({
-        projectName: 'Test Project',
-        siteDetails: { uploadConfig: mockUploadConfig }
-      })
-
-      const statusResponse = {
-        status: 'ready',
-        filename: 'test.kml',
-        fileSize: 3754,
-        completedAt: '2025-07-02T21:29:38.471Z',
-        s3Location: {
-          s3Bucket: 'test-bucket',
-          s3Key: 'test-key',
-          fileId: 'test-id',
-          s3Url: 'test-url',
-          checksumSha256: 'test-checksum'
-        }
-      }
-
-      mockCdpService.getStatus.mockResolvedValue(statusResponse)
-
-      // Mock successful file validation
-      mockFileValidationService.validateFileExtension.mockReturnValue({
-        isValid: true,
-        extension: 'kml',
-        errorMessage: null
-      })
-
-      // Mock config for S3 bucket
-      config.get.mockImplementation((key) => {
-        if (key === 'cdpUploader') {
-          return {
-            s3Bucket: 'test-bucket'
-          }
-        }
-        return undefined
-      })
-
-      const h = { redirect: jest.fn() }
-
-      await uploadAndWaitController.handler(mockRequest, h)
-
-      expect(
-        mockFileValidationService.validateFileExtension
-      ).toHaveBeenCalledWith('test.kml', ['kml'])
-
-      expect(authenticatedPostRequestSpy).toHaveBeenCalledWith(
-        mockRequest,
-        '/geo-parser/extract',
-        {
-          s3Bucket: 'test-bucket',
-          s3Key: 'test-key',
-          fileType: 'kml'
-        }
-      )
-
-      expect(updateExemptionSiteDetailsSpy).toHaveBeenCalledWith(
-        mockRequest,
-        'uploadedFile',
-        {
-          ...statusResponse,
-          s3Location: {
-            s3Bucket: 'test-bucket',
-            s3Key: statusResponse.s3Location.s3Key,
-            fileId: statusResponse.s3Location.fileId,
-            s3Url: statusResponse.s3Location.s3Url,
-            checksumSha256: statusResponse.s3Location.checksumSha256
-          }
-        }
-      )
-
-      expect(updateExemptionSiteDetailsSpy).toHaveBeenCalledWith(
-        mockRequest,
-        'extractedCoordinates',
-        [
-          {
-            type: 'Point',
-            coordinates: [0, 0]
-          }
-        ]
-      )
-
-      expect(updateExemptionSiteDetailsSpy).toHaveBeenCalledWith(
-        mockRequest,
-        'geoJSON',
-        {
-          type: 'FeatureCollection',
-          features: [
-            {
-              type: 'Feature',
-              geometry: {
-                type: 'Point',
-                coordinates: [0, 0]
-              }
-            }
-          ]
-        }
-      )
-
-      expect(updateExemptionSiteDetailsSpy).toHaveBeenCalledWith(
-        mockRequest,
-        'featureCount',
-        1
-      )
-
-      expect(updateExemptionSiteDetailsSpy).toHaveBeenCalledWith(
-        mockRequest,
-        'uploadConfig',
-        undefined
-      )
-
-      expect(h.redirect).toHaveBeenCalledWith(routes.REVIEW_SITE_DETAILS)
-    })
-
-    test('should redirect to FILE_UPLOAD with error when file validation fails for wrong extension', async () => {
-      getExemptionCacheSpy.mockReturnValue({
-        projectName: 'Test Project',
-        siteDetails: { uploadConfig: mockUploadConfig }
-      })
-
-      const statusResponse = {
-        status: 'ready',
-        filename: 'document.pdf',
-        fileSize: 1024,
-        completedAt: '2025-07-02T21:29:38.471Z'
-      }
-
-      mockCdpService.getStatus.mockResolvedValue(statusResponse)
-
-      // Mock failed file validation
-      mockFileValidationService.validateFileExtension.mockReturnValue({
-        isValid: false,
-        extension: 'pdf',
-        errorMessage: 'The selected file must be a KML file'
-      })
-
-      const h = { redirect: jest.fn() }
-
-      await uploadAndWaitController.handler(mockRequest, h)
-
-      expect(
-        mockFileValidationService.validateFileExtension
-      ).toHaveBeenCalledWith('document.pdf', ['kml'])
-
-      expect(updateExemptionSiteDetailsSpy).toHaveBeenCalledWith(
-        mockRequest,
-        'uploadError',
-        {
-          message: 'The selected file must be a KML file',
-          fieldName: 'file',
-          fileType: 'kml'
-        }
-      )
-
-      expect(updateExemptionSiteDetailsSpy).toHaveBeenCalledWith(
-        mockRequest,
-        'uploadConfig',
-        undefined
-      )
-
-      expect(h.redirect).toHaveBeenCalledWith(routes.FILE_UPLOAD)
-
-      // Should not store uploaded file when validation fails
-      expect(updateExemptionSiteDetailsSpy).not.toHaveBeenCalledWith(
-        mockRequest,
-        'uploadedFile',
-        expect.anything()
-      )
-    })
-
-    test('should validate shapefile extensions correctly', async () => {
-      const shapefileUploadConfig = {
-        ...mockUploadConfig,
-        fileType: 'shapefile'
-      }
-
-      getExemptionCacheSpy.mockReturnValue({
-        projectName: 'Test Project',
-        siteDetails: { uploadConfig: shapefileUploadConfig }
-      })
-
-      const statusResponse = {
-        status: 'ready',
-        filename: 'coordinates.zip',
-        fileSize: 5432,
-        completedAt: '2025-07-02T21:29:38.471Z',
-        s3Location: {
-          s3Bucket: 'test-bucket',
-          s3Key: 'test-key',
-          fileId: 'test-id',
-          s3Url: 'test-url',
-          checksumSha256: 'test-checksum'
-        }
-      }
-
-      mockCdpService.getStatus.mockResolvedValue(statusResponse)
-
-      // Mock successful shapefile validation
-      mockFileValidationService.validateFileExtension.mockReturnValue({
-        isValid: true,
-        extension: 'zip',
-        errorMessage: null
-      })
-
-      // Mock config for S3 bucket
-      config.get.mockImplementation((key) => {
-        if (key === 'cdpUploader') {
-          return {
-            s3Bucket: 'test-bucket'
-          }
-        }
-        return undefined
-      })
-
-      const h = { redirect: jest.fn() }
-
-      await uploadAndWaitController.handler(mockRequest, h)
-
-      expect(
-        mockFileValidationService.validateFileExtension
-      ).toHaveBeenCalledWith('coordinates.zip', ['zip'])
-
-      expect(authenticatedPostRequestSpy).toHaveBeenCalledWith(
-        mockRequest,
-        '/geo-parser/extract',
-        {
-          s3Bucket: 'test-bucket',
-          s3Key: 'test-key',
-          fileType: 'shapefile'
-        }
-      )
-
-      expect(updateExemptionSiteDetailsSpy).toHaveBeenCalledWith(
-        mockRequest,
-        'uploadedFile',
-        {
-          ...statusResponse,
-          s3Location: {
-            s3Bucket: 'test-bucket',
-            s3Key: statusResponse.s3Location.s3Key,
-            fileId: statusResponse.s3Location.fileId,
-            s3Url: statusResponse.s3Location.s3Url,
-            checksumSha256: statusResponse.s3Location.checksumSha256
-          }
-        }
-      )
-
-      expect(updateExemptionSiteDetailsSpy).toHaveBeenCalledWith(
-        mockRequest,
-        'extractedCoordinates',
-        [
-          {
-            type: 'Point',
-            coordinates: [0, 0]
-          }
-        ]
-      )
-
-      expect(updateExemptionSiteDetailsSpy).toHaveBeenCalledWith(
-        mockRequest,
-        'geoJSON',
-        {
-          type: 'FeatureCollection',
-          features: [
-            {
-              type: 'Feature',
-              geometry: {
-                type: 'Point',
-                coordinates: [0, 0]
-              }
-            }
-          ]
-        }
-      )
-
-      expect(updateExemptionSiteDetailsSpy).toHaveBeenCalledWith(
-        mockRequest,
-        'featureCount',
-        1
-      )
-
-      expect(updateExemptionSiteDetailsSpy).toHaveBeenCalledWith(
-        mockRequest,
-        'uploadConfig',
-        undefined
-      )
-
-      expect(h.redirect).toHaveBeenCalledWith(routes.REVIEW_SITE_DETAILS)
-    })
-
-    test('should redirect to FILE_UPLOAD with error when status is rejected', async () => {
-      getExemptionCacheSpy.mockReturnValue({
-        projectName: 'Test Project',
-        siteDetails: { uploadConfig: mockUploadConfig }
-      })
-
-      mockCdpService.getStatus.mockResolvedValue({
-        status: 'rejected',
-        message: 'The selected file contains a virus'
-      })
-
-      const h = { redirect: jest.fn() }
-
-      await uploadAndWaitController.handler(mockRequest, h)
-
-      expect(updateExemptionSiteDetailsSpy).toHaveBeenCalledWith(
-        mockRequest,
-        'uploadError',
-        {
-          message: 'The selected file contains a virus',
-          fieldName: 'file',
-          fileType: 'kml'
-        }
-      )
-
-      expect(updateExemptionSiteDetailsSpy).toHaveBeenCalledWith(
-        mockRequest,
-        'uploadConfig',
-        undefined
-      )
-
-      expect(h.redirect).toHaveBeenCalledWith(routes.FILE_UPLOAD)
-    })
-
-    test('should handle different error message types correctly', async () => {
-      const testCases = [
-        {
-          message: 'file is empty',
-          expected: 'The selected file is empty'
-        },
-        {
-          message: 'file must be smaller than 50MB',
-          expected: 'The selected file must be smaller than 50 MB'
-        },
-        {
-          message: 'must be a kml file',
-          expected: 'The selected file must be a KML file'
-        },
-        {
-          message: 'Select a file to upload',
-          expected: 'Select a file to upload'
-        },
-        {
-          message: 'unknown error',
-          expected: 'The selected file could not be uploaded – try again'
-        }
-      ]
-
-      for (const testCase of testCases) {
-        getExemptionCacheSpy.mockReturnValue({
-          projectName: 'Test Project',
-          siteDetails: { uploadConfig: mockUploadConfig }
-        })
-
-        mockCdpService.getStatus.mockResolvedValue({
-          status: 'rejected',
-          message: testCase.message
-        })
-
-        const h = { redirect: jest.fn() }
-
+    const mockRequest = createMockRequest()
+    // const mockUploadConfig = createMockUploadConfig()
+
+    describe('when no upload config exists', () => {
+      test('should redirect to CHOOSE_FILE_UPLOAD_TYPE', async () => {
+        // Given no upload config exists
+        getExemptionCacheSpy.mockReturnValue({})
+        const h = createMockResponseHandler()
+
+        // When handler is called
         await uploadAndWaitController.handler(mockRequest, h)
 
-        expect(updateExemptionSiteDetailsSpy).toHaveBeenCalledWith(
+        // Then redirect to choose file upload type
+        expectRedirectTo(h, routes.CHOOSE_FILE_UPLOAD_TYPE)
+      })
+    })
+
+    describe('when checking upload status', () => {
+      test('should show waiting page when status is pending', async () => {
+        // Given exemption with upload config and pending status
+        getExemptionCacheSpy.mockReturnValue(createMockExemption())
+        mockCdpService.getStatus.mockResolvedValue(
+          createMockStatusResponse('pending')
+        )
+        const h = createMockResponseHandler()
+
+        // When handler is called
+        await uploadAndWaitController.handler(mockRequest, h)
+
+        // Then CDP service is called with correct parameters
+        expect(mockCdpService.getStatus).toHaveBeenCalledWith(
+          'test-upload-id',
+          'test-status-url'
+        )
+
+        // And waiting page is displayed
+        expectViewCalledWith(h, UPLOAD_AND_WAIT_VIEW_ROUTE, {
+          pageTitle: 'Checking your file...',
+          heading: 'Checking your file...',
+          projectName: 'Test Project',
+          isProcessing: true,
+          pageRefreshTimeInSeconds: 2,
+          filename: 'test.kml'
+        })
+      })
+
+      test('should show waiting page when status is scanning', async () => {
+        // Given exemption with upload config and scanning status
+        getExemptionCacheSpy.mockReturnValue(createMockExemption())
+        mockCdpService.getStatus.mockResolvedValue(
+          createMockStatusResponse('scanning')
+        )
+        const h = createMockResponseHandler()
+
+        // When handler is called
+        await uploadAndWaitController.handler(mockRequest, h)
+
+        // Then waiting page is displayed
+        expectViewCalledWith(h, UPLOAD_AND_WAIT_VIEW_ROUTE, {
+          pageTitle: 'Checking your file...',
+          heading: 'Checking your file...',
+          projectName: 'Test Project',
+          isProcessing: true,
+          pageRefreshTimeInSeconds: 2,
+          filename: 'test.kml'
+        })
+      })
+
+      test('should redirect to CHOOSE_FILE_UPLOAD_TYPE for unknown status', async () => {
+        // Given exemption with upload config and unknown status
+        getExemptionCacheSpy.mockReturnValue(createMockExemption())
+        mockCdpService.getStatus.mockResolvedValue({
+          status: 'unknown',
+          filename: 'test.kml'
+        })
+
+        const h = createMockResponseHandler()
+
+        // When handler is called
+        await uploadAndWaitController.handler(mockRequest, h)
+
+        // Then warning is logged
+        expect(mockRequest.logger.warn).toHaveBeenCalledWith(
+          'Unknown upload status',
+          {
+            uploadId: 'test-upload-id',
+            status: 'unknown'
+          }
+        )
+
+        // And user is redirected to choose file upload type
+        expectRedirectTo(h, routes.CHOOSE_FILE_UPLOAD_TYPE)
+      })
+    })
+
+    describe('when file upload is ready', () => {
+      describe('with valid KML file', () => {
+        test('should process file and redirect to review page', async () => {
+          // Given exemption with upload config and ready status
+          getExemptionCacheSpy.mockReturnValue(createMockExemption())
+          const statusResponse = createMockStatusResponse('ready')
+          mockCdpService.getStatus.mockResolvedValue(statusResponse)
+
+          // And successful file validation
+          mockFileValidationService.validateFileExtension.mockReturnValue({
+            isValid: true,
+            extension: 'kml',
+            errorMessage: null
+          })
+
+          const h = createMockResponseHandler()
+
+          // When handler is called
+          await uploadAndWaitController.handler(mockRequest, h)
+
+          // Then file validation is performed
+          expect(
+            mockFileValidationService.validateFileExtension
+          ).toHaveBeenCalledWith('test.kml', ['kml'])
+
+          // And geo-parser API is called
+          expect(authenticatedPostRequestSpy).toHaveBeenCalledWith(
+            mockRequest,
+            '/geo-parser/extract',
+            {
+              s3Bucket: 'test-bucket',
+              s3Key: 'test-key',
+              fileType: 'kml'
+            }
+          )
+
+          // And file processing data is stored correctly
+          expectSuccessfulFileProcessing(
+            updateExemptionSiteDetailsSpy,
+            mockRequest
+          )
+
+          // And user is redirected to review page
+          expectRedirectTo(h, routes.REVIEW_SITE_DETAILS)
+        })
+      })
+
+      describe('with valid Shapefile', () => {
+        test('should process shapefile and redirect to review page', async () => {
+          // Given exemption with shapefile upload config
+          const shapefileUploadConfig = createMockUploadConfig({
+            fileType: 'shapefile'
+          })
+          getExemptionCacheSpy.mockReturnValue(
+            createMockExemption({
+              siteDetails: { uploadConfig: shapefileUploadConfig }
+            })
+          )
+
+          const statusResponse = createMockStatusResponse('ready', {
+            filename: 'coordinates.zip'
+          })
+          mockCdpService.getStatus.mockResolvedValue(statusResponse)
+
+          // And successful shapefile validation
+          mockFileValidationService.validateFileExtension.mockReturnValue({
+            isValid: true,
+            extension: 'zip',
+            errorMessage: null
+          })
+
+          const h = createMockResponseHandler()
+
+          // When handler is called
+          await uploadAndWaitController.handler(mockRequest, h)
+
+          // Then file validation is performed with zip extension
+          expect(
+            mockFileValidationService.validateFileExtension
+          ).toHaveBeenCalledWith('coordinates.zip', ['zip'])
+
+          // And geo-parser API is called with shapefile type
+          expect(authenticatedPostRequestSpy).toHaveBeenCalledWith(
+            mockRequest,
+            '/geo-parser/extract',
+            {
+              s3Bucket: 'test-bucket',
+              s3Key: 'test-key',
+              fileType: 'shapefile'
+            }
+          )
+
+          // And file processing data is stored correctly
+          expectSuccessfulFileProcessing(
+            updateExemptionSiteDetailsSpy,
+            mockRequest
+          )
+
+          // And user is redirected to review page
+          expectRedirectTo(h, routes.REVIEW_SITE_DETAILS)
+        })
+      })
+    })
+
+    describe('when file validation fails', () => {
+      test('should redirect to file upload with error for wrong extension', async () => {
+        await expectFileValidationFailure(
           mockRequest,
-          'uploadError',
+          getExemptionCacheSpy,
+          mockCdpService,
+          mockFileValidationService,
+          updateExemptionSiteDetailsSpy,
+          'document.pdf',
+          'kml',
+          ['kml'],
+          'The selected file must be a KML file'
+        )
+      })
+
+      test('should handle unknown file type in getAllowedExtensions default case', async () => {
+        await expectFileValidationFailure(
+          mockRequest,
+          getExemptionCacheSpy,
+          mockCdpService,
+          mockFileValidationService,
+          updateExemptionSiteDetailsSpy,
+          'test.unknown',
+          'unknown',
+          [],
+          'The selected file could not be uploaded – try again'
+        )
+      })
+    })
+
+    describe('when upload is rejected', () => {
+      test('should redirect to file upload with virus error message', async () => {
+        await expectRejectedStatusHandling(
+          mockRequest,
+          getExemptionCacheSpy,
+          mockCdpService,
+          updateExemptionSiteDetailsSpy,
+          'The selected file contains a virus',
+          'The selected file contains a virus'
+        )
+      })
+
+      test('should handle error status the same as rejected status', async () => {
+        // Given exemption with upload config and error status
+        getExemptionCacheSpy.mockReturnValue(createMockExemption())
+        mockCdpService.getStatus.mockResolvedValue({
+          status: 'error',
+          message: 'Processing failed'
+        })
+
+        const h = createMockResponseHandler()
+
+        // When handler is called
+        await uploadAndWaitController.handler(mockRequest, h)
+
+        // Then error is set in cache
+        expectUploadErrorSet(
+          updateExemptionSiteDetailsSpy,
+          mockRequest,
+          'The selected file could not be uploaded – try again'
+        )
+
+        // And upload config is cleared
+        expectUploadConfigCleared(updateExemptionSiteDetailsSpy, mockRequest)
+
+        // And user is redirected to file upload
+        expectRedirectTo(h, routes.FILE_UPLOAD)
+      })
+
+      test('should handle different error message types correctly', async () => {
+        const testCases = [
+          { message: 'file is empty', expected: 'The selected file is empty' },
+          {
+            message: 'file must be smaller than 50MB',
+            expected: 'The selected file must be smaller than 50 MB'
+          },
+          {
+            message: 'must be a kml file',
+            expected: 'The selected file must be a KML file'
+          },
+          {
+            message: 'Select a file to upload',
+            expected: 'Select a file to upload'
+          },
+          {
+            message: 'unknown error',
+            expected: 'The selected file could not be uploaded – try again'
+          }
+        ]
+
+        for (const testCase of testCases) {
+          await expectRejectedStatusHandling(
+            mockRequest,
+            getExemptionCacheSpy,
+            mockCdpService,
+            updateExemptionSiteDetailsSpy,
+            testCase.message,
+            testCase.expected
+          )
+        }
+      })
+
+      test('should handle unknown file type message correctly', async () => {
+        await expectRejectedStatusHandling(
+          mockRequest,
+          getExemptionCacheSpy,
+          mockCdpService,
+          updateExemptionSiteDetailsSpy,
+          'must be a foo file',
+          'The selected file could not be uploaded – try again',
+          'foo'
+        )
+      })
+
+      test('should handle shapefile error message correctly', async () => {
+        await expectRejectedStatusHandling(
+          mockRequest,
+          getExemptionCacheSpy,
+          mockCdpService,
+          updateExemptionSiteDetailsSpy,
+          'must be a shapefile',
+          'The selected file must be a Shapefile',
+          'shapefile'
+        )
+      })
+    })
+
+    describe('when geo-parser API fails', () => {
+      test('should handle geo-parser API errors gracefully', async () => {
+        // Given exemption with upload config and ready status
+        getExemptionCacheSpy.mockReturnValue(createMockExemption())
+        const statusResponse = createMockStatusResponse('ready')
+        mockCdpService.getStatus.mockResolvedValue(statusResponse)
+
+        // And successful file validation
+        mockFileValidationService.validateFileExtension.mockReturnValue({
+          isValid: true,
+          extension: 'kml',
+          errorMessage: null
+        })
+
+        // But geo-parser API fails
+        authenticatedPostRequestSpy.mockRejectedValue(
+          new Error('Geo-parser service unavailable')
+        )
+
+        const h = createMockResponseHandler()
+
+        // When handler is called
+        await uploadAndWaitController.handler(mockRequest, h)
+
+        // Then geo-parser API is called
+        expect(authenticatedPostRequestSpy).toHaveBeenCalledWith(
+          mockRequest,
+          '/geo-parser/extract',
+          {
+            s3Bucket: 'test-bucket',
+            s3Key: 'test-key',
+            fileType: 'kml'
+          }
+        )
+
+        // And error is logged
+        expect(mockRequest.logger.error).toHaveBeenCalledWith(
+          'Failed to extract coordinates from uploaded file',
+          {
+            error: 'Geo-parser service unavailable',
+            filename: 'test.kml',
+            fileType: 'kml'
+          }
+        )
+
+        // And generic error is set in cache
+        expectUploadErrorSet(
+          updateExemptionSiteDetailsSpy,
+          mockRequest,
+          'The selected file could not be processed – try again'
+        )
+
+        // And upload config is cleared
+        expectUploadConfigCleared(updateExemptionSiteDetailsSpy, mockRequest)
+
+        // And user is redirected to file upload
+        expectRedirectTo(h, routes.FILE_UPLOAD)
+      })
+
+      test('should handle geo-parser API returning invalid response', async () => {
+        // Given exemption with upload config and ready status
+        getExemptionCacheSpy.mockReturnValue(createMockExemption())
+        const statusResponse = createMockStatusResponse('ready')
+        mockCdpService.getStatus.mockResolvedValue(statusResponse)
+
+        // And successful file validation
+        mockFileValidationService.validateFileExtension.mockReturnValue({
+          isValid: true,
+          extension: 'kml',
+          errorMessage: null
+        })
+
+        // But geo-parser API returns invalid response
+        authenticatedPostRequestSpy.mockResolvedValue({
+          statusCode: 400,
+          payload: {
+            error: 'Invalid file format'
+          }
+        })
+
+        const h = createMockResponseHandler()
+
+        // When handler is called
+        await uploadAndWaitController.handler(mockRequest, h)
+
+        // Then error handling occurs
+        expectUploadErrorSet(
+          updateExemptionSiteDetailsSpy,
+          mockRequest,
+          'The selected file could not be processed – try again'
+        )
+
+        expectUploadConfigCleared(updateExemptionSiteDetailsSpy, mockRequest)
+        expectRedirectTo(h, routes.FILE_UPLOAD)
+      })
+
+      test('should handle geo-parser API returning unsuccessful response', async () => {
+        // Given exemption with upload config and ready status
+        getExemptionCacheSpy.mockReturnValue(createMockExemption())
+        const statusResponse = createMockStatusResponse('ready')
+        mockCdpService.getStatus.mockResolvedValue(statusResponse)
+
+        // And successful file validation
+        mockFileValidationService.validateFileExtension.mockReturnValue({
+          isValid: true,
+          extension: 'kml',
+          errorMessage: null
+        })
+
+        // But geo-parser API returns unsuccessful response
+        authenticatedPostRequestSpy.mockResolvedValue({
+          statusCode: 200,
+          payload: {
+            message: 'error',
+            error: 'Could not parse file'
+          }
+        })
+
+        const h = createMockResponseHandler()
+
+        // When handler is called
+        await uploadAndWaitController.handler(mockRequest, h)
+
+        // Then error handling occurs
+        expectUploadErrorSet(
+          updateExemptionSiteDetailsSpy,
+          mockRequest,
+          'The selected file could not be processed – try again'
+        )
+
+        expectUploadConfigCleared(updateExemptionSiteDetailsSpy, mockRequest)
+        expectRedirectTo(h, routes.FILE_UPLOAD)
+      })
+
+      test('should handle geo-parser API returning invalid GeoJSON structure', async () => {
+        // Given exemption with upload config and ready status
+        getExemptionCacheSpy.mockReturnValue(createMockExemption())
+        const statusResponse = createMockStatusResponse('ready')
+        mockCdpService.getStatus.mockResolvedValue(statusResponse)
+
+        // And successful file validation
+        mockFileValidationService.validateFileExtension.mockReturnValue({
+          isValid: true,
+          extension: 'kml',
+          errorMessage: null
+        })
+
+        // But geo-parser API returns response with invalid GeoJSON
+        authenticatedPostRequestSpy.mockResolvedValue({
+          statusCode: 200,
+          payload: {
+            message: 'success',
+            value: {
+              type: 'FeatureCollection'
+              // Missing features array
+            }
+          }
+        })
+
+        const h = createMockResponseHandler()
+
+        // When handler is called
+        await uploadAndWaitController.handler(mockRequest, h)
+
+        // Then error handling occurs
+        expectUploadErrorSet(
+          updateExemptionSiteDetailsSpy,
+          mockRequest,
+          'The selected file could not be processed – try again'
+        )
+
+        expectUploadConfigCleared(updateExemptionSiteDetailsSpy, mockRequest)
+        expectRedirectTo(h, routes.FILE_UPLOAD)
+      })
+    })
+
+    describe('when service errors occur', () => {
+      test('should handle CDP service errors gracefully', async () => {
+        // Given exemption with upload config and CDP service error
+        getExemptionCacheSpy.mockReturnValue(createMockExemption())
+        mockCdpService.getStatus.mockRejectedValue(
+          new Error('Service unavailable')
+        )
+
+        const h = createMockResponseHandler()
+
+        // When handler is called
+        await uploadAndWaitController.handler(mockRequest, h)
+
+        // Then error is logged
+        expect(mockRequest.logger.error).toHaveBeenCalledWith(
+          'Failed to check upload status',
+          {
+            error: 'Service unavailable',
+            uploadId: 'test-upload-id'
+          }
+        )
+
+        // And upload config is cleared
+        expectUploadConfigCleared(updateExemptionSiteDetailsSpy, mockRequest)
+
+        // And user is redirected to choose file upload type
+        expectRedirectTo(h, routes.CHOOSE_FILE_UPLOAD_TYPE)
+      })
+    })
+
+    describe('logging behavior', () => {
+      test('should log debug information on successful status check', async () => {
+        // Given exemption with upload config and pending status
+        getExemptionCacheSpy.mockReturnValue(createMockExemption())
+        mockCdpService.getStatus.mockResolvedValue(
+          createMockStatusResponse('pending')
+        )
+
+        const h = createMockResponseHandler()
+
+        // When handler is called
+        await uploadAndWaitController.handler(mockRequest, h)
+
+        // Then debug information is logged (behavior, not exact count)
+        expect(mockRequest.logger.debug).toHaveBeenCalled()
+      })
+
+      test('should log successful coordinate extraction info', async () => {
+        // Given exemption with upload config and ready status
+        getExemptionCacheSpy.mockReturnValue(createMockExemption())
+        const statusResponse = createMockStatusResponse('ready')
+        mockCdpService.getStatus.mockResolvedValue(statusResponse)
+
+        // And successful file validation
+        mockFileValidationService.validateFileExtension.mockReturnValue({
+          isValid: true,
+          extension: 'kml',
+          errorMessage: null
+        })
+
+        const h = createMockResponseHandler()
+
+        // When handler is called
+        await uploadAndWaitController.handler(mockRequest, h)
+
+        // Then info logging occurs for successful extraction
+        expect(mockRequest.logger.info).toHaveBeenCalledWith(
+          'Successfully extracted coordinates',
           expect.objectContaining({
-            message: testCase.expected
+            featureCount: expect.any(Number),
+            coordinateCount: expect.any(Number)
           })
         )
-      }
+
+        // And completion logging occurs
+        expect(mockRequest.logger.info).toHaveBeenCalledWith(
+          'File upload and coordinate extraction completed successfully',
+          expect.objectContaining({
+            filename: 'test.kml',
+            fileType: 'kml',
+            featureCount: expect.any(Number)
+          })
+        )
+      })
     })
 
-    test('should handle unknown file type message correctly', async () => {
-      const testCase = {
-        message: 'must be a foo file',
-        expected: 'The selected file could not be uploaded – try again'
-      }
+    describe('edge cases', () => {
+      test('should handle missing s3Location in status response', async () => {
+        // Given exemption with upload config and ready status without s3Location
+        getExemptionCacheSpy.mockReturnValue(createMockExemption())
+        const statusResponse = createMockStatusResponse('ready')
+        delete statusResponse.s3Location
+        mockCdpService.getStatus.mockResolvedValue(statusResponse)
 
-      const mockUploadConfigUnknownFile = {
-        ...mockUploadConfig,
-        fileType: 'foo'
-      }
-
-      getExemptionCacheSpy.mockReturnValue({
-        projectName: 'Test Project',
-        siteDetails: { uploadConfig: mockUploadConfigUnknownFile }
-      })
-
-      mockCdpService.getStatus.mockResolvedValue({
-        status: 'rejected',
-        message: testCase.message
-      })
-
-      const h = { redirect: jest.fn() }
-
-      await uploadAndWaitController.handler(mockRequest, h)
-
-      expect(updateExemptionSiteDetailsSpy).toHaveBeenCalledWith(
-        mockRequest,
-        'uploadError',
-        expect.objectContaining({
-          message: testCase.expected
+        // And successful file validation
+        mockFileValidationService.validateFileExtension.mockReturnValue({
+          isValid: true,
+          extension: 'kml',
+          errorMessage: null
         })
-      )
-    })
 
-    test('should handle shapefile error message correctly', async () => {
-      const shapefileUploadConfig = {
-        ...mockUploadConfig,
-        fileType: 'shapefile'
-      }
+        const h = createMockResponseHandler()
 
-      getExemptionCacheSpy.mockReturnValue({
-        projectName: 'Test Project',
-        siteDetails: { uploadConfig: shapefileUploadConfig }
+        // When handler is called
+        await uploadAndWaitController.handler(mockRequest, h)
+
+        // Then error handling occurs due to missing s3Location
+        expectUploadErrorSet(
+          updateExemptionSiteDetailsSpy,
+          mockRequest,
+          'The selected file could not be processed – try again'
+        )
+
+        expectUploadConfigCleared(updateExemptionSiteDetailsSpy, mockRequest)
+        expectRedirectTo(h, routes.FILE_UPLOAD)
       })
 
-      mockCdpService.getStatus.mockResolvedValue({
-        status: 'rejected',
-        message: 'must be a shapefile'
-      })
-
-      const h = { redirect: jest.fn() }
-
-      await uploadAndWaitController.handler(mockRequest, h)
-
-      expect(updateExemptionSiteDetailsSpy).toHaveBeenCalledWith(
-        mockRequest,
-        'uploadError',
-        expect.objectContaining({
-          message: 'The selected file must be a Shapefile'
+      test('should handle empty filename in status response', async () => {
+        // Given exemption with upload config and status with empty filename
+        getExemptionCacheSpy.mockReturnValue(createMockExemption())
+        mockCdpService.getStatus.mockResolvedValue({
+          status: 'pending',
+          filename: ''
         })
-      )
-    })
 
-    test('should redirect to CHOOSE_FILE_UPLOAD_TYPE for unknown status', async () => {
-      getExemptionCacheSpy.mockReturnValue({
-        projectName: 'Test Project',
-        siteDetails: { uploadConfig: mockUploadConfig }
+        const h = createMockResponseHandler()
+
+        // When handler is called
+        await uploadAndWaitController.handler(mockRequest, h)
+
+        // Then waiting page is still displayed (handles empty filename gracefully)
+        expectViewCalledWith(h, UPLOAD_AND_WAIT_VIEW_ROUTE, {
+          pageTitle: 'Checking your file...',
+          heading: 'Checking your file...',
+          projectName: 'Test Project',
+          isProcessing: true,
+          pageRefreshTimeInSeconds: 2,
+          filename: ''
+        })
       })
-
-      mockCdpService.getStatus.mockResolvedValue({
-        status: 'unknown',
-        filename: 'test.kml'
-      })
-
-      const h = { redirect: jest.fn() }
-
-      await uploadAndWaitController.handler(mockRequest, h)
-
-      expect(mockRequest.logger.warn).toHaveBeenCalledWith(
-        'Unknown upload status',
-        {
-          uploadId: 'test-upload-id',
-          status: 'unknown'
-        }
-      )
-
-      expect(h.redirect).toHaveBeenCalledWith(routes.CHOOSE_FILE_UPLOAD_TYPE)
-    })
-
-    test('should handle CDP service errors gracefully', async () => {
-      getExemptionCacheSpy.mockReturnValue({
-        projectName: 'Test Project',
-        siteDetails: { uploadConfig: mockUploadConfig }
-      })
-
-      mockCdpService.getStatus.mockRejectedValue(
-        new Error('Service unavailable')
-      )
-
-      const h = { redirect: jest.fn() }
-
-      await uploadAndWaitController.handler(mockRequest, h)
-
-      expect(mockRequest.logger.error).toHaveBeenCalledWith(
-        'Failed to check upload status',
-        {
-          error: 'Service unavailable',
-          uploadId: 'test-upload-id'
-        }
-      )
-
-      expect(updateExemptionSiteDetailsSpy).toHaveBeenCalledWith(
-        mockRequest,
-        'uploadConfig',
-        undefined
-      )
-
-      expect(h.redirect).toHaveBeenCalledWith(routes.CHOOSE_FILE_UPLOAD_TYPE)
-    })
-
-    test('should log debug information on successful status check', async () => {
-      getExemptionCacheSpy.mockReturnValue({
-        projectName: 'Test Project',
-        siteDetails: { uploadConfig: mockUploadConfig }
-      })
-
-      mockCdpService.getStatus.mockResolvedValue({
-        status: 'pending',
-        filename: 'test.kml'
-      })
-
-      const h = { view: jest.fn() }
-
-      await uploadAndWaitController.handler(mockRequest, h)
-
-      expect(mockRequest.logger.debug).toHaveBeenCalledTimes(2)
-    })
-
-    test('should handle unknown file type in getAllowedExtensions default case', async () => {
-      const unknownFileTypeConfig = {
-        ...mockUploadConfig,
-        fileType: 'unknown'
-      }
-
-      getExemptionCacheSpy.mockReturnValue({
-        projectName: 'Test Project',
-        siteDetails: { uploadConfig: unknownFileTypeConfig }
-      })
-
-      const statusResponse = {
-        status: 'ready',
-        filename: 'test.unknown',
-        fileSize: 1024,
-        completedAt: '2025-07-02T21:29:38.471Z'
-      }
-
-      mockCdpService.getStatus.mockResolvedValue(statusResponse)
-
-      // Mock file validation to fail due to empty allowed extensions array
-      mockFileValidationService.validateFileExtension.mockReturnValue({
-        isValid: false,
-        extension: 'unknown',
-        errorMessage: 'The selected file could not be uploaded – try again'
-      })
-
-      const h = { redirect: jest.fn() }
-
-      await uploadAndWaitController.handler(mockRequest, h)
-
-      // Verify that validateFileExtension is called with empty array (default case)
-      expect(
-        mockFileValidationService.validateFileExtension
-      ).toHaveBeenCalledWith('test.unknown', [])
-
-      // Verify error handling for unknown file type
-      expect(updateExemptionSiteDetailsSpy).toHaveBeenCalledWith(
-        mockRequest,
-        'uploadError',
-        {
-          message: 'The selected file could not be uploaded – try again',
-          fieldName: 'file',
-          fileType: 'unknown'
-        }
-      )
-
-      expect(updateExemptionSiteDetailsSpy).toHaveBeenCalledWith(
-        mockRequest,
-        'uploadConfig',
-        undefined
-      )
-
-      expect(h.redirect).toHaveBeenCalledWith(routes.FILE_UPLOAD)
     })
   })
 })

--- a/src/server/exemption/site-details/upload-and-wait/controller.test.js
+++ b/src/server/exemption/site-details/upload-and-wait/controller.test.js
@@ -112,31 +112,6 @@ const setupMockConfig = () => {
   })
 }
 
-// Assertion Helpers
-const expectCacheUpdateWith = (spy, request, key, value) => {
-  expect(spy).toHaveBeenCalledWith(request, key, value)
-}
-
-const expectRedirectTo = (h, route) => {
-  expect(h.redirect).toHaveBeenCalledWith(route)
-}
-
-const expectViewCalledWith = (h, viewRoute, viewData) => {
-  expect(h.view).toHaveBeenCalledWith(viewRoute, viewData)
-}
-
-const expectUploadErrorSet = (spy, request, message, fileType = 'kml') => {
-  expectCacheUpdateWith(spy, request, 'uploadError', {
-    message,
-    fieldName: 'file',
-    fileType
-  })
-}
-
-const expectUploadConfigCleared = (spy, request) => {
-  expectCacheUpdateWith(spy, request, 'uploadConfig', null)
-}
-
 const expectSuccessfulFileProcessing = (spies, request) => {
   const { updateExemptionSiteDetailsBatchSpy } = spies
 
@@ -223,14 +198,21 @@ const expectRejectedStatusHandling = async (
   await uploadAndWaitController.handler(mockRequest, h)
 
   // Then expected error handling occurs
-  expectUploadErrorSet(
-    updateExemptionSiteDetailsSpy,
+  expect(updateExemptionSiteDetailsSpy).toHaveBeenCalledWith(
     mockRequest,
-    expectedErrorMessage,
-    fileType
+    'uploadError',
+    {
+      message: expectedErrorMessage,
+      fieldName: 'file',
+      fileType
+    }
   )
-  expectUploadConfigCleared(updateExemptionSiteDetailsSpy, mockRequest)
-  expectRedirectTo(h, routes.FILE_UPLOAD)
+  expect(updateExemptionSiteDetailsSpy).toHaveBeenCalledWith(
+    mockRequest,
+    'uploadConfig',
+    null
+  )
+  expect(h.redirect).toHaveBeenCalledWith(routes.FILE_UPLOAD)
 }
 
 const expectFileValidationFailure = async (
@@ -273,14 +255,21 @@ const expectFileValidationFailure = async (
   )
 
   // And error handling occurs
-  expectUploadErrorSet(
-    updateExemptionSiteDetailsSpy,
+  expect(updateExemptionSiteDetailsSpy).toHaveBeenCalledWith(
     mockRequest,
-    errorMessage,
-    fileType
+    'uploadError',
+    {
+      message: errorMessage,
+      fieldName: 'file',
+      fileType
+    }
   )
-  expectUploadConfigCleared(updateExemptionSiteDetailsSpy, mockRequest)
-  expectRedirectTo(h, routes.FILE_UPLOAD)
+  expect(updateExemptionSiteDetailsSpy).toHaveBeenCalledWith(
+    mockRequest,
+    'uploadConfig',
+    null
+  )
+  expect(h.redirect).toHaveBeenCalledWith(routes.FILE_UPLOAD)
 
   // And uploaded file should not be stored when validation fails
   expect(updateExemptionSiteDetailsSpy).not.toHaveBeenCalledWith(
@@ -321,7 +310,6 @@ describe('#uploadAndWait', () => {
     const mockRequest = createMockRequest()
 
     describe('when no upload config exists', () => {
-      /* eslint-disable jest/expect-expect */
       test('should redirect to CHOOSE_FILE_UPLOAD_TYPE', async () => {
         // Given no upload config exists
         getExemptionCacheSpy.mockReturnValue({})
@@ -331,7 +319,7 @@ describe('#uploadAndWait', () => {
         await uploadAndWaitController.handler(mockRequest, h)
 
         // Then redirect to choose file upload type
-        expectRedirectTo(h, routes.CHOOSE_FILE_UPLOAD_TYPE)
+        expect(h.redirect).toHaveBeenCalledWith(routes.CHOOSE_FILE_UPLOAD_TYPE)
       })
     })
 
@@ -354,7 +342,7 @@ describe('#uploadAndWait', () => {
         )
 
         // And waiting page is displayed
-        expectViewCalledWith(h, UPLOAD_AND_WAIT_VIEW_ROUTE, {
+        expect(h.view).toHaveBeenCalledWith(UPLOAD_AND_WAIT_VIEW_ROUTE, {
           pageTitle: 'Checking your file...',
           heading: 'Checking your file...',
           projectName: 'Test Project',
@@ -364,7 +352,6 @@ describe('#uploadAndWait', () => {
         })
       })
 
-      /* eslint-disable jest/expect-expect */
       test('should show waiting page when status is scanning', async () => {
         // Given exemption with upload config and scanning status
         getExemptionCacheSpy.mockReturnValue(createMockExemption())
@@ -377,7 +364,7 @@ describe('#uploadAndWait', () => {
         await uploadAndWaitController.handler(mockRequest, h)
 
         // Then waiting page is displayed
-        expectViewCalledWith(h, UPLOAD_AND_WAIT_VIEW_ROUTE, {
+        expect(h.view).toHaveBeenCalledWith(UPLOAD_AND_WAIT_VIEW_ROUTE, {
           pageTitle: 'Checking your file...',
           heading: 'Checking your file...',
           projectName: 'Test Project',
@@ -410,7 +397,7 @@ describe('#uploadAndWait', () => {
         )
 
         // And user is redirected to choose file upload type
-        expectRedirectTo(h, routes.CHOOSE_FILE_UPLOAD_TYPE)
+        expect(h.redirect).toHaveBeenCalledWith(routes.CHOOSE_FILE_UPLOAD_TYPE)
       })
     })
 
@@ -460,7 +447,7 @@ describe('#uploadAndWait', () => {
           )
 
           // And user is redirected to review page
-          expectRedirectTo(h, routes.REVIEW_SITE_DETAILS)
+          expect(h.redirect).toHaveBeenCalledWith(routes.REVIEW_SITE_DETAILS)
         })
       })
 
@@ -519,7 +506,7 @@ describe('#uploadAndWait', () => {
           )
 
           // And user is redirected to review page
-          expectRedirectTo(h, routes.REVIEW_SITE_DETAILS)
+          expect(h.redirect).toHaveBeenCalledWith(routes.REVIEW_SITE_DETAILS)
         })
       })
     })
@@ -569,7 +556,6 @@ describe('#uploadAndWait', () => {
         )
       })
 
-      /* eslint-disable jest/expect-expect */
       test('should handle error status the same as rejected status', async () => {
         // Given exemption with upload config and error status
         getExemptionCacheSpy.mockReturnValue(createMockExemption())
@@ -584,17 +570,25 @@ describe('#uploadAndWait', () => {
         await uploadAndWaitController.handler(mockRequest, h)
 
         // Then error is set in cache
-        expectUploadErrorSet(
-          updateExemptionSiteDetailsSpy,
+        expect(updateExemptionSiteDetailsSpy).toHaveBeenCalledWith(
           mockRequest,
-          'The selected file could not be uploaded – try again'
+          'uploadError',
+          {
+            message: 'The selected file could not be uploaded – try again',
+            fieldName: 'file',
+            fileType: 'kml'
+          }
         )
 
         // And upload config is cleared
-        expectUploadConfigCleared(updateExemptionSiteDetailsSpy, mockRequest)
+        expect(updateExemptionSiteDetailsSpy).toHaveBeenCalledWith(
+          mockRequest,
+          'uploadConfig',
+          null
+        )
 
         // And user is redirected to file upload
-        expectRedirectTo(h, routes.FILE_UPLOAD)
+        expect(h.redirect).toHaveBeenCalledWith(routes.FILE_UPLOAD)
       })
 
       /* eslint-disable jest/expect-expect */
@@ -704,20 +698,27 @@ describe('#uploadAndWait', () => {
         )
 
         // And generic error is set in cache
-        expectUploadErrorSet(
-          updateExemptionSiteDetailsSpy,
+        expect(updateExemptionSiteDetailsSpy).toHaveBeenCalledWith(
           mockRequest,
-          'The selected file could not be processed – try again'
+          'uploadError',
+          {
+            message: 'The selected file could not be processed – try again',
+            fieldName: 'file',
+            fileType: 'kml'
+          }
         )
 
         // And upload config is cleared
-        expectUploadConfigCleared(updateExemptionSiteDetailsSpy, mockRequest)
+        expect(updateExemptionSiteDetailsSpy).toHaveBeenCalledWith(
+          mockRequest,
+          'uploadConfig',
+          null
+        )
 
         // And user is redirected to file upload
-        expectRedirectTo(h, routes.FILE_UPLOAD)
+        expect(h.redirect).toHaveBeenCalledWith(routes.FILE_UPLOAD)
       })
 
-      /* eslint-disable jest/expect-expect */
       test('should handle geo-parser API returning invalid response', async () => {
         // Given exemption with upload config and ready status
         getExemptionCacheSpy.mockReturnValue(createMockExemption())
@@ -745,17 +746,24 @@ describe('#uploadAndWait', () => {
         await uploadAndWaitController.handler(mockRequest, h)
 
         // Then error handling occurs
-        expectUploadErrorSet(
-          updateExemptionSiteDetailsSpy,
+        expect(updateExemptionSiteDetailsSpy).toHaveBeenCalledWith(
           mockRequest,
-          'The selected file could not be processed – try again'
+          'uploadError',
+          {
+            message: 'The selected file could not be processed – try again',
+            fieldName: 'file',
+            fileType: 'kml'
+          }
         )
 
-        expectUploadConfigCleared(updateExemptionSiteDetailsSpy, mockRequest)
-        expectRedirectTo(h, routes.FILE_UPLOAD)
+        expect(updateExemptionSiteDetailsSpy).toHaveBeenCalledWith(
+          mockRequest,
+          'uploadConfig',
+          null
+        )
+        expect(h.redirect).toHaveBeenCalledWith(routes.FILE_UPLOAD)
       })
 
-      /* eslint-disable jest/expect-expect */
       test('should handle geo-parser API returning unsuccessful response', async () => {
         // Given exemption with upload config and ready status
         getExemptionCacheSpy.mockReturnValue(createMockExemption())
@@ -784,17 +792,24 @@ describe('#uploadAndWait', () => {
         await uploadAndWaitController.handler(mockRequest, h)
 
         // Then error handling occurs
-        expectUploadErrorSet(
-          updateExemptionSiteDetailsSpy,
+        expect(updateExemptionSiteDetailsSpy).toHaveBeenCalledWith(
           mockRequest,
-          'The selected file could not be processed – try again'
+          'uploadError',
+          {
+            message: 'The selected file could not be processed – try again',
+            fieldName: 'file',
+            fileType: 'kml'
+          }
         )
 
-        expectUploadConfigCleared(updateExemptionSiteDetailsSpy, mockRequest)
-        expectRedirectTo(h, routes.FILE_UPLOAD)
+        expect(updateExemptionSiteDetailsSpy).toHaveBeenCalledWith(
+          mockRequest,
+          'uploadConfig',
+          null
+        )
+        expect(h.redirect).toHaveBeenCalledWith(routes.FILE_UPLOAD)
       })
 
-      /* eslint-disable jest/expect-expect */
       test('should handle geo-parser API returning invalid GeoJSON structure', async () => {
         // Given exemption with upload config and ready status
         getExemptionCacheSpy.mockReturnValue(createMockExemption())
@@ -826,14 +841,22 @@ describe('#uploadAndWait', () => {
         await uploadAndWaitController.handler(mockRequest, h)
 
         // Then error handling occurs
-        expectUploadErrorSet(
-          updateExemptionSiteDetailsSpy,
+        expect(updateExemptionSiteDetailsSpy).toHaveBeenCalledWith(
           mockRequest,
-          'The selected file could not be processed – try again'
+          'uploadError',
+          {
+            message: 'The selected file could not be processed – try again',
+            fieldName: 'file',
+            fileType: 'kml'
+          }
         )
 
-        expectUploadConfigCleared(updateExemptionSiteDetailsSpy, mockRequest)
-        expectRedirectTo(h, routes.FILE_UPLOAD)
+        expect(updateExemptionSiteDetailsSpy).toHaveBeenCalledWith(
+          mockRequest,
+          'uploadConfig',
+          null
+        )
+        expect(h.redirect).toHaveBeenCalledWith(routes.FILE_UPLOAD)
       })
     })
 
@@ -860,10 +883,14 @@ describe('#uploadAndWait', () => {
         )
 
         // And upload config is cleared
-        expectUploadConfigCleared(updateExemptionSiteDetailsSpy, mockRequest)
+        expect(updateExemptionSiteDetailsSpy).toHaveBeenCalledWith(
+          mockRequest,
+          'uploadConfig',
+          null
+        )
 
         // And user is redirected to choose file upload type
-        expectRedirectTo(h, routes.CHOOSE_FILE_UPLOAD_TYPE)
+        expect(h.redirect).toHaveBeenCalledWith(routes.CHOOSE_FILE_UPLOAD_TYPE)
       })
     })
 
@@ -924,7 +951,6 @@ describe('#uploadAndWait', () => {
     })
 
     describe('edge cases', () => {
-      /* eslint-disable jest/expect-expect */
       test('should handle missing s3Location in status response', async () => {
         // Given exemption with upload config and ready status without s3Location
         getExemptionCacheSpy.mockReturnValue(createMockExemption())
@@ -945,17 +971,24 @@ describe('#uploadAndWait', () => {
         await uploadAndWaitController.handler(mockRequest, h)
 
         // Then error handling occurs due to missing s3Location
-        expectUploadErrorSet(
-          updateExemptionSiteDetailsSpy,
+        expect(updateExemptionSiteDetailsSpy).toHaveBeenCalledWith(
           mockRequest,
-          'The selected file could not be processed – try again'
+          'uploadError',
+          {
+            message: 'The selected file could not be processed – try again',
+            fieldName: 'file',
+            fileType: 'kml'
+          }
         )
 
-        expectUploadConfigCleared(updateExemptionSiteDetailsSpy, mockRequest)
-        expectRedirectTo(h, routes.FILE_UPLOAD)
+        expect(updateExemptionSiteDetailsSpy).toHaveBeenCalledWith(
+          mockRequest,
+          'uploadConfig',
+          null
+        )
+        expect(h.redirect).toHaveBeenCalledWith(routes.FILE_UPLOAD)
       })
 
-      /* eslint-disable jest/expect-expect */
       test('should handle empty filename in status response', async () => {
         // Given exemption with upload config and status with empty filename
         getExemptionCacheSpy.mockReturnValue(createMockExemption())
@@ -970,7 +1003,7 @@ describe('#uploadAndWait', () => {
         await uploadAndWaitController.handler(mockRequest, h)
 
         // Then waiting page is still displayed (handles empty filename gracefully)
-        expectViewCalledWith(h, UPLOAD_AND_WAIT_VIEW_ROUTE, {
+        expect(h.view).toHaveBeenCalledWith(UPLOAD_AND_WAIT_VIEW_ROUTE, {
           pageTitle: 'Checking your file...',
           heading: 'Checking your file...',
           projectName: 'Test Project',

--- a/src/server/exemption/site-details/upload-and-wait/controller.test.js
+++ b/src/server/exemption/site-details/upload-and-wait/controller.test.js
@@ -6,12 +6,91 @@ import {
 import * as cacheUtils from '~/src/server/common/helpers/session-cache/utils.js'
 import * as cdpUploadService from '~/src/services/cdp-upload-service/index.js'
 import * as fileValidationService from '~/src/services/file-validation/index.js'
+import * as authenticatedRequests from '~/src/server/common/helpers/authenticated-requests.js'
 import { mockExemption } from '~/src/server/test-helpers/mocks.js'
 import { routes } from '~/src/server/common/constants/routes.js'
+import { config } from '~/src/config/config.js'
+import path from 'path'
+import hapi from '@hapi/hapi'
 
 jest.mock('~/src/server/common/helpers/session-cache/utils.js')
 jest.mock('~/src/services/cdp-upload-service/index.js')
 jest.mock('~/src/services/file-validation/index.js')
+jest.mock('~/src/server/common/helpers/authenticated-requests.js')
+jest.mock('~/src/config/config.js')
+jest.mock('path')
+jest.mock('@hapi/hapi')
+
+// Mock logger configuration
+jest.mock('~/src/server/common/helpers/logging/logger-options.js', () => ({
+  loggerOptions: {
+    enabled: true,
+    ignorePaths: ['/health'],
+    redact: {
+      paths: []
+    }
+  }
+}))
+
+// Mock logger
+jest.mock('~/src/server/common/helpers/logging/logger.js', () => ({
+  createLogger: jest.fn().mockReturnValue({
+    info: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn()
+  })
+}))
+
+// Mock path.join to return a fixed path
+path.join.mockImplementation((...args) => args.join('/'))
+
+// Mock manifest file
+jest.mock('~/src/config/nunjucks/context/context.js', () => ({
+  getContext: jest.fn().mockReturnValue({})
+}))
+
+// Mock session configuration
+jest.mock('~/src/server/common/helpers/session-cache/session-cache.js', () => ({
+  sessionConfig: {
+    cache: {
+      name: 'test-cache',
+      ttl: 24 * 60 * 60 * 1000
+    }
+  }
+}))
+
+// Mock cache engine
+jest.mock('~/src/server/common/helpers/session-cache/cache-engine.js', () => ({
+  getCacheEngine: jest.fn().mockReturnValue({
+    start: jest.fn(),
+    stop: jest.fn(),
+    isReady: jest.fn().mockReturnValue(true),
+    validateSegmentName: jest.fn(),
+    get: jest.fn(),
+    set: jest.fn(),
+    drop: jest.fn()
+  })
+}))
+
+// Mock server cache
+const mockServerCache = {
+  get: jest.fn(),
+  set: jest.fn(),
+  drop: jest.fn()
+}
+
+// Mock Hapi server
+const mockServer = {
+  app: {},
+  cache: jest.fn().mockReturnValue(mockServerCache),
+  register: jest.fn(),
+  ext: jest.fn(),
+  initialize: jest.fn(),
+  stop: jest.fn()
+}
+
+hapi.server.mockReturnValue(mockServer)
 
 describe('#uploadAndWait', () => {
   /** @type {Server} */
@@ -20,8 +99,94 @@ describe('#uploadAndWait', () => {
   let updateExemptionSiteDetailsSpy
   let mockCdpService
   let mockFileValidationService
+  let authenticatedPostRequestSpy
 
   beforeAll(async () => {
+    config.get.mockImplementation((key) => {
+      switch (key) {
+        case 'cdpUploader':
+          return {
+            s3Bucket: 'test-bucket'
+          }
+        case 'root':
+          return '/test/root'
+        case 'assetPath':
+          return '/test/assets'
+        case 'env':
+          return 'test'
+        case 'isDev':
+          return false
+        case 'isTest':
+          return true
+        case 'isProd':
+          return false
+        case 'serviceName':
+          return 'test-service'
+        case 'serviceUrl':
+          return 'http://test-service'
+        case 'port':
+          return 3000
+        case 'staticCacheControl':
+          return 'public, max-age=86400'
+        case 'cookieOptions':
+          return {
+            ttl: 24 * 60 * 60 * 1000,
+            encoding: 'base64json',
+            isSecure: true,
+            isHttpOnly: true,
+            clearInvalid: true,
+            strictHeader: true
+          }
+        case 'sessionCookieName':
+          return 'test-session'
+        case 'redisHost':
+          return 'localhost'
+        case 'redisPort':
+          return 6379
+        case 'redisPassword':
+          return ''
+        case 'redisPrefix':
+          return 'test:'
+        case 'redisTls':
+          return false
+        case 'redisDb':
+          return 0
+        case 'redisTimeout':
+          return 2000
+        case 'sessionTtl':
+          return 24 * 60 * 60 * 1000
+        case 'trustStorePath':
+          return '/test/trust-store'
+        case 'trustStoreType':
+          return 'test'
+        case 'trustStorePassword':
+          return 'test'
+        case 'trustStoreCerts':
+          return []
+        case 'trustStoreEnabled':
+          return false
+        case 'session.cache.name':
+          return 'test-cache'
+        case 'session.cache.engine':
+          return 'memory'
+        case 'session.cookie.password':
+          return 'test-password'
+        case 'session.cookie.ttl':
+          return 24 * 60 * 60 * 1000
+        case 'session.cookie.secure':
+          return false
+        case 'redis.ttl':
+          return 24 * 60 * 60 * 1000
+        case 'log':
+          return {
+            enabled: true,
+            redact: []
+          }
+        default:
+          return undefined
+      }
+    })
+
     server = await createServer()
     await server.initialize()
   })
@@ -45,6 +210,27 @@ describe('#uploadAndWait', () => {
       validateFileExtension: jest.fn()
     }
 
+    authenticatedPostRequestSpy = jest
+      .spyOn(authenticatedRequests, 'authenticatedPostRequest')
+      .mockResolvedValue({
+        statusCode: 200,
+        payload: {
+          message: 'success',
+          value: {
+            type: 'FeatureCollection',
+            features: [
+              {
+                type: 'Feature',
+                geometry: {
+                  type: 'Point',
+                  coordinates: [0, 0]
+                }
+              }
+            ]
+          }
+        }
+      })
+
     jest
       .spyOn(cdpUploadService, 'getCdpUploadService')
       .mockReturnValue(mockCdpService)
@@ -55,7 +241,9 @@ describe('#uploadAndWait', () => {
   })
 
   afterAll(async () => {
-    await server.stop({ timeout: 0 })
+    if (server) {
+      await server.stop({ timeout: 0 })
+    }
   })
 
   describe('#uploadAndWaitController', () => {
@@ -63,7 +251,8 @@ describe('#uploadAndWait', () => {
       logger: {
         debug: jest.fn(),
         warn: jest.fn(),
-        error: jest.fn()
+        error: jest.fn(),
+        info: jest.fn()
       }
     }
 
@@ -137,7 +326,7 @@ describe('#uploadAndWait', () => {
       })
     })
 
-    test('should redirect to FILE_UPLOAD when status is ready and file validation passes', async () => {
+    test('should redirect to REVIEW_SITE_DETAILS when status is ready and file validation passes', async () => {
       getExemptionCacheSpy.mockReturnValue({
         projectName: 'Test Project',
         siteDetails: { uploadConfig: mockUploadConfig }
@@ -150,13 +339,10 @@ describe('#uploadAndWait', () => {
         completedAt: '2025-07-02T21:29:38.471Z',
         s3Location: {
           s3Bucket: 'test-bucket',
-          s3Key:
-            's3Path/a283cf8a-b13e-4ae3-85e9-7c3db9a4a076/558d2f8d-5b78-47e7-9958-e315763f44af',
-          fileId: '558d2f8d-5b78-47e7-9958-e315763f44af',
-          s3Url:
-            's3://test-bucket/s3Path/a283cf8a-b13e-4ae3-85e9-7c3db9a4a076/558d2f8d-5b78-47e7-9958-e315763f44af',
-          detectedContentType: 'application/vnd.google-earth.kml+xml',
-          checksumSha256: '2Vvqe1CDdtBezIBTQWyf3IYhc0dnuKgy/YeOY055s6g='
+          s3Key: 'test-key',
+          fileId: 'test-id',
+          s3Url: 'test-url',
+          checksumSha256: 'test-checksum'
         }
       }
 
@@ -169,6 +355,16 @@ describe('#uploadAndWait', () => {
         errorMessage: null
       })
 
+      // Mock config for S3 bucket
+      config.get.mockImplementation((key) => {
+        if (key === 'cdpUploader') {
+          return {
+            s3Bucket: 'test-bucket'
+          }
+        }
+        return undefined
+      })
+
       const h = { redirect: jest.fn() }
 
       await uploadAndWaitController.handler(mockRequest, h)
@@ -177,10 +373,63 @@ describe('#uploadAndWait', () => {
         mockFileValidationService.validateFileExtension
       ).toHaveBeenCalledWith('test.kml', ['kml'])
 
+      expect(authenticatedPostRequestSpy).toHaveBeenCalledWith(
+        mockRequest,
+        '/geo-parser/extract',
+        {
+          s3Bucket: 'test-bucket',
+          s3Key: 'test-key',
+          fileType: 'kml'
+        }
+      )
+
       expect(updateExemptionSiteDetailsSpy).toHaveBeenCalledWith(
         mockRequest,
         'uploadedFile',
-        statusResponse
+        {
+          ...statusResponse,
+          s3Location: {
+            s3Bucket: 'test-bucket',
+            s3Key: statusResponse.s3Location.s3Key,
+            fileId: statusResponse.s3Location.fileId,
+            s3Url: statusResponse.s3Location.s3Url,
+            checksumSha256: statusResponse.s3Location.checksumSha256
+          }
+        }
+      )
+
+      expect(updateExemptionSiteDetailsSpy).toHaveBeenCalledWith(
+        mockRequest,
+        'extractedCoordinates',
+        [
+          {
+            type: 'Point',
+            coordinates: [0, 0]
+          }
+        ]
+      )
+
+      expect(updateExemptionSiteDetailsSpy).toHaveBeenCalledWith(
+        mockRequest,
+        'geoJSON',
+        {
+          type: 'FeatureCollection',
+          features: [
+            {
+              type: 'Feature',
+              geometry: {
+                type: 'Point',
+                coordinates: [0, 0]
+              }
+            }
+          ]
+        }
+      )
+
+      expect(updateExemptionSiteDetailsSpy).toHaveBeenCalledWith(
+        mockRequest,
+        'featureCount',
+        1
       )
 
       expect(updateExemptionSiteDetailsSpy).toHaveBeenCalledWith(
@@ -189,7 +438,7 @@ describe('#uploadAndWait', () => {
         undefined
       )
 
-      expect(h.redirect).toHaveBeenCalledWith(routes.FILE_UPLOAD)
+      expect(h.redirect).toHaveBeenCalledWith(routes.REVIEW_SITE_DETAILS)
     })
 
     test('should redirect to FILE_UPLOAD with error when file validation fails for wrong extension', async () => {
@@ -262,7 +511,15 @@ describe('#uploadAndWait', () => {
       const statusResponse = {
         status: 'ready',
         filename: 'coordinates.zip',
-        fileSize: 5432
+        fileSize: 5432,
+        completedAt: '2025-07-02T21:29:38.471Z',
+        s3Location: {
+          s3Bucket: 'test-bucket',
+          s3Key: 'test-key',
+          fileId: 'test-id',
+          s3Url: 'test-url',
+          checksumSha256: 'test-checksum'
+        }
       }
 
       mockCdpService.getStatus.mockResolvedValue(statusResponse)
@@ -274,6 +531,16 @@ describe('#uploadAndWait', () => {
         errorMessage: null
       })
 
+      // Mock config for S3 bucket
+      config.get.mockImplementation((key) => {
+        if (key === 'cdpUploader') {
+          return {
+            s3Bucket: 'test-bucket'
+          }
+        }
+        return undefined
+      })
+
       const h = { redirect: jest.fn() }
 
       await uploadAndWaitController.handler(mockRequest, h)
@@ -282,13 +549,72 @@ describe('#uploadAndWait', () => {
         mockFileValidationService.validateFileExtension
       ).toHaveBeenCalledWith('coordinates.zip', ['zip'])
 
+      expect(authenticatedPostRequestSpy).toHaveBeenCalledWith(
+        mockRequest,
+        '/geo-parser/extract',
+        {
+          s3Bucket: 'test-bucket',
+          s3Key: 'test-key',
+          fileType: 'shapefile'
+        }
+      )
+
       expect(updateExemptionSiteDetailsSpy).toHaveBeenCalledWith(
         mockRequest,
         'uploadedFile',
-        statusResponse
+        {
+          ...statusResponse,
+          s3Location: {
+            s3Bucket: 'test-bucket',
+            s3Key: statusResponse.s3Location.s3Key,
+            fileId: statusResponse.s3Location.fileId,
+            s3Url: statusResponse.s3Location.s3Url,
+            checksumSha256: statusResponse.s3Location.checksumSha256
+          }
+        }
       )
 
-      expect(h.redirect).toHaveBeenCalledWith(routes.FILE_UPLOAD)
+      expect(updateExemptionSiteDetailsSpy).toHaveBeenCalledWith(
+        mockRequest,
+        'extractedCoordinates',
+        [
+          {
+            type: 'Point',
+            coordinates: [0, 0]
+          }
+        ]
+      )
+
+      expect(updateExemptionSiteDetailsSpy).toHaveBeenCalledWith(
+        mockRequest,
+        'geoJSON',
+        {
+          type: 'FeatureCollection',
+          features: [
+            {
+              type: 'Feature',
+              geometry: {
+                type: 'Point',
+                coordinates: [0, 0]
+              }
+            }
+          ]
+        }
+      )
+
+      expect(updateExemptionSiteDetailsSpy).toHaveBeenCalledWith(
+        mockRequest,
+        'featureCount',
+        1
+      )
+
+      expect(updateExemptionSiteDetailsSpy).toHaveBeenCalledWith(
+        mockRequest,
+        'uploadConfig',
+        undefined
+      )
+
+      expect(h.redirect).toHaveBeenCalledWith(routes.REVIEW_SITE_DETAILS)
     })
 
     test('should redirect to FILE_UPLOAD with error when status is rejected', async () => {

--- a/src/server/exemption/site-details/upload-and-wait/controller.test.js
+++ b/src/server/exemption/site-details/upload-and-wait/controller.test.js
@@ -227,22 +227,20 @@ const expectUploadErrorSet = (spy, request, message, fileType = 'kml') => {
 }
 
 const expectUploadConfigCleared = (spy, request) => {
-  expectCacheUpdateWith(spy, request, 'uploadConfig', undefined)
+  expectCacheUpdateWith(spy, request, 'uploadConfig', null)
 }
 
-const expectSuccessfulFileProcessing = (spy, request) => {
-  // Verify essential data is stored (not testing exact structure)
-  expect(spy).toHaveBeenCalledWith(request, 'uploadedFile', expect.any(Object))
-  expect(spy).toHaveBeenCalledWith(
-    request,
-    'extractedCoordinates',
-    expect.any(Array)
-  )
-  expect(spy).toHaveBeenCalledWith(request, 'geoJSON', expect.any(Object))
-  expect(spy).toHaveBeenCalledWith(request, 'featureCount', expect.any(Number))
+const expectSuccessfulFileProcessing = (spies, request) => {
+  const { updateExemptionSiteDetailsBatchSpy } = spies
 
-  // Verify upload config is cleared (this behavior matters)
-  expectUploadConfigCleared(spy, request)
+  // Verify batch update was called with all the required data including clearing upload config
+  expect(updateExemptionSiteDetailsBatchSpy).toHaveBeenCalledWith(request, {
+    uploadedFile: expect.any(Object),
+    extractedCoordinates: expect.any(Array),
+    geoJSON: expect.any(Object),
+    featureCount: expect.any(Number),
+    uploadConfig: null // Verify upload config is cleared as part of batch operation
+  })
 }
 
 // Service Mock Setup Helpers
@@ -274,7 +272,15 @@ const setupCacheSpies = () => {
     .spyOn(cacheUtils, 'updateExemptionSiteDetails')
     .mockImplementation()
 
-  return { getExemptionCacheSpy, updateExemptionSiteDetailsSpy }
+  const updateExemptionSiteDetailsBatchSpy = jest
+    .spyOn(cacheUtils, 'updateExemptionSiteDetailsBatch')
+    .mockImplementation()
+
+  return {
+    getExemptionCacheSpy,
+    updateExemptionSiteDetailsSpy,
+    updateExemptionSiteDetailsBatchSpy
+  }
 }
 
 const setupAuthenticatedRequestSpy = () => {
@@ -382,6 +388,7 @@ describe('#uploadAndWait', () => {
   let server
   let getExemptionCacheSpy
   let updateExemptionSiteDetailsSpy
+  let updateExemptionSiteDetailsBatchSpy
   let mockCdpService
   let mockFileValidationService
   let authenticatedPostRequestSpy
@@ -400,6 +407,8 @@ describe('#uploadAndWait', () => {
     const cacheSpies = setupCacheSpies()
     getExemptionCacheSpy = cacheSpies.getExemptionCacheSpy
     updateExemptionSiteDetailsSpy = cacheSpies.updateExemptionSiteDetailsSpy
+    updateExemptionSiteDetailsBatchSpy =
+      cacheSpies.updateExemptionSiteDetailsBatchSpy
 
     const services = setupMockServices()
     mockCdpService = services.mockCdpService
@@ -549,7 +558,10 @@ describe('#uploadAndWait', () => {
 
           // And file processing data is stored correctly
           expectSuccessfulFileProcessing(
-            updateExemptionSiteDetailsSpy,
+            {
+              updateExemptionSiteDetailsSpy,
+              updateExemptionSiteDetailsBatchSpy
+            },
             mockRequest
           )
 
@@ -605,7 +617,10 @@ describe('#uploadAndWait', () => {
 
           // And file processing data is stored correctly
           expectSuccessfulFileProcessing(
-            updateExemptionSiteDetailsSpy,
+            {
+              updateExemptionSiteDetailsSpy,
+              updateExemptionSiteDetailsBatchSpy
+            },
             mockRequest
           )
 

--- a/src/server/exemption/site-details/upload-and-wait/index.njk
+++ b/src/server/exemption/site-details/upload-and-wait/index.njk
@@ -4,9 +4,9 @@
   {{ heading }} - {{ serviceName }}
 {% endblock %}
 
-{% block beforeContent %} 
+{% block beforeContent %}
 
-{% endblock %} 
+{% endblock %}
 
 {% block footer %}
 
@@ -23,13 +23,13 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-                
+
       {% if isProcessing %}
 
         <div class="govuk-!-text-align-centre">
           <div class="app-loading-spinner" role="status">
-            <span class="app-loading-spinner__text">Checking your file</span>          
-          </div>          
+            <span class="app-loading-spinner__text">Checking your file</span>
+          </div>
           <h1 class="govuk-heading-l govuk-!-padding-top-6">{{ heading }}</h1>
           <p class="govuk-body">This may take a few seconds.</p>
         </div>
@@ -41,15 +41,13 @@
         {% endif %}
 
         <p class="govuk-body">Something went wrong. Please try uploading your file again.</p>
-        
+
         <div class="govuk-button-group">
           <a href="{{ routes.FILE_UPLOAD }}" class="govuk-button">Try again</a>
           <a href="{{ routes.TASK_LIST }}" class="govuk-link">Cancel</a>
         </div>
       {% endif %}
-
-
     </div>
   </div>
 
-{% endblock %} 
+{% endblock %}


### PR DESCRIPTION
ML-74 

- extract coordinates from Shapefiles and KML files 
- show the review site details page
- as a temp measure renders the coordinates to screen (will be replaced by the map in a future ticket)
