### PR TITLE
ML-142 - Set activity subtype to undefined not null if not relevant

### DIFF
--- a/src/server/common/helpers/mcms-context/cache-mcms-context.test.js
+++ b/src/server/common/helpers/mcms-context/cache-mcms-context.test.js
@@ -92,7 +92,6 @@ describe('Cache / get MCMS context', () => {
 
       expect(mockRequest.yar.flash).toHaveBeenCalledWith('mcmsContext', {
         activityType: 'INCINERATION',
-        activitySubtype: null,
         article: '34',
         pdfDownloadUrl: 'https://example.com/incineration.pdf'
       })

--- a/src/server/common/helpers/mcms-context/schema.js
+++ b/src/server/common/helpers/mcms-context/schema.js
@@ -52,7 +52,7 @@ export const paramsSchema = Joi.object({
       value.EXE_ACTIVITY_SUBTYPE_DEPOSIT ||
       value.EXE_ACTIVITY_SUBTYPE_REMOVAL ||
       value.EXE_ACTIVITY_SUBTYPE_DREDGING ||
-      null
+      undefined
 
     return {
       activityType: value[ACTIVITY_TYPE],

--- a/src/server/common/helpers/mcms-context/schema.test.js
+++ b/src/server/common/helpers/mcms-context/schema.test.js
@@ -171,7 +171,6 @@ describe('mcms-context schema', () => {
         expect(error).toBeUndefined()
         expect(value).toEqual({
           activityType: 'INCINERATION',
-          activitySubtype: null,
           article: '17',
           pdfDownloadUrl: 'https://example.com/test.pdf'
         })


### PR DESCRIPTION
Bug fix - when activity subtype was not needed due to the main type being one other than construction / deposit / removal / dredging, the subtype was being set to null which caused backend validation to fail. This sets it to undefined instead.