### PR TITLE
adding feature branch scans for pull request

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - feature/**
     types:
       - opened
       - edited


### PR DESCRIPTION
This PR would allow us to have pull request github action scan when we merge a ticket branch into a feature branch which is named in the patter feature/** as previously this didnt happen and it only worked when pointing base branch of PR to main