### PR TITLE
Fix regression issue with coordinates vs coordinate system label on review pages

### DIFF
--- a/src/server/common/components/polygon-summary/template.njk
+++ b/src/server/common/components/polygon-summary/template.njk
@@ -11,7 +11,7 @@
   },
   {
     key: {
-      text: "Coordinates system"
+      text: "Coordinate system"
     },
     value: {
       html: params.siteDetails.coordinateSystemText | replace('\n', '<br> ')

--- a/src/server/common/components/polygon-summary/template.test.js
+++ b/src/server/common/components/polygon-summary/template.test.js
@@ -56,7 +56,7 @@ describe('Polygon Summary Component', () => {
     test('Should display all required static fields', () => {
       const htmlContent = $component.html()
       expect(htmlContent).toContain('Method of providing site location')
-      expect(htmlContent).toContain('Coordinates system')
+      expect(htmlContent).toContain('Coordinate system')
     })
 
     test('Should handle coordinate system text with line breaks', () => {
@@ -117,7 +117,7 @@ describe('Polygon Summary Component', () => {
     test('Should display all required static fields', () => {
       const htmlContent = $component.html()
       expect(htmlContent).toContain('Method of providing site location')
-      expect(htmlContent).toContain('Coordinates system')
+      expect(htmlContent).toContain('Coordinate system')
     })
 
     test('Should handle OSGB36 coordinate system with line breaks', () => {

--- a/src/server/common/components/site-details-card/point-circle.njk
+++ b/src/server/common/components/site-details-card/point-circle.njk
@@ -28,7 +28,7 @@
       },
       {
         key: {
-          text: "Coordinates system"
+          text: "Coordinate system"
         },
         value: {
           html: params.siteDetails.coordinateSystemText | replace('\n', '<br> ')

--- a/src/server/common/components/site-details-card/polygon.njk
+++ b/src/server/common/components/site-details-card/polygon.njk
@@ -11,7 +11,7 @@
   },
   {
     key: {
-      text: "Coordinates system"
+      text: "Coordinate system"
     },
     value: {
       html: params.siteDetails.coordinateSystemText | replace('\n', '<br> ')

--- a/src/server/common/components/site-details-card/template.test.js
+++ b/src/server/common/components/site-details-card/template.test.js
@@ -153,7 +153,7 @@ describe('Site Details Card Component', () => {
         ).map((el) => el.textContent.trim())
 
         expect(keys).toContain('Method of providing site location')
-        expect(keys).toContain('Coordinates system')
+        expect(keys).toContain('Coordinate system')
         expect(keys).toContain('Coordinates at centre of site')
         expect(keys).toContain('Width of circular site')
         expect(keys).toContain('Map view')
@@ -269,7 +269,7 @@ describe('Site Details Card Component', () => {
         ).map((el) => el.textContent.trim())
 
         expect(keys).toContain('Method of providing site location')
-        expect(keys).toContain('Coordinates system')
+        expect(keys).toContain('Coordinate system')
         expect(keys).toContain('Map view')
       })
 
@@ -352,7 +352,7 @@ describe('Site Details Card Component', () => {
 
         // Should still have base fields and map view
         expect(keys).toContain('Method of providing site location')
-        expect(keys).toContain('Coordinates system')
+        expect(keys).toContain('Coordinate system')
         expect(keys).toContain('Map view')
       })
     })

--- a/tests/integration/check-your-answers/fixtures.js
+++ b/tests/integration/check-your-answers/fixtures.js
@@ -217,7 +217,7 @@ export const testScenarios = [
       siteDetails: {
         'Method of providing site location':
           'Manually enter one set of coordinates and a width to create a circular site',
-        'Coordinates system':
+        'Coordinate system':
           'WGS84 (World Geodetic System 1984) Latitude and longitude',
         'Coordinates at centre of site': '54.726200, -1.599400',
         'Width of circular site': '100 metres',
@@ -268,7 +268,7 @@ export const testScenarios = [
       siteDetails: {
         'Method of providing site location':
           'Manually enter one set of coordinates and a width to create a circular site',
-        'Coordinates system': 'OSGB36 (National Grid) Eastings and Northings',
+        'Coordinate system': 'OSGB36 (National Grid) Eastings and Northings',
         'Coordinates at centre of site': '425053, 564180',
         'Width of circular site': '100 metres',
         'Map view': ''
@@ -319,7 +319,7 @@ export const testScenarios = [
       siteDetails: {
         'Method of providing site location':
           'Manually enter multiple sets of coordinates to mark the boundary of the site',
-        'Coordinates system':
+        'Coordinate system':
           'WGS84 (World Geodetic System 1984) Latitude and longitude',
         'Start and end points': '54.721000, -1.595000',
         'Point 2': '54.725000, -1.590000',
@@ -372,7 +372,7 @@ export const testScenarios = [
       siteDetails: {
         'Method of providing site location':
           'Manually enter multiple sets of coordinates to mark the boundary of the site',
-        'Coordinates system': 'OSGB36 (National Grid) Eastings and Northings',
+        'Coordinate system': 'OSGB36 (National Grid) Eastings and Northings',
         'Start and end points': '425053, 564180',
         'Point 2': '426000, 565000',
         'Point 3': '427000, 566000',

--- a/tests/integration/view-details/fixtures.js
+++ b/tests/integration/view-details/fixtures.js
@@ -121,7 +121,7 @@ export const testScenarios = [
       siteDetails: {
         'Method of providing site location':
           'Manually enter one set of coordinates and a width to create a circular site',
-        'Coordinates system':
+        'Coordinate system':
           'WGS84 (World Geodetic System 1984) Latitude and longitude',
         'Coordinates at centre of site': '51.489676, -0.231530',
         'Width of circular site': '100 metres'
@@ -142,7 +142,7 @@ export const testScenarios = [
       siteDetails: {
         'Method of providing site location':
           'Manually enter one set of coordinates and a width to create a circular site',
-        'Coordinates system': 'OSGB36 (National Grid) Eastings and Northings',
+        'Coordinate system': 'OSGB36 (National Grid) Eastings and Northings',
         'Coordinates at centre of site': '123456, 654321',
         'Width of circular site': '250 metres'
       }
@@ -185,11 +185,11 @@ export const testScenarios = [
       siteDetails: {
         'Method of providing site location':
           'Manually enter multiple sets of coordinates to mark the boundary of the site',
-        'Coordinates system':
+        'Coordinate system':
           'WGS84 (World Geodetic System 1984) Latitude and longitude'
       },
       siteDetailsExtended: {
-        expectedRowCount: 6, // Method + Coordinates System + 3 coordinate points + map
+        expectedRowCount: 6, // Method + Coordinate System + 3 coordinate points + map
         coordinatePoints: [
           '55.123456, -1.234567',
           '55.223456, -1.334567',
@@ -209,10 +209,10 @@ export const testScenarios = [
       siteDetails: {
         'Method of providing site location':
           'Manually enter multiple sets of coordinates to mark the boundary of the site',
-        'Coordinates system': 'OSGB36 (National Grid) Eastings and Northings'
+        'Coordinate system': 'OSGB36 (National Grid) Eastings and Northings'
       },
       siteDetailsExtended: {
-        expectedRowCount: 6, // Method + Coordinates System + 3 coordinate points + map
+        expectedRowCount: 6, // Method + Coordinate System + 3 coordinate points + map
         coordinatePoints: ['123456, 654321', '123556, 654421', '123656, 654521']
       }
     }
@@ -237,7 +237,7 @@ export const testScenarios = [
       siteDetails: {
         'Method of providing site location':
           'Manually enter one set of coordinates and a width to create a circular site',
-        'Coordinates system':
+        'Coordinate system':
           'WGS84 (World Geodetic System 1984) Latitude and longitude',
         'Coordinates at centre of site': '51.489676, -0.231530',
         'Width of circular site': '100 metres'


### PR DESCRIPTION
Recent merge of ML-101 reverted the previous fix for this.

As per the design in ML-101 user story the label should be *Coordinate system*

<img width="1014" height="2020" alt="image" src="https://github.com/user-attachments/assets/03063e73-5e9e-4bdf-9a2b-a35f4c541fe0" />
