### PR TITLE
Rename 'exempt activity' labels

### DIFF
--- a/src/server/common/constants/exemptions.js
+++ b/src/server/common/constants/exemptions.js
@@ -19,3 +19,5 @@ export const OSGB36_CONSTANTS = {
   MIN_NORTHINGS: 100000,
   MAX_NORTHINGS: 9999999
 }
+
+export const EXEMPTION_TYPE = 'Exempt activity notification'

--- a/src/server/exemption/dashboard/controller.test.js
+++ b/src/server/exemption/dashboard/controller.test.js
@@ -75,7 +75,7 @@ describe('#dashboard', () => {
         {
           id: 'abc123',
           projectName: 'Test Project',
-          type: 'Exempt activity',
+
           reference: 'ML-2024-001',
           status: 'Draft',
           submittedAt: null
@@ -87,7 +87,7 @@ describe('#dashboard', () => {
       expect(expectedFormattedProjects).toEqual([
         [
           { text: 'Test Project' },
-          { text: 'Exempt activity' },
+          { text: 'Exempt activity notification' },
           { text: '-' },
           {
             html: '<strong class="govuk-tag govuk-tag--light-blue">Draft</strong>'
@@ -137,14 +137,14 @@ describe('#dashboard', () => {
       const projects = [
         {
           projectName: 'Test Project 1',
-          type: 'Exempt activity',
+
           reference: 'ML-2024-001',
           status: 'Draft',
           submittedAt: null
         },
         {
           projectName: 'Test Project 2',
-          type: 'Exempt activity',
+
           reference: 'ML-2024-002',
           status: 'Closed',
           submittedAt: '2024-01-15'
@@ -206,7 +206,7 @@ describe('#dashboard', () => {
     test('Should display Continue link for draft exemptions pointing to /exemption/task-list/{id}', async () => {
       const draftExemption = {
         projectName: 'Draft Exemption',
-        type: 'Exempt activity',
+
         reference: 'ML-2024-003',
         status: 'Draft',
         submittedAt: null,

--- a/src/server/exemption/dashboard/utils.js
+++ b/src/server/exemption/dashboard/utils.js
@@ -1,5 +1,6 @@
 import { formatDate } from '~/src/config/nunjucks/filters/format-date.js'
 import { routes } from '~/src/server/common/constants/routes.js'
+import { EXEMPTION_TYPE } from '~/src/server/common/constants/exemptions.js'
 
 export const getActionButtons = (project) => {
   let buttons = ''
@@ -19,7 +20,7 @@ export const formatProjectsForDisplay = (projects) =>
 
     return [
       { text: project.projectName },
-      { text: project.type },
+      { text: EXEMPTION_TYPE },
       { text: project.applicationReference || '-' },
       {
         html: `<strong class="govuk-tag ${tagClass}">${project.status}</strong>`

--- a/src/server/exemption/dashboard/utils.test.js
+++ b/src/server/exemption/dashboard/utils.test.js
@@ -21,7 +21,6 @@ describe('#formatProjectsForDisplay', () => {
       {
         id: 'abc123',
         projectName: 'Test Project',
-        type: 'Exempt activity',
         applicationReference: 'ML-2024-001',
         status: 'Draft',
         submittedAt: '2024-01-15'
@@ -33,7 +32,7 @@ describe('#formatProjectsForDisplay', () => {
     expect(result).toEqual([
       [
         { text: 'Test Project' },
-        { text: 'Exempt activity' },
+        { text: 'Exempt activity notification' },
         { text: 'ML-2024-001' },
         {
           html: '<strong class="govuk-tag govuk-tag--light-blue">Draft</strong>'
@@ -51,7 +50,7 @@ describe('#formatProjectsForDisplay', () => {
       {
         id: 'abc123',
         projectName: 'Test Project',
-        type: 'Exempt activity',
+
         applicationReference: null,
         status: 'Draft',
         submittedAt: null
@@ -63,7 +62,7 @@ describe('#formatProjectsForDisplay', () => {
     expect(result).toEqual([
       [
         { text: 'Test Project' },
-        { text: 'Exempt activity' },
+        { text: 'Exempt activity notification' },
         { text: '-' },
         {
           html: '<strong class="govuk-tag govuk-tag--light-blue">Draft</strong>'
@@ -81,14 +80,14 @@ describe('#formatProjectsForDisplay', () => {
       {
         id: 'abc123',
         projectName: 'Project 1',
-        type: 'Exempt activity',
+
         applicationReference: 'ML-2024-001',
         status: 'Draft',
         submittedAt: '2024-01-15'
       },
       {
         projectName: 'Project 2',
-        type: 'Exempt activity',
+
         applicationReference: 'ML-2024-002',
         status: 'Closed',
         submittedAt: '2024-06-25'
@@ -100,7 +99,7 @@ describe('#formatProjectsForDisplay', () => {
     expect(result).toHaveLength(2)
     expect(result[0]).toEqual([
       { text: 'Project 1' },
-      { text: 'Exempt activity' },
+      { text: 'Exempt activity notification' },
       { text: 'ML-2024-001' },
       {
         html: '<strong class="govuk-tag govuk-tag--light-blue">Draft</strong>'
@@ -112,7 +111,7 @@ describe('#formatProjectsForDisplay', () => {
     ])
     expect(result[1]).toEqual([
       { text: 'Project 2' },
-      { text: 'Exempt activity' },
+      { text: 'Exempt activity notification' },
       { text: 'ML-2024-002' },
       {
         html: '<strong class="govuk-tag govuk-tag--green">Closed</strong>'
@@ -132,14 +131,14 @@ describe('#formatProjectsForDisplay', () => {
     const projects = [
       {
         projectName: 'Test Project',
-        type: 'Exempt activity',
+
         applicationReference: 'ML-2024-001',
         status: 'Draft',
         submittedAt: '2024-01-15'
       },
       {
         projectName: 'Test Project',
-        type: 'Exempt activity',
+
         applicationReference: 'ML-2024-001',
         status: 'Closed',
         submittedAt: '2024-01-15'

--- a/src/server/exemption/task-list/controller.js
+++ b/src/server/exemption/task-list/controller.js
@@ -7,6 +7,7 @@ import {
 import { transformTaskList } from '~/src/server/exemption/task-list/utils.js'
 import { routes } from '~/src/server/common/constants/routes.js'
 import { authenticatedGetRequest } from '~/src/server/common/helpers/authenticated-requests.js'
+import { EXEMPTION_TYPE } from '~/src/server/common/constants/exemptions.js'
 
 import Boom from '@hapi/boom'
 
@@ -14,7 +15,8 @@ export const TASK_LIST_VIEW_ROUTE = 'exemption/task-list/index'
 
 const taskListViewSettings = {
   pageTitle: 'Task list',
-  heading: 'Task list'
+  heading: 'Task list',
+  type: EXEMPTION_TYPE
 }
 
 /**

--- a/src/server/exemption/task-list/controller.test.js
+++ b/src/server/exemption/task-list/controller.test.js
@@ -62,7 +62,7 @@ describe('#taskListController', () => {
     )
 
     expect(document.querySelector('.govuk-caption-l').textContent.trim()).toBe(
-      'Exempt activity'
+      'Exempt activity notification'
     )
 
     expect(
@@ -99,6 +99,7 @@ describe('#taskListController', () => {
     expect(h.view).toHaveBeenCalledWith(TASK_LIST_VIEW_ROUTE, {
       pageTitle: 'Task list',
       heading: 'Task list',
+      type: 'Exempt activity notification',
       projectName: 'Test Project',
       taskList: [
         {

--- a/src/server/exemption/task-list/index.njk
+++ b/src/server/exemption/task-list/index.njk
@@ -8,7 +8,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       {% if projectName %}
-        <span class="govuk-caption-l">Exempt activity</span>
+        <span class="govuk-caption-l">{{type}}</span>
       {% endif %}
       {% if projectName %}
         <h1 class="govuk-heading-l">

--- a/src/server/test-helpers/mocks.js
+++ b/src/server/test-helpers/mocks.js
@@ -48,7 +48,6 @@ export const mockProjectList = [
   {
     id: 'abc123',
     projectName: 'Test Project',
-    type: 'Exempt activity',
     reference: 'ML-2024-001',
     status: 'Draft',
     submittedAt: null


### PR DESCRIPTION
Don't use `type` property on exemption data from DB as it will be removed; instead just infer that the label should be 'Exempt activity notification'