### PR TITLE
Fix page heading to show project name on View Details page

### DIFF
--- a/src/server/exemption/view-details/controller.js
+++ b/src/server/exemption/view-details/controller.js
@@ -47,7 +47,7 @@ export const viewDetailsController = {
       const pageCaption = `${exemption.applicationReference} - Exempt activity notification`
 
       return h.view(VIEW_DETAILS_VIEW_ROUTE, {
-        pageTitle: 'View notification details',
+        pageTitle: exemption.projectName,
         pageCaption,
         backLink: routes.DASHBOARD,
         isReadOnly: true,

--- a/src/server/exemption/view-details/controller.js
+++ b/src/server/exemption/view-details/controller.js
@@ -1,10 +1,10 @@
 import Boom from '@hapi/boom'
-import { routes } from '~/src/server/common/constants/routes.js'
-import { createSiteDetailsDataJson } from '~/src/server/common/helpers/site-details.js'
-import { processSiteDetails } from '~/src/server/common/helpers/exemption-site-details.js'
 import { errorMessages } from '~/src/server/common/constants/error-messages.js'
-import { getExemptionService } from '~/src/services/exemption-service/index.js'
 import { EXEMPTION_STATUS } from '~/src/server/common/constants/exemptions.js'
+import { routes } from '~/src/server/common/constants/routes.js'
+import { processSiteDetails } from '~/src/server/common/helpers/exemption-site-details.js'
+import { createSiteDetailsDataJson } from '~/src/server/common/helpers/site-details.js'
+import { getExemptionService } from '~/src/services/exemption-service/index.js'
 
 export const VIEW_DETAILS_VIEW_ROUTE = 'exemption/view-details/index'
 

--- a/src/server/exemption/view-details/controller.test.js
+++ b/src/server/exemption/view-details/controller.test.js
@@ -248,7 +248,7 @@ describe('view details controller', () => {
         expect(mockH.view).toHaveBeenCalledWith(
           VIEW_DETAILS_VIEW_ROUTE,
           expect.objectContaining({
-            pageTitle: 'View notification details',
+            pageTitle: submittedExemption.projectName,
             pageCaption: 'EXE/2025/00003 - Exempt activity notification',
             backLink: '/home',
             isReadOnly: true,

--- a/tests/integration/view-details/fixtures.js
+++ b/tests/integration/view-details/fixtures.js
@@ -81,7 +81,7 @@ export const mockPolygonCoordinatesOSGB36 = [
 ]
 
 const baseExpectedContent = {
-  pageTitle: 'View notification details',
+  pageTitle: 'Test Marine Activity Project',
   pageCaption: 'EXE/2025/00003 - Exempt activity notification',
   backLinkText: 'Back',
   backLinkHref: '/home',


### PR DESCRIPTION
Fix page heading to show project name - this is part of ML-101 but making this small fix to allow my journey tests PR to be merged.