### PR TITLE
ML-111 - Store IAT MCMS context in cache then save with project name

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,6 @@
+# CLAUDE.md
+
+### Code Standards
+
+- Use the rules in the .cursor/rules folder
+- Don't add code comments, unless there is complex logic to explain

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,13 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(npm run format:*)",
+      "Bash(npm i:*)",
+      "Bash(claude mcp add playwright npx '@playwright/mcp@latest')",
+      "Bash(npm run dev:*)",
+      "Bash(curl:*)"
+    ],
+    "deny": [],
+    "ask": []
+  }
+}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -4,8 +4,7 @@
       "Bash(npm run format:*)",
       "Bash(npm i:*)",
       "Bash(claude mcp add playwright npx '@playwright/mcp@latest')",
-      "Bash(npm run dev:*)",
-      "Bash(curl:*)"
+      "Bash(npm run dev:*)"
     ],
     "deny": [],
     "ask": []

--- a/.cursor/rules/javascript.mdc
+++ b/.cursor/rules/javascript.mdc
@@ -89,6 +89,7 @@ alwaysApply: true
   - UI: test behavior + use data-testid
 - Use describe blocks and beforeEach for setup
 - Mock external dependencies
+- Don't add clearAllMocks or resetAllMocks to individual test files because it's already in jest.config.js
 
 ### Jest Mocking Best Practices
 

--- a/src/server/common/constants/mcms-context.js
+++ b/src/server/common/constants/mcms-context.js
@@ -1,0 +1,52 @@
+export const requiredQueryParams = {
+  ACTIVITY_TYPE: 'ACTIVITY_TYPE',
+  ARTICLE: 'ARTICLE',
+  pdfDownloadUrl: 'pdfDownloadUrl'
+}
+
+export const validActivitySubtypes = [
+  'coastalProtectionDrainageOrFloodDefence',
+  'crossrailAct',
+  'deepseaMining',
+  'defenceMiningCrossrail',
+  'dredgedMaterial',
+  'emergency',
+  'fishing',
+  'hullCleaning',
+  'maintenance',
+  'markersMooringsAidsToNavigation',
+  'markersMooringsAndAidToNavigation',
+  'miscellaneous',
+  'navigationalDredging',
+  'ObstructionsDanger',
+  'pollutionResponse',
+  'pontoons',
+  'scientificResearch',
+  'shellfish',
+  'waste'
+]
+
+export const activityTypes = {
+  CON: 'CON',
+  DEPOSIT: 'DEPOSIT',
+  REMOVAL: 'REMOVAL',
+  DREDGE: 'DREDGE',
+  INCINERATION: 'INCINERATION',
+  EXPLOSIVES: 'EXPLOSIVES',
+  SCUTTLING: 'SCUTTLING'
+}
+
+export const articleCodes = [
+  '13',
+  '17',
+  '17A',
+  '17B',
+  '18A',
+  '20',
+  '21',
+  '25',
+  '25A',
+  '26A',
+  '34',
+  '35'
+]

--- a/src/server/common/helpers/mcms-context/cache-mcms-context.js
+++ b/src/server/common/helpers/mcms-context/cache-mcms-context.js
@@ -1,0 +1,35 @@
+import { paramsSchema } from './schema.js'
+
+const mcmsContextCacheKey = 'mcmsContext'
+
+export const cacheMcmsContextFromQueryParams = (request) => {
+  if (request.path === '/') {
+    const { error, value } = paramsSchema.validate(request.query)
+
+    if (!error) {
+      request.yar.flash(mcmsContextCacheKey, value)
+    } else {
+      request.logger.error(
+        error,
+        `Missing or invalid MCMS query string context on URL: ${request.url} - ${error.message}`
+      )
+    }
+  }
+}
+
+export const getMcmsContextFromCache = (request) => {
+  const cachedParams = request.yar.flash(mcmsContextCacheKey)
+  if (!cachedParams?.length) {
+    request.logger.error(
+      `Missing MCMS query string context on URL: ${request.url}`
+    )
+    return null
+  }
+  if (cachedParams.length > 1) {
+    request.logger.error(
+      `Multiple MCMS contexts cached for URL: ${request.url}`
+    )
+  }
+
+  return cachedParams[0]
+}

--- a/src/server/common/helpers/mcms-context/cache-mcms-context.test.js
+++ b/src/server/common/helpers/mcms-context/cache-mcms-context.test.js
@@ -1,0 +1,157 @@
+import {
+  cacheMcmsContextFromQueryParams,
+  getMcmsContextFromCache
+} from './cache-mcms-context.js'
+
+describe('Cache / get MCMS context', () => {
+  let mockRequest
+  let logError
+
+  beforeEach(() => {
+    logError = jest.fn()
+    mockRequest = {
+      path: '/',
+      query: {},
+      url: 'http://example.com/?ACTIVITY_TYPE=CON&ARTICLE=17',
+      yar: {
+        flash: jest.fn()
+      },
+      logger: {
+        error: logError
+      }
+    }
+  })
+
+  describe('cacheMcmsContextFromQueryParams', () => {
+    it('should cache valid query params on root path', () => {
+      mockRequest.query = {
+        ACTIVITY_TYPE: 'CON',
+        ARTICLE: '17',
+        pdfDownloadUrl: 'https://example.com/test.pdf',
+        EXE_ACTIVITY_SUBTYPE_CONSTRUCTION: 'maintenance'
+      }
+
+      cacheMcmsContextFromQueryParams(mockRequest)
+
+      const expectedTransformedValue = {
+        activityType: 'CON',
+        activitySubtype: 'maintenance',
+        article: '17',
+        pdfDownloadUrl: 'https://example.com/test.pdf'
+      }
+
+      expect(mockRequest.yar.flash).toHaveBeenCalledWith(
+        'mcmsContext',
+        expectedTransformedValue
+      )
+      expect(logError).not.toHaveBeenCalled()
+    })
+
+    it('should log error and not cache when validation fails', () => {
+      mockRequest.query = {
+        ACTIVITY_TYPE: 'INVALID_TYPE',
+        ARTICLE: '17',
+        pdfDownloadUrl: 'https://example.com/test.pdf'
+      }
+
+      cacheMcmsContextFromQueryParams(mockRequest)
+
+      expect(mockRequest.yar.flash).not.toHaveBeenCalled()
+      expect(logError.mock.calls[0][1]).toBe(
+        'Missing or invalid MCMS query string context on URL: http://example.com/?ACTIVITY_TYPE=CON&ARTICLE=17 - "ACTIVITY_TYPE" must be one of [CON, DEPOSIT, REMOVAL, DREDGE, INCINERATION, EXPLOSIVES, SCUTTLING]'
+      )
+    })
+
+    it('should do nothing when not on root path', () => {
+      mockRequest.path = '/some-other-path'
+
+      cacheMcmsContextFromQueryParams(mockRequest)
+
+      expect(mockRequest.yar.flash).not.toHaveBeenCalled()
+    })
+
+    it('should handle empty query params', () => {
+      mockRequest.query = {}
+
+      cacheMcmsContextFromQueryParams(mockRequest)
+
+      expect(mockRequest.yar.flash).not.toHaveBeenCalled()
+      expect(logError.mock.calls[0][1]).toBe(
+        'Missing or invalid MCMS query string context on URL: http://example.com/?ACTIVITY_TYPE=CON&ARTICLE=17 - "ACTIVITY_TYPE" is required'
+      )
+    })
+
+    it("should cache valid query params without subtype if the activity type doesn't require one", () => {
+      mockRequest.query = {
+        ACTIVITY_TYPE: 'INCINERATION',
+        ARTICLE: '34',
+        pdfDownloadUrl: 'https://example.com/incineration.pdf'
+      }
+
+      cacheMcmsContextFromQueryParams(mockRequest)
+
+      expect(mockRequest.yar.flash).toHaveBeenCalledWith('mcmsContext', {
+        activityType: 'INCINERATION',
+        activitySubtype: null,
+        article: '34',
+        pdfDownloadUrl: 'https://example.com/incineration.pdf'
+      })
+    })
+  })
+
+  describe('getMcmsContextFromCache', () => {
+    it('should return cached MCMS context when available', () => {
+      const cachedContext = {
+        activityType: 'CON',
+        activitySubtype: 'maintenance',
+        article: '17',
+        pdfDownloadUrl: 'https://example.com/test.pdf'
+      }
+
+      mockRequest.yar.flash.mockReturnValue([cachedContext])
+
+      const result = getMcmsContextFromCache(mockRequest)
+
+      expect(mockRequest.yar.flash).toHaveBeenCalledWith('mcmsContext')
+      expect(result).toEqual(cachedContext)
+      expect(logError).not.toHaveBeenCalled()
+    })
+
+    it('should return null and log error when no cached context', () => {
+      mockRequest.yar.flash.mockReturnValue([])
+
+      const result = getMcmsContextFromCache(mockRequest)
+
+      expect(mockRequest.yar.flash).toHaveBeenCalledWith('mcmsContext')
+      expect(result).toBeNull()
+      expect(logError).toHaveBeenCalledWith(
+        `Missing MCMS query string context on URL: ${mockRequest.url}`
+      )
+    })
+
+    it('should return first context and log error when multiple cached contexts', () => {
+      const firstContext = {
+        activityType: 'CON',
+        activitySubtype: 'maintenance',
+        article: '17',
+        pdfDownloadUrl: 'https://example.com/test1.pdf'
+      }
+      const secondContext = {
+        activityType: 'DEPOSIT',
+        activitySubtype: 'dredgedMaterial',
+        article: '18A',
+        pdfDownloadUrl: 'https://example.com/test2.pdf'
+      }
+
+      mockRequest.yar.flash.mockReturnValue([firstContext, secondContext])
+
+      const result = getMcmsContextFromCache(mockRequest)
+
+      expect(mockRequest.yar.flash).toHaveBeenCalledWith('mcmsContext')
+      expect(result).toEqual(firstContext)
+      expect(logError).toHaveBeenCalledWith(
+        `Multiple MCMS contexts cached for URL: ${mockRequest.url}`
+      )
+    })
+  })
+})

--- a/src/server/common/helpers/mcms-context/schema.js
+++ b/src/server/common/helpers/mcms-context/schema.js
@@ -1,0 +1,65 @@
+import Joi from 'joi'
+import {
+  requiredQueryParams,
+  validActivitySubtypes,
+  activityTypes,
+  articleCodes
+} from '~/src/server/common/constants/mcms-context.js'
+
+const { ACTIVITY_TYPE, ARTICLE, pdfDownloadUrl } = requiredQueryParams
+
+export const paramsSchema = Joi.object({
+  [ACTIVITY_TYPE]: Joi.string()
+    .valid(...Object.values(activityTypes))
+    .required(),
+  [ARTICLE]: Joi.string()
+    .valid(...articleCodes)
+    .required(),
+  [pdfDownloadUrl]: Joi.string().required(),
+  EXE_ACTIVITY_SUBTYPE_CONSTRUCTION: Joi.when(ACTIVITY_TYPE, {
+    is: activityTypes.CON,
+    then: Joi.string()
+      .valid(...validActivitySubtypes)
+      .required(),
+    otherwise: Joi.forbidden()
+  }),
+  EXE_ACTIVITY_SUBTYPE_DEPOSIT: Joi.when(ACTIVITY_TYPE, {
+    is: activityTypes.DEPOSIT,
+    then: Joi.string()
+      .valid(...validActivitySubtypes)
+      .required(),
+    otherwise: Joi.forbidden()
+  }),
+  EXE_ACTIVITY_SUBTYPE_REMOVAL: Joi.when(ACTIVITY_TYPE, {
+    is: activityTypes.REMOVAL,
+    then: Joi.string()
+      .valid(...validActivitySubtypes)
+      .required(),
+    otherwise: Joi.forbidden()
+  }),
+  EXE_ACTIVITY_SUBTYPE_DREDGING: Joi.when(ACTIVITY_TYPE, {
+    is: activityTypes.DREDGE,
+    then: Joi.string()
+      .valid(...validActivitySubtypes)
+      .required(),
+    otherwise: Joi.forbidden()
+  })
+})
+  .unknown(true)
+  .custom((value) => {
+    // Find the activity subtype value from any of the EXE_ACTIVITY_SUBTYPE_* fields
+    const activitySubtype =
+      value.EXE_ACTIVITY_SUBTYPE_CONSTRUCTION ||
+      value.EXE_ACTIVITY_SUBTYPE_DEPOSIT ||
+      value.EXE_ACTIVITY_SUBTYPE_REMOVAL ||
+      value.EXE_ACTIVITY_SUBTYPE_DREDGING ||
+      null
+
+    // Return the transformed object
+    return {
+      activityType: value[ACTIVITY_TYPE],
+      activitySubtype,
+      article: value[ARTICLE],
+      pdfDownloadUrl: value[pdfDownloadUrl]
+    }
+  })

--- a/src/server/common/helpers/mcms-context/schema.js
+++ b/src/server/common/helpers/mcms-context/schema.js
@@ -47,7 +47,6 @@ export const paramsSchema = Joi.object({
 })
   .unknown(true)
   .custom((value) => {
-    // Find the activity subtype value from any of the EXE_ACTIVITY_SUBTYPE_* fields
     const activitySubtype =
       value.EXE_ACTIVITY_SUBTYPE_CONSTRUCTION ||
       value.EXE_ACTIVITY_SUBTYPE_DEPOSIT ||
@@ -55,7 +54,6 @@ export const paramsSchema = Joi.object({
       value.EXE_ACTIVITY_SUBTYPE_DREDGING ||
       null
 
-    // Return the transformed object
     return {
       activityType: value[ACTIVITY_TYPE],
       activitySubtype,

--- a/src/server/common/helpers/mcms-context/schema.test.js
+++ b/src/server/common/helpers/mcms-context/schema.test.js
@@ -1,0 +1,244 @@
+import { paramsSchema } from './schema.js'
+
+describe('mcms-context schema', () => {
+  describe('paramsSchema validation and transformation', () => {
+    const validBaseParams = {
+      ACTIVITY_TYPE: 'CON',
+      ARTICLE: '17',
+      pdfDownloadUrl: 'https://example.com/test.pdf'
+    }
+
+    describe('validation', () => {
+      it('should validate valid params with construction subtype', () => {
+        const params = {
+          ...validBaseParams,
+          EXE_ACTIVITY_SUBTYPE_CONSTRUCTION: 'maintenance'
+        }
+
+        const { error } = paramsSchema.validate(params)
+        expect(error).toBeUndefined()
+      })
+
+      it('should validate valid params with deposit subtype', () => {
+        const params = {
+          ...validBaseParams,
+          ACTIVITY_TYPE: 'DEPOSIT',
+          EXE_ACTIVITY_SUBTYPE_DEPOSIT: 'dredgedMaterial'
+        }
+
+        const { error } = paramsSchema.validate(params)
+        expect(error).toBeUndefined()
+      })
+
+      it('should validate valid params with removal subtype', () => {
+        const params = {
+          ...validBaseParams,
+          ACTIVITY_TYPE: 'REMOVAL',
+          EXE_ACTIVITY_SUBTYPE_REMOVAL: 'emergency'
+        }
+
+        const { error } = paramsSchema.validate(params)
+        expect(error).toBeUndefined()
+      })
+
+      it('should validate valid params with dredging subtype', () => {
+        const params = {
+          ...validBaseParams,
+          ACTIVITY_TYPE: 'DREDGE',
+          EXE_ACTIVITY_SUBTYPE_DREDGING: 'navigationalDredging'
+        }
+
+        const { error } = paramsSchema.validate(params)
+        expect(error).toBeUndefined()
+      })
+
+      it('should validate params without subtype for non-requiring activity types', () => {
+        const params = {
+          ...validBaseParams,
+          ACTIVITY_TYPE: 'INCINERATION'
+        }
+
+        const { error } = paramsSchema.validate(params)
+        expect(error).toBeUndefined()
+      })
+
+      it('should reject invalid ACTIVITY_TYPE', () => {
+        const params = {
+          ...validBaseParams,
+          ACTIVITY_TYPE: 'INVALID'
+        }
+
+        const { error } = paramsSchema.validate(params)
+        expect(error).toBeDefined()
+        expect(error.details[0].path).toEqual(['ACTIVITY_TYPE'])
+      })
+
+      it('should reject invalid ARTICLE', () => {
+        const params = {
+          ...validBaseParams,
+          ARTICLE: '99'
+        }
+
+        const { error } = paramsSchema.validate(params)
+        expect(error).toBeDefined()
+        expect(error.details[0].path).toEqual(['ARTICLE'])
+      })
+
+      it('should require EXE_ACTIVITY_SUBTYPE_CONSTRUCTION when ACTIVITY_TYPE is CON', () => {
+        const params = {
+          ...validBaseParams,
+          ACTIVITY_TYPE: 'CON'
+        }
+
+        const { error } = paramsSchema.validate(params)
+        expect(error).toBeDefined()
+        expect(error.details[0].path).toEqual([
+          'EXE_ACTIVITY_SUBTYPE_CONSTRUCTION'
+        ])
+      })
+
+      it('should reject EXE_ACTIVITY_SUBTYPE_CONSTRUCTION when ACTIVITY_TYPE is not CON', () => {
+        const params = {
+          ...validBaseParams,
+          ACTIVITY_TYPE: 'DEPOSIT',
+          EXE_ACTIVITY_SUBTYPE_CONSTRUCTION: 'maintenance'
+        }
+
+        const { error } = paramsSchema.validate(params)
+        expect(error).toBeDefined()
+        expect(error.details[0].path).toEqual([
+          'EXE_ACTIVITY_SUBTYPE_CONSTRUCTION'
+        ])
+      })
+
+      it('should reject invalid activity subtype value', () => {
+        const params = {
+          ...validBaseParams,
+          ACTIVITY_TYPE: 'CON',
+          EXE_ACTIVITY_SUBTYPE_CONSTRUCTION: 'invalidSubtype'
+        }
+
+        const { error } = paramsSchema.validate(params)
+        expect(error).toBeDefined()
+        expect(error.details[0].path).toEqual([
+          'EXE_ACTIVITY_SUBTYPE_CONSTRUCTION'
+        ])
+      })
+    })
+
+    describe('transformation', () => {
+      it('should transform valid params with construction subtype', () => {
+        const params = {
+          ...validBaseParams,
+          EXE_ACTIVITY_SUBTYPE_CONSTRUCTION: 'maintenance',
+          extraParam: 'ignored'
+        }
+
+        const { error, value } = paramsSchema.validate(params)
+        expect(error).toBeUndefined()
+        expect(value).toEqual({
+          activityType: 'CON',
+          activitySubtype: 'maintenance',
+          article: '17',
+          pdfDownloadUrl: 'https://example.com/test.pdf'
+        })
+      })
+
+      it('should transform valid params with deposit subtype', () => {
+        const params = {
+          ...validBaseParams,
+          ACTIVITY_TYPE: 'DEPOSIT',
+          EXE_ACTIVITY_SUBTYPE_DEPOSIT: 'dredgedMaterial'
+        }
+
+        const { error, value } = paramsSchema.validate(params)
+        expect(error).toBeUndefined()
+        expect(value).toEqual({
+          activityType: 'DEPOSIT',
+          activitySubtype: 'dredgedMaterial',
+          article: '17',
+          pdfDownloadUrl: 'https://example.com/test.pdf'
+        })
+      })
+
+      it('should transform valid params with null subtype for non-requiring activity types', () => {
+        const params = {
+          ...validBaseParams,
+          ACTIVITY_TYPE: 'INCINERATION'
+        }
+
+        const { error, value } = paramsSchema.validate(params)
+        expect(error).toBeUndefined()
+        expect(value).toEqual({
+          activityType: 'INCINERATION',
+          activitySubtype: null,
+          article: '17',
+          pdfDownloadUrl: 'https://example.com/test.pdf'
+        })
+      })
+
+      it('should transform params with all valid article codes', () => {
+        const articleCodes = [
+          '13',
+          '17',
+          '17A',
+          '17B',
+          '18A',
+          '20',
+          '21',
+          '25',
+          '25A',
+          '26A',
+          '34',
+          '35'
+        ]
+
+        articleCodes.forEach((article) => {
+          const params = {
+            ...validBaseParams,
+            ARTICLE: article,
+            ACTIVITY_TYPE: 'INCINERATION'
+          }
+
+          const { error, value } = paramsSchema.validate(params)
+          expect(error).toBeUndefined()
+          expect(value.article).toBe(article)
+        })
+      })
+
+      it('should transform params with all valid activity types', () => {
+        const activityTypes = [
+          'CON',
+          'DEPOSIT',
+          'REMOVAL',
+          'DREDGE',
+          'INCINERATION',
+          'EXPLOSIVES',
+          'SCUTTLING'
+        ]
+
+        activityTypes.forEach((activityType) => {
+          const params = {
+            ...validBaseParams,
+            ACTIVITY_TYPE: activityType
+          }
+
+          // Add required subtype for specific activity types
+          if (activityType === 'CON') {
+            params.EXE_ACTIVITY_SUBTYPE_CONSTRUCTION = 'maintenance'
+          } else if (activityType === 'DEPOSIT') {
+            params.EXE_ACTIVITY_SUBTYPE_DEPOSIT = 'dredgedMaterial'
+          } else if (activityType === 'REMOVAL') {
+            params.EXE_ACTIVITY_SUBTYPE_REMOVAL = 'emergency'
+          } else if (activityType === 'DREDGE') {
+            params.EXE_ACTIVITY_SUBTYPE_DREDGING = 'navigationalDredging'
+          }
+
+          const { error, value } = paramsSchema.validate(params)
+          expect(error).toBeUndefined()
+          expect(value.activityType).toBe(activityType)
+        })
+      })
+    })
+  })
+})

--- a/src/server/common/plugins/defra-id.js
+++ b/src/server/common/plugins/defra-id.js
@@ -3,6 +3,7 @@ import { config } from '~/src/config/config.js'
 import { openIdProvider } from '~/src/server/common/plugins/auth/open-id.js'
 import { routes } from '~/src/server/common/constants/routes.js'
 import { validateUserSession } from '~/src/server/common/plugins/auth/validate.js'
+import { cacheMcmsContextFromQueryParams } from '~/src/server/common/helpers/mcms-context/cache-mcms-context.js'
 
 export const defraId = {
   plugin: {
@@ -48,7 +49,8 @@ export const defraId = {
           isSameSite: 'Lax'
         },
         keepAlive: true,
-        redirectTo: () => {
+        redirectTo: (request) => {
+          cacheMcmsContextFromQueryParams(request)
           return `/login`
         },
         validate: async (request, session) => {

--- a/src/server/common/plugins/defra-id.test.js
+++ b/src/server/common/plugins/defra-id.test.js
@@ -22,8 +22,6 @@ describe('defraId plugin', () => {
   let mockRequest
 
   beforeEach(() => {
-    jest.clearAllMocks()
-
     mockRequest = {
       yar: {
         flash: jest.fn()

--- a/src/server/exemption/project-name/controller.js
+++ b/src/server/exemption/project-name/controller.js
@@ -13,6 +13,7 @@ import {
 import { routes } from '~/src/server/common/constants/routes.js'
 
 import joi from 'joi'
+import { getMcmsContextFromCache } from '~/src/server/common/helpers/mcms-context/cache-mcms-context.js'
 
 const errorMessages = {
   PROJECT_NAME_REQUIRED: 'Enter the project name',
@@ -86,17 +87,16 @@ export const projectNameSubmitController = {
       const exemption = getExemptionCache(request)
 
       const isUpdate = !!exemption.id
-
+      const mcmsContext = getMcmsContextFromCache(request)
       const { payload: responsePayload } = isUpdate
         ? await authenticatedPatchRequest(request, '/exemption/project-name', {
             ...payload,
             id: exemption.id
           })
-        : await authenticatedPostRequest(
-            request,
-            '/exemption/project-name',
-            payload
-          )
+        : await authenticatedPostRequest(request, '/exemption/project-name', {
+            ...payload,
+            mcmsContext
+          })
 
       setExemptionCache(request, {
         ...exemption,


### PR DESCRIPTION
Exemption app will be reached from the Fivium IAT tool, with a request to the root path and a query string eg `/?ADV_TYPE=EXE&ARTICLE=17&outcomeType=WO_EXE_AVAILABLE_ARTICLE_17&pdfDownloadUrl=https://marinelicensingtest.marinemanagement.org.uk/mmofox5uat/journey/self-service/outcome-document/0233066a-a875-443e-890d-80c392d83ea2&ACTIVITY_TYPE=DEPOSIT&EXE_ACTIVITY_SUBTYPE_DEPOSIT=scientificResearch`

The user will be redirected to login; cache the query string context first, then retrieve when the user saves the exemption with the project name.