### PR TITLE
ML-738 - Add content security policy

### DIFF
--- a/src/server/common/helpers/content-security-policy.js
+++ b/src/server/common/helpers/content-security-policy.js
@@ -22,6 +22,8 @@ const contentSecurityPolicy = {
       'manifest-src': "'self'",
       'media-src': "'self'",
       'object-src': "'none'",
+      // Hash 'sha256-GUQ5ad8JK5KmEWmROf3LZd9ge94daqNvd8xy9YS1iDw=' is to support a GOV.UK frontend script bundled within Nunjucks macros
+      // https://frontend.design-system.service.gov.uk/import-javascript/#if-our-inline-javascript-snippet-is-blocked-by-a-content-security-policy
       'script-src':
         "'self' 'sha256-GUQ5ad8JK5KmEWmROf3LZd9ge94daqNvd8xy9YS1iDw='",
       'style-src': "'self'"

--- a/src/server/common/helpers/content-security-policy.js
+++ b/src/server/common/helpers/content-security-policy.js
@@ -11,19 +11,20 @@ const contentSecurityPolicy = {
       'cdpUploader.cdpUploadServiceBaseUrl'
     )
     const cspDirectives = {
+      'base-uri': "'self'",
+      'connect-src': "'self'",
       'default-src': "'self'",
-      'font-src': "'self' data:",
-      'connect-src': "'self' data:",
+      'font-src': "'self'",
+      'form-action': `'self' ${uploaderServiceHost}`,
+      'frame-src': "'self'",
+      'frame-ancestors': "'none'",
+      'img-src': "'self' data: https://tile.openstreetmap.org",
+      'manifest-src': "'self'",
       'media-src': "'self'",
-      'style-src': "'self'",
+      'object-src': "'none'",
       'script-src':
         "'self' 'sha256-GUQ5ad8JK5KmEWmROf3LZd9ge94daqNvd8xy9YS1iDw='",
-      'img-src': "'self' data: https://tile.openstreetmap.org",
-      'frame-src': "'self'",
-      'object-src': "'none'",
-      'frame-ancestors': "'none'",
-      'form-action': `'self' ${uploaderServiceHost}`,
-      'manifest-src': "'self'"
+      'style-src': "'self'"
     }
 
     const cspHeader = Object.entries(cspDirectives)
@@ -32,11 +33,7 @@ const contentSecurityPolicy = {
 
     server.ext('onPreResponse', (request, h) => {
       const response = request.response
-
-      if (!response.isBoom) {
-        response.header('Content-Security-Policy', cspHeader)
-      }
-
+      response.header?.('Content-Security-Policy', cspHeader)
       return h.continue
     })
   }

--- a/src/server/common/helpers/content-security-policy.js
+++ b/src/server/common/helpers/content-security-policy.js
@@ -1,0 +1,45 @@
+import { config } from '~/src/config/config.js'
+
+/**
+ * Manage content security policies.
+ * @satisfies {import('@hapi/hapi').Plugin}
+ */
+const contentSecurityPolicy = {
+  name: 'content-security-policy',
+  register: (server) => {
+    const uploaderServiceHost = config.get(
+      'cdpUploader.cdpUploadServiceBaseUrl'
+    )
+    const cspDirectives = {
+      'default-src': "'self'",
+      'font-src': "'self' data:",
+      'connect-src': "'self' data:",
+      'media-src': "'self'",
+      'style-src': "'self'",
+      'script-src':
+        "'self' 'sha256-GUQ5ad8JK5KmEWmROf3LZd9ge94daqNvd8xy9YS1iDw='",
+      'img-src': "'self' data: https://tile.openstreetmap.org",
+      'frame-src': "'self'",
+      'object-src': "'none'",
+      'frame-ancestors': "'none'",
+      'form-action': `'self' ${uploaderServiceHost}`,
+      'manifest-src': "'self'"
+    }
+
+    const cspHeader = Object.entries(cspDirectives)
+      .map(([directive, value]) => `${directive} ${value}`)
+      .join('; ')
+
+    server.ext('onPreResponse', (request, h) => {
+      const response = request.response
+
+      if (!response.isBoom) {
+        response.header('Content-Security-Policy', cspHeader)
+      }
+
+      return h.continue
+    })
+  }
+}
+
+export { contentSecurityPolicy }

--- a/src/server/common/helpers/content-security-policy.test.js
+++ b/src/server/common/helpers/content-security-policy.test.js
@@ -35,27 +35,140 @@ describe('contentSecurityPolicy', () => {
       onPreResponseHandler = server.ext.mock.calls[0][1]
     })
 
-    it('should set CSP header with correct directives', () => {
-      const result = onPreResponseHandler(mockRequest, mockH)
+    it('should register onPreResponse hook', () => {
+      onPreResponseHandler(mockRequest, mockH)
 
       expect(server.ext).toHaveBeenCalledWith(
         'onPreResponse',
         expect.any(Function)
       )
-      expect(result).toBe(mockH.continue)
-      expect(mockResponse.header).toHaveBeenCalledWith(
-        'Content-Security-Policy',
-        "default-src 'self'; font-src 'self' data:; connect-src 'self' data:; media-src 'self'; style-src 'self'; script-src 'self' 'sha256-GUQ5ad8JK5KmEWmROf3LZd9ge94daqNvd8xy9YS1iDw='; img-src 'self' data: https://tile.openstreetmap.org; frame-src 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self' http://localhost:7337; manifest-src 'self'"
-      )
     })
 
-    it('should not set CSP header for Boom errors', () => {
-      mockRequest.response.isBoom = true
-
+    it('should return h.continue', () => {
       const result = onPreResponseHandler(mockRequest, mockH)
 
       expect(result).toBe(mockH.continue)
-      expect(mockResponse.header).not.toHaveBeenCalled()
+    })
+
+    it('should set base-uri directive', () => {
+      onPreResponseHandler(mockRequest, mockH)
+
+      expect(mockResponse.header).toHaveBeenCalledWith(
+        'Content-Security-Policy',
+        expect.stringContaining("base-uri 'self'")
+      )
+    })
+
+    it('should set default-src directive', () => {
+      onPreResponseHandler(mockRequest, mockH)
+
+      expect(mockResponse.header).toHaveBeenCalledWith(
+        'Content-Security-Policy',
+        expect.stringContaining("default-src 'self'")
+      )
+    })
+
+    it('should set connect-src directive', () => {
+      onPreResponseHandler(mockRequest, mockH)
+
+      expect(mockResponse.header).toHaveBeenCalledWith(
+        'Content-Security-Policy',
+        expect.stringContaining("connect-src 'self'")
+      )
+    })
+
+    it('should set font-src directive', () => {
+      onPreResponseHandler(mockRequest, mockH)
+
+      expect(mockResponse.header).toHaveBeenCalledWith(
+        'Content-Security-Policy',
+        expect.stringContaining("font-src 'self'")
+      )
+    })
+
+    it('should set form-action directive', () => {
+      onPreResponseHandler(mockRequest, mockH)
+
+      expect(mockResponse.header).toHaveBeenCalledWith(
+        'Content-Security-Policy',
+        expect.stringContaining("form-action 'self' http://localhost:7337")
+      )
+    })
+
+    it('should set frame-src directive', () => {
+      onPreResponseHandler(mockRequest, mockH)
+
+      expect(mockResponse.header).toHaveBeenCalledWith(
+        'Content-Security-Policy',
+        expect.stringContaining("frame-src 'self'")
+      )
+    })
+
+    it('should set frame-ancestors directive', () => {
+      onPreResponseHandler(mockRequest, mockH)
+
+      expect(mockResponse.header).toHaveBeenCalledWith(
+        'Content-Security-Policy',
+        expect.stringContaining("frame-ancestors 'none'")
+      )
+    })
+
+    it('should set img-src directive', () => {
+      onPreResponseHandler(mockRequest, mockH)
+
+      expect(mockResponse.header).toHaveBeenCalledWith(
+        'Content-Security-Policy',
+        expect.stringContaining(
+          "img-src 'self' data: https://tile.openstreetmap.org"
+        )
+      )
+    })
+
+    it('should set manifest-src directive', () => {
+      onPreResponseHandler(mockRequest, mockH)
+
+      expect(mockResponse.header).toHaveBeenCalledWith(
+        'Content-Security-Policy',
+        expect.stringContaining("manifest-src 'self'")
+      )
+    })
+
+    it('should set media-src directive', () => {
+      onPreResponseHandler(mockRequest, mockH)
+
+      expect(mockResponse.header).toHaveBeenCalledWith(
+        'Content-Security-Policy',
+        expect.stringContaining("media-src 'self'")
+      )
+    })
+
+    it('should set object-src directive', () => {
+      onPreResponseHandler(mockRequest, mockH)
+
+      expect(mockResponse.header).toHaveBeenCalledWith(
+        'Content-Security-Policy',
+        expect.stringContaining("object-src 'none'")
+      )
+    })
+
+    it('should set script-src directive', () => {
+      onPreResponseHandler(mockRequest, mockH)
+
+      expect(mockResponse.header).toHaveBeenCalledWith(
+        'Content-Security-Policy',
+        expect.stringContaining(
+          "script-src 'self' 'sha256-GUQ5ad8JK5KmEWmROf3LZd9ge94daqNvd8xy9YS1iDw='"
+        )
+      )
+    })
+
+    it('should set style-src directive', () => {
+      onPreResponseHandler(mockRequest, mockH)
+
+      expect(mockResponse.header).toHaveBeenCalledWith(
+        'Content-Security-Policy',
+        expect.stringContaining("style-src 'self'")
+      )
     })
   })
 })

--- a/src/server/common/helpers/content-security-policy.test.js
+++ b/src/server/common/helpers/content-security-policy.test.js
@@ -1,0 +1,61 @@
+import { contentSecurityPolicy } from './content-security-policy.js'
+
+describe('contentSecurityPolicy', () => {
+  let server
+  let mockResponse
+  let mockRequest
+  let mockH
+
+  beforeEach(() => {
+    mockResponse = {
+      header: jest.fn().mockReturnThis(),
+      isBoom: false
+    }
+    mockRequest = {
+      response: mockResponse
+    }
+    mockH = {
+      continue: Symbol('continue')
+    }
+    server = {
+      ext: jest.fn()
+    }
+  })
+
+  it('should register as a Hapi plugin', () => {
+    expect(contentSecurityPolicy.name).toBe('content-security-policy')
+    expect(contentSecurityPolicy.register).toBeInstanceOf(Function)
+  })
+
+  describe('when registered', () => {
+    let onPreResponseHandler
+
+    beforeEach(async () => {
+      await contentSecurityPolicy.register(server)
+      onPreResponseHandler = server.ext.mock.calls[0][1]
+    })
+
+    it('should set CSP header with correct directives', () => {
+      const result = onPreResponseHandler(mockRequest, mockH)
+
+      expect(server.ext).toHaveBeenCalledWith(
+        'onPreResponse',
+        expect.any(Function)
+      )
+      expect(result).toBe(mockH.continue)
+      expect(mockResponse.header).toHaveBeenCalledWith(
+        'Content-Security-Policy',
+        "default-src 'self'; font-src 'self' data:; connect-src 'self' data:; media-src 'self'; style-src 'self'; script-src 'self' 'sha256-GUQ5ad8JK5KmEWmROf3LZd9ge94daqNvd8xy9YS1iDw='; img-src 'self' data: https://tile.openstreetmap.org; frame-src 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self' http://localhost:7337; manifest-src 'self'"
+      )
+    })
+
+    it('should not set CSP header for Boom errors', () => {
+      mockRequest.response.isBoom = true
+
+      const result = onPreResponseHandler(mockRequest, mockH)
+
+      expect(result).toBe(mockH.continue)
+      expect(mockResponse.header).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -19,6 +19,7 @@ import { csrf } from '~/src/server/common/helpers/csrf.js'
 import { openId } from '~/src/server/common/plugins/open-id.js'
 import { cookies } from '~/src/server/common/plugins/cookies.js'
 import { setPageCacheControlHeaders } from '~/src/server/common/helpers/cache-control.js'
+import { contentSecurityPolicy } from '~/src/server/common/helpers/content-security-policy.js'
 
 export async function createServer() {
   setupProxy()
@@ -76,6 +77,7 @@ export async function createServer() {
     cookie,
     basic,
     nunjucksConfig,
+    contentSecurityPolicy,
     csrf,
     openId,
     cookies,


### PR DESCRIPTION
Avoids using `blankie` / `@hapi/scooter` dependencies as in [the template](https://github.com/DEFRA/cdp-node-frontend-template/commit/395ae07420f02e18ddbacdab004fa44129673cc9) due to a vulnerability in a sub-dependency (scooter -> useragent -> tmp).