### PR TITLE
ML-754 - Apply nonce to inline clarity script and CSP

### DIFF
--- a/src/server/common/helpers/content-security-policy.js
+++ b/src/server/common/helpers/content-security-policy.js
@@ -14,7 +14,7 @@ const contentSecurityPolicy = {
     const clarityProjectId = config.get('clarityProjectId')
     const cspDirectives = {
       'base-uri': "'self'",
-      'connect-src': "'self' https://l.clarity.ms/collect",
+      'connect-src': "'self' https://*.clarity.ms/collect",
       'default-src': "'self'",
       'font-src': "'self'",
       'form-action': `'self' ${uploaderServiceHost}`,

--- a/src/server/common/helpers/content-security-policy.js
+++ b/src/server/common/helpers/content-security-policy.js
@@ -11,9 +11,10 @@ const contentSecurityPolicy = {
     const uploaderServiceHost = config.get(
       'cdpUploader.cdpUploadServiceBaseUrl'
     )
+    const clarityProjectId = config.get('clarityProjectId')
     const cspDirectives = {
       'base-uri': "'self'",
-      'connect-src': "'self'",
+      'connect-src': "'self' https://l.clarity.ms/collect",
       'default-src': "'self'",
       'font-src': "'self'",
       'form-action': `'self' ${uploaderServiceHost}`,
@@ -35,7 +36,7 @@ const contentSecurityPolicy = {
       const cspNonce = randomBytes(16).toString('hex')
       // Hash 'sha256-GUQ5ad8JK5KmEWmROf3LZd9ge94daqNvd8xy9YS1iDw=' is to support a GOV.UK frontend script bundled within Nunjucks macros
       // https://frontend.design-system.service.gov.uk/import-javascript/#if-our-inline-javascript-snippet-is-blocked-by-a-content-security-policy
-      const scriptSrc = `; script-src 'self' 'sha256-GUQ5ad8JK5KmEWmROf3LZd9ge94daqNvd8xy9YS1iDw=' 'nonce-${cspNonce}'`
+      const scriptSrc = `; script-src 'self' 'sha256-GUQ5ad8JK5KmEWmROf3LZd9ge94daqNvd8xy9YS1iDw=' https://www.clarity.ms/tag/${clarityProjectId} https://scripts.clarity.ms 'nonce-${cspNonce}'`
       response.header?.('Content-Security-Policy', cspHeader + scriptSrc)
       if (response.variety === 'view') {
         response.source.context = {

--- a/src/server/common/helpers/content-security-policy.test.js
+++ b/src/server/common/helpers/content-security-policy.test.js
@@ -1,5 +1,11 @@
 import { contentSecurityPolicy } from './content-security-policy.js'
 
+jest.mock('~/src/config/config.js', () => ({
+  config: {
+    get: jest.fn(() => '123') // clarityProjectId
+  }
+}))
+
 describe('contentSecurityPolicy', () => {
   let server
   let mockResponse
@@ -157,7 +163,7 @@ describe('contentSecurityPolicy', () => {
       expect(mockResponse.header).toHaveBeenCalledWith(
         'Content-Security-Policy',
         expect.stringContaining(
-          "script-src 'self' 'sha256-GUQ5ad8JK5KmEWmROf3LZd9ge94daqNvd8xy9YS1iDw=' 'nonce-"
+          "script-src 'self' 'sha256-GUQ5ad8JK5KmEWmROf3LZd9ge94daqNvd8xy9YS1iDw=' https://www.clarity.ms/tag/123 https://scripts.clarity.ms 'nonce-"
         )
       )
     })

--- a/src/server/common/helpers/content-security-policy.test.js
+++ b/src/server/common/helpers/content-security-policy.test.js
@@ -157,7 +157,7 @@ describe('contentSecurityPolicy', () => {
       expect(mockResponse.header).toHaveBeenCalledWith(
         'Content-Security-Policy',
         expect.stringContaining(
-          "script-src 'self' 'sha256-GUQ5ad8JK5KmEWmROf3LZd9ge94daqNvd8xy9YS1iDw='"
+          "script-src 'self' 'sha256-GUQ5ad8JK5KmEWmROf3LZd9ge94daqNvd8xy9YS1iDw=' 'nonce-"
         )
       )
     })

--- a/src/server/common/helpers/content-security-policy.test.js
+++ b/src/server/common/helpers/content-security-policy.test.js
@@ -2,7 +2,9 @@ import { contentSecurityPolicy } from './content-security-policy.js'
 
 jest.mock('~/src/config/config.js', () => ({
   config: {
-    get: jest.fn(() => '123') // clarityProjectId
+    get: jest.fn((key) =>
+      key === 'cdpUploader.cdpUploadServiceBaseUrl' ? 'http://uploader' : '123'
+    ) // clarityProjectId
   }
 }))
 
@@ -97,7 +99,7 @@ describe('contentSecurityPolicy', () => {
 
       expect(mockResponse.header).toHaveBeenCalledWith(
         'Content-Security-Policy',
-        expect.stringContaining("form-action 'self' http://localhost:7337")
+        expect.stringContaining("form-action 'self' http://uploader")
       )
     })
 

--- a/src/server/common/helpers/content-security-policy.test.js
+++ b/src/server/common/helpers/content-security-policy.test.js
@@ -81,7 +81,9 @@ describe('contentSecurityPolicy', () => {
 
       expect(mockResponse.header).toHaveBeenCalledWith(
         'Content-Security-Policy',
-        expect.stringContaining("connect-src 'self'")
+        expect.stringContaining(
+          "connect-src 'self' https://*.clarity.ms/collect"
+        )
       )
     })
 

--- a/src/server/common/templates/layouts/page.njk
+++ b/src/server/common/templates/layouts/page.njk
@@ -16,7 +16,7 @@
 {% block head %}
   <link href="{{ getAssetPath('stylesheets/application.scss') }}" rel="stylesheet">
   {% if clarityProjectId %}
-    <script>
+    <script nonce='{{ cspNonce }}'>
       window.CLARITY_PROJECT_ID = "{{ clarityProjectId }}";
       window.ANALYTICS_ENABLED = {{ analyticsEnabled | dump }};
     </script>


### PR DESCRIPTION
Stop CSP from blocking inline clarity script by adding a nonce to the script tag. Also allow clarity hosts for dynamically created scripts and data collection.

A static hash won't work as the contents of the inline script may change based on the environment, due to the clarity ID changing. So generate a nonce per-request.