### PR TITLE
Only run on main and name report

### DIFF
--- a/.github/workflows/allure-report.yml
+++ b/.github/workflows/allure-report.yml
@@ -2,7 +2,7 @@ name: Integration Tests - Allure Report
 
 on:
   push:
-  pull_request:
+    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -38,7 +38,7 @@ jobs:
       - name: Generate Allure Report
         if: always()
         run: |
-          npx allure generate allure-results --single-file --clean --output allure-report
+          npx allure generate allure-results --single-file --clean --output allure-report --name marine-licensing-dom-testing-library-tests
 
       - name: Add test run info to report
         if: always()

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test": "jest --coverage --verbose",
     "test:watch": "jest --watch",
     "test:mutation": "npx stryker run stryker.conf.cjs",
-    "test:integration:allure": "npx jest tests/ --coverage=false && npx allure generate allure-results --single-file --clean",
+    "test:integration:allure": "npx jest tests/ --coverage=false && npx allure generate allure-results --single-file --clean --name marine-licensing-dom-testing-library-tests",
     "server:watch": "nodemon --exec tsx --enable-source-maps ./src",
     "server:debug": "nodemon --exec tsx --enable-source-maps --inspect ./src",
     "prestart": "npm run build",


### PR DESCRIPTION
It's wasteful to run the report step on all branches as we only publish from `main`.

I've also added a name to the report while I was here.