### PR TITLE
ML-644 - Remove auth on privacy page

### DIFF
--- a/src/server/help/privacy/index.js
+++ b/src/server/help/privacy/index.js
@@ -15,7 +15,7 @@ export const privacy = {
           method: 'GET',
           path: routes.PRIVACY,
           options: {
-            auth: { strategy: 'defra-id', mode: 'try' }
+            auth: false
           },
           ...privacyController
         }

--- a/src/server/help/privacy/index.test.js
+++ b/src/server/help/privacy/index.test.js
@@ -14,7 +14,7 @@ describe('privacy route', () => {
         method: 'GET',
         path: '/help/privacy',
         options: {
-          auth: { strategy: 'defra-id', mode: 'try' }
+          auth: false
         }
       })
     ])


### PR DESCRIPTION
Auth had been set to defraId / try; but it was still redirecting to login when the user was already logged in.

Remove any requirement for auth on the /help/privacy route