### PR TITLE
ML-1213: Remove cancel link from Site Name page

### DIFF
--- a/src/server/marine-licence/site-details/site-name/controller.js
+++ b/src/server/marine-licence/site-details/site-name/controller.js
@@ -18,6 +18,7 @@ import {
 } from '#src/server/common/helpers/site-details/site-name.js'
 import { saveSiteDetailsToBackend } from '#src/server/common/helpers/marine-licence/save-site-details.js'
 import { getSiteDetailsBySite } from '#src/server/common/helpers/marine-licence/session-cache/site-details-utils.js'
+import { getCancelLink } from '#src/server/marine-licence/site-details/utils/cancel-link.js'
 
 export const SITE_NAME_VIEW_ROUTE = 'templates/site-name.njk'
 
@@ -25,11 +26,6 @@ const getBackLink = (isSavePage) =>
   isSavePage
     ? marineLicenceRoutes.MARINE_LICENCE_REVIEW_SITE_DETAILS
     : marineLicenceRoutes.MARINE_LICENCE_COORDINATES_TYPE_CHOICE
-
-const getCancelLink = (isSavePage) =>
-  isSavePage
-    ? marineLicenceRoutes.MARINE_LICENCE_REVIEW_SITE_DETAILS
-    : marineLicenceRoutes.MARINE_LICENCE_TASK_LIST
 
 const createValidationFailAction = (request, h, err) => {
   const { payload } = request

--- a/src/server/marine-licence/site-details/site-name/controller.test.js
+++ b/src/server/marine-licence/site-details/site-name/controller.test.js
@@ -13,7 +13,10 @@ import {
   getMarineLicenceCache,
   updateMarineLicenceSiteDetails
 } from '#src/server/common/helpers/marine-licence/session-cache/utils.js'
-import { mockMarineLicenceApplication } from '#src/server/test-helpers/mocks/marine-licence-mocks.js'
+import {
+  mockManualCoordinatesMarineLicence,
+  mockMarineLicenceApplication
+} from '#src/server/test-helpers/mocks/marine-licence-mocks.js'
 import { saveSiteDetailsToBackend } from '#src/server/common/helpers/marine-licence/save-site-details.js'
 
 vi.mock('~/src/server/common/helpers/marine-licence/session-cache/utils.js')
@@ -33,27 +36,23 @@ describe('#siteName', () => {
     test('should render with correct context', () => {
       const request = createMockRequest()
 
-      vi.mocked(getMarineLicenceCache).mockReturnValueOnce({
-        ...mockMarineLicenceApplication,
-        siteDetails: [
-          {
-            ...mockMarineLicenceApplication.siteDetails[0],
-            siteName: mockSiteName
-          }
-        ]
-      })
+      vi.mocked(getMarineLicenceCache).mockReturnValueOnce(
+        mockManualCoordinatesMarineLicence
+      )
 
       siteNameController.handler(request, h)
 
       expect(h.view).toHaveBeenCalledWith(SITE_NAME_VIEW_ROUTE, {
         pageTitle: 'Site name',
         heading: 'Site name',
-        backLink: marineLicenceRoutes.MARINE_LICENCE_REVIEW_SITE_DETAILS,
-        cancelLink: marineLicenceRoutes.MARINE_LICENCE_REVIEW_SITE_DETAILS,
-        payload: { siteName: mockSiteName },
+        backLink: marineLicenceRoutes.MARINE_LICENCE_COORDINATES_TYPE_CHOICE,
+        cancelLink: marineLicenceRoutes.MARINE_LICENCE_TASK_LIST,
+        payload: {
+          siteName: mockManualCoordinatesMarineLicence.siteDetails[0].siteName
+        },
         projectName: 'Test Project',
         siteNumber: 1,
-        action: true
+        action: false
       })
     })
 
@@ -138,7 +137,6 @@ describe('#siteName', () => {
         pageTitle: 'Site name',
         heading: 'Site name',
         backLink: marineLicenceRoutes.MARINE_LICENCE_REVIEW_SITE_DETAILS,
-        cancelLink: marineLicenceRoutes.MARINE_LICENCE_REVIEW_SITE_DETAILS,
         payload: { siteName: '' },
         projectName: 'Test Project',
         siteNumber: 1,
@@ -159,7 +157,6 @@ describe('#siteName', () => {
         pageTitle: 'Site name',
         heading: 'Site name',
         backLink: marineLicenceRoutes.MARINE_LICENCE_REVIEW_SITE_DETAILS,
-        cancelLink: marineLicenceRoutes.MARINE_LICENCE_REVIEW_SITE_DETAILS,
         payload: { siteName: 'invalid' },
         projectName: 'Test Project',
         siteNumber: 1,
@@ -188,8 +185,7 @@ describe('#siteName', () => {
         SITE_NAME_VIEW_ROUTE,
         expect.objectContaining({
           action: true,
-          backLink: marineLicenceRoutes.MARINE_LICENCE_REVIEW_SITE_DETAILS,
-          cancelLink: marineLicenceRoutes.MARINE_LICENCE_REVIEW_SITE_DETAILS
+          backLink: marineLicenceRoutes.MARINE_LICENCE_REVIEW_SITE_DETAILS
         })
       )
     })

--- a/src/server/marine-licence/site-details/utils/cancel-link.js
+++ b/src/server/marine-licence/site-details/utils/cancel-link.js
@@ -1,0 +1,4 @@
+import { marineLicenceRoutes } from '#src/server/common/constants/routes.js'
+
+export const getCancelLink = (action) =>
+  action ? undefined : marineLicenceRoutes.MARINE_LICENCE_TASK_LIST

--- a/src/server/marine-licence/site-details/utils/cancel-link.test.js
+++ b/src/server/marine-licence/site-details/utils/cancel-link.test.js
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { getCancelLink } from './cancel-link.js'
+import { marineLicenceRoutes } from '#src/server/common/constants/routes.js'
+
+describe('getCancelLink', () => {
+  it('should return cancel link when action is undefined', () => {
+    const result = getCancelLink(undefined)
+    expect(result).toBe(marineLicenceRoutes.MARINE_LICENCE_TASK_LIST)
+  })
+
+  it('should return cancel link when action is falsy', () => {
+    const result = getCancelLink(null)
+    expect(result).toBe(marineLicenceRoutes.MARINE_LICENCE_TASK_LIST)
+  })
+
+  it('should return cancel link when action is empty string', () => {
+    const result = getCancelLink('')
+    expect(result).toBe(marineLicenceRoutes.MARINE_LICENCE_TASK_LIST)
+  })
+
+  it('should return undefined when action has a value', () => {
+    const result = getCancelLink('edit')
+    expect(result).toBeUndefined()
+  })
+
+  it('should return undefined when action is any truthy string', () => {
+    const result = getCancelLink('some-action')
+    expect(result).toBeUndefined()
+  })
+})

--- a/src/server/test-helpers/mocks/marine-licence-mocks.js
+++ b/src/server/test-helpers/mocks/marine-licence-mocks.js
@@ -96,3 +96,13 @@ export const mockFileUploadMarineLicence = {
     }
   ]
 }
+
+export const mockManualCoordinatesMarineLicence = {
+  ...mockMarineLicenceApplication,
+  siteDetails: [
+    {
+      coordinatesType: 'coordinates',
+      siteName: 'Test site name'
+    }
+  ]
+}

--- a/tests/integration/site-details/site-name/site-name-marine-licence.test.js
+++ b/tests/integration/site-details/site-name/site-name-marine-licence.test.js
@@ -13,7 +13,7 @@ import {
   makePostRequest
 } from '~/src/server/test-helpers/server-requests.js'
 import { JSDOM } from 'jsdom'
-import { getByRole } from '@testing-library/dom'
+import { getByRole, queryByRole } from '@testing-library/dom'
 import { statusCodes } from '~/src/server/common/constants/status-codes.js'
 
 describe('Site name page (marine licence)', () => {
@@ -112,10 +112,7 @@ describe('Site name page (marine licence)', () => {
       marineLicenceRoutes.MARINE_LICENCE_REVIEW_SITE_DETAILS
     )
 
-    const cancelLink = getByRole(document, 'link', { name: 'Cancel' })
-    expect(cancelLink).toHaveAttribute(
-      'href',
-      marineLicenceRoutes.MARINE_LICENCE_REVIEW_SITE_DETAILS
-    )
+    const cancelLink = queryByRole(document, 'link', { name: 'Cancel' })
+    expect(cancelLink).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
Remove cancel link from Site Name page on Marine Licence