### PR TITLE
Fix: Ignore allure-results in Jest watch mode

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -43,7 +43,7 @@ export default {
   transformIgnorePatterns: [
     `node_modules/(?!${['@defra/hapi-tracing', 'node-fetch'].join('|')}/)`
   ],
-  watchPathIgnorePatterns: ['./allure-results']
+  watchPathIgnorePatterns: ['<rootDir>/allure-results']
 }
 
 /**


### PR DESCRIPTION
Jest watch mode (`npm run jest:watch`) loops infinitely due to the introduction of the allure reporter. This fix ignores it so it will work correctly.