### PR TITLE
ML-616 - await validateUserSession promise

### DIFF
--- a/src/server/common/plugins/defra-id.js
+++ b/src/server/common/plugins/defra-id.js
@@ -55,7 +55,7 @@ export const defraId = {
           return `/login`
         },
         validate: async (request, session) => {
-          const validity = validateUserSession(request, session)
+          const validity = await validateUserSession(request, session)
           if (validity.isValid === false) {
             clearExemptionCache(request)
           }

--- a/src/server/common/plugins/defra-id.test.js
+++ b/src/server/common/plugins/defra-id.test.js
@@ -154,7 +154,7 @@ describe('defraId plugin', () => {
   })
 
   test('should call clearExemptionCache when validity.isValid is false', async () => {
-    mockedValidateUserSession.mockReturnValue({ isValid: false })
+    mockedValidateUserSession.mockResolvedValue({ isValid: false })
 
     await defraId.plugin.register(mockServer)
 


### PR DESCRIPTION
await the promise returned from validateUserSession so that invalid sessions can be correctly detected, and the exemption cache cleared