### PR TITLE
ML-1197 - LCML - 'Enter the width of the circular site in metres' page

### DIFF
--- a/src/server/common/helpers/marine-licence/save-site-details.js
+++ b/src/server/common/helpers/marine-licence/save-site-details.js
@@ -47,16 +47,26 @@ export const prepareFileUploadDataForSave = (siteDetails, request) => {
 }
 
 export const prepareManualCoordinateDataForSave = (siteDetails, request) => {
+  const dataToSave = []
+
   for (const site of siteDetails) {
-    request.logger.info(
-      {
-        coordinatesType: site.coordinatesType,
-        coordinatesEntry: site.coordinatesEntry
-      },
-      'Saving manual coordinate site details'
-    )
+    const siteToSave = {
+      coordinatesType: site.coordinatesType,
+      coordinatesEntry: site.coordinatesEntry,
+      coordinateSystem: site.coordinateSystem,
+      coordinates: site.coordinates,
+      siteName: site.siteName,
+      activityDetails: site.activityDetails
+    }
+
+    if (site.coordinatesEntry === 'single') {
+      siteToSave.circleWidth = site.circleWidth
+    }
+
+    dataToSave.push(siteToSave)
   }
-  return siteDetails
+
+  return dataToSave
 }
 
 export const saveSiteDetailsToBackend = async (

--- a/src/server/common/helpers/marine-licence/save-site-details.js
+++ b/src/server/common/helpers/marine-licence/save-site-details.js
@@ -46,7 +46,7 @@ export const prepareFileUploadDataForSave = (siteDetails, request) => {
   return dataToSave
 }
 
-export const prepareManualCoordinateDataForSave = (siteDetails, request) => {
+export const prepareManualCoordinateDataForSave = (siteDetails) => {
   const dataToSave = []
 
   for (const site of siteDetails) {
@@ -100,7 +100,7 @@ export const saveSiteDetailsToBackend = async (
   const dataToSave =
     coordinatesType === 'file'
       ? prepareFileUploadDataForSave(siteDetailsToUpdate, request)
-      : prepareManualCoordinateDataForSave(siteDetailsToUpdate, request)
+      : prepareManualCoordinateDataForSave(siteDetailsToUpdate)
 
   try {
     if (isSingleSite) {

--- a/src/server/common/helpers/marine-licence/save-site-details.js
+++ b/src/server/common/helpers/marine-licence/save-site-details.js
@@ -46,6 +46,19 @@ export const prepareFileUploadDataForSave = (siteDetails, request) => {
   return dataToSave
 }
 
+export const prepareManualCoordinateDataForSave = (siteDetails, request) => {
+  for (const site of siteDetails) {
+    request.logger.info(
+      {
+        coordinatesType: site.coordinatesType,
+        coordinatesEntry: site.coordinatesEntry
+      },
+      'Saving manual coordinate site details'
+    )
+  }
+  return siteDetails
+}
+
 export const saveSiteDetailsToBackend = async (
   request,
   h,
@@ -68,17 +81,16 @@ export const saveSiteDetailsToBackend = async (
     throw new Error('Site details are required to save')
   }
 
-  if (coordinatesType !== 'file') {
-    throw new Error('Only file journeys can be saved for now')
-  }
-
   const isSingleSite = siteIndex !== undefined
 
   const siteDetailsToUpdate = isSingleSite
     ? siteDetails.filter((_, index) => index === siteIndex)
     : siteDetails
 
-  const dataToSave = prepareFileUploadDataForSave(siteDetailsToUpdate, request)
+  const dataToSave =
+    coordinatesType === 'file'
+      ? prepareFileUploadDataForSave(siteDetailsToUpdate, request)
+      : prepareManualCoordinateDataForSave(siteDetailsToUpdate, request)
 
   try {
     if (isSingleSite) {

--- a/src/server/common/helpers/marine-licence/save-site-details.test.js
+++ b/src/server/common/helpers/marine-licence/save-site-details.test.js
@@ -243,27 +243,6 @@ describe('save-site-details', () => {
       })
     })
 
-    test('should log save information for each site', () => {
-      const siteDetails = [
-        {
-          coordinatesType: 'coordinates',
-          coordinatesEntry: 'single',
-          siteName: 'Test site'
-        }
-      ]
-
-      prepareManualCoordinateDataForSave(siteDetails, mockRequest)
-
-      expect(mockRequest.logger.info).toHaveBeenCalledWith(
-        {
-          coordinatesType: 'coordinates',
-          coordinatesEntry: 'single'
-        },
-        'Saving manual coordinate site details'
-      )
-    })
-  })
-
   describe('saveSiteDetailsToBackend', () => {
     test('should save site details successfully with single site option', async () => {
       vi.mocked(authenticatedPatchRequest).mockResolvedValue({

--- a/src/server/common/helpers/marine-licence/save-site-details.test.js
+++ b/src/server/common/helpers/marine-licence/save-site-details.test.js
@@ -226,10 +226,7 @@ describe('save-site-details', () => {
         }
       ]
 
-      const result = prepareManualCoordinateDataForSave(
-        siteDetails,
-        mockRequest
-      )
+      const result = prepareManualCoordinateDataForSave(siteDetails)
 
       expect(result).toHaveLength(1)
       expect(result[0]).not.toHaveProperty('circleWidth')

--- a/src/server/common/helpers/marine-licence/save-site-details.test.js
+++ b/src/server/common/helpers/marine-licence/save-site-details.test.js
@@ -177,13 +177,70 @@ describe('save-site-details', () => {
   })
 
   describe('prepareManualCoordinateDataForSave', () => {
-    test('should return site details as-is for manual coordinate entry', () => {
+    test('should return a structured object for single coordinate entry including circleWidth', () => {
+      const siteDetails = [
+        {
+          coordinatesType: 'coordinates',
+          coordinatesEntry: 'single',
+          coordinateSystem: 'wgs84',
+          coordinates: { latitude: '51.489676', longitude: '-0.231530' },
+          circleWidth: '100',
+          siteName: 'Test site',
+          activityDetails: { description: 'Test activity' },
+          someUiOnlyField: 'should not appear'
+        }
+      ]
+
       const result = prepareManualCoordinateDataForSave(
-        mockManualCoordinatesMarineLicence.siteDetails,
+        siteDetails,
         mockRequest
       )
 
-      expect(result).toEqual(mockManualCoordinatesMarineLicence.siteDetails)
+      expect(result).toHaveLength(1)
+      expect(result[0]).toEqual({
+        coordinatesType: 'coordinates',
+        coordinatesEntry: 'single',
+        coordinateSystem: 'wgs84',
+        coordinates: { latitude: '51.489676', longitude: '-0.231530' },
+        circleWidth: '100',
+        siteName: 'Test site',
+        activityDetails: { description: 'Test activity' }
+      })
+      expect(result[0]).not.toHaveProperty('someUiOnlyField')
+    })
+
+    test('should return a structured object for multiple coordinate entry without circleWidth', () => {
+      const siteDetails = [
+        {
+          coordinatesType: 'coordinates',
+          coordinatesEntry: 'multiple',
+          coordinateSystem: 'wgs84',
+          coordinates: [
+            { latitude: '51.489676', longitude: '-0.231530' },
+            { latitude: '51.490000', longitude: '-0.230000' },
+            { latitude: '51.488000', longitude: '-0.232000' }
+          ],
+          circleWidth: '100',
+          siteName: 'Test polygon site',
+          activityDetails: null
+        }
+      ]
+
+      const result = prepareManualCoordinateDataForSave(
+        siteDetails,
+        mockRequest
+      )
+
+      expect(result).toHaveLength(1)
+      expect(result[0]).not.toHaveProperty('circleWidth')
+      expect(result[0]).toEqual({
+        coordinatesType: 'coordinates',
+        coordinatesEntry: 'multiple',
+        coordinateSystem: 'wgs84',
+        coordinates: siteDetails[0].coordinates,
+        siteName: 'Test polygon site',
+        activityDetails: null
+      })
     })
 
     test('should log save information for each site', () => {
@@ -295,7 +352,7 @@ describe('save-site-details', () => {
         mockRequest,
         apiRoutes.UPDATE_MARINE_LICENCE_SITE_DETAILS,
         {
-          siteDetails: mockManualCoordinatesMarineLicence.siteDetails,
+          siteDetails: expect.any(Array),
           id: mockManualCoordinatesMarineLicence.id
         }
       )
@@ -305,7 +362,7 @@ describe('save-site-details', () => {
         mockH,
         expect.objectContaining({
           ...mockManualCoordinatesMarineLicence,
-          siteDetails: mockManualCoordinatesMarineLicence.siteDetails
+          siteDetails: expect.any(Array)
         })
       )
 

--- a/src/server/common/helpers/marine-licence/save-site-details.test.js
+++ b/src/server/common/helpers/marine-licence/save-site-details.test.js
@@ -246,23 +246,6 @@ describe('save-site-details', () => {
       )
     })
 
-    test('should not save manual coordinates', async () => {
-      const manualMarineLicence = {
-        ...mockMarineLicenceApplication,
-        siteDetails: [
-          {
-            coordinatesType: 'coordinates',
-            coordinatesEntry: 'single'
-          }
-        ]
-      }
-      vi.mocked(getMarineLicenceCache).mockReturnValue(manualMarineLicence)
-
-      await expect(
-        saveSiteDetailsToBackend(mockRequest, mockH)
-      ).rejects.toThrow('Only file journeys can be saved for now')
-    })
-
     test('should throw error when Marine Licence ID is missing', async () => {
       vi.mocked(getMarineLicenceCache).mockReturnValue({
         ...mockMarineLicenceApplication,

--- a/src/server/common/helpers/marine-licence/save-site-details.test.js
+++ b/src/server/common/helpers/marine-licence/save-site-details.test.js
@@ -1,7 +1,8 @@
 import { describe, test, expect, vi, beforeEach } from 'vitest'
 import {
   saveSiteDetailsToBackend,
-  prepareFileUploadDataForSave
+  prepareFileUploadDataForSave,
+  prepareManualCoordinateDataForSave
 } from './save-site-details.js'
 import { authenticatedPatchRequest } from '../authenticated-requests.js'
 import {
@@ -10,7 +11,10 @@ import {
 } from './session-cache/utils.js'
 import { createMockRequest } from '#src/server/test-helpers/mocks/helpers.js'
 import Boom from '@hapi/boom'
-import { mockMarineLicenceApplication } from '#src/server/test-helpers/mocks/marine-licence-mocks.js'
+import {
+  mockMarineLicenceApplication,
+  mockManualCoordinatesMarineLicence
+} from '#src/server/test-helpers/mocks/marine-licence-mocks.js'
 import { apiRoutes } from '#src/server/common/constants/routes.js'
 
 vi.mock('../authenticated-requests.js')
@@ -169,6 +173,37 @@ describe('save-site-details', () => {
       const result = prepareFileUploadDataForSave(siteDetails, mockRequest)[0]
 
       expect(result.featureCount).toBe(0)
+    })
+  })
+
+  describe('prepareManualCoordinateDataForSave', () => {
+    test('should return site details as-is for manual coordinate entry', () => {
+      const result = prepareManualCoordinateDataForSave(
+        mockManualCoordinatesMarineLicence.siteDetails,
+        mockRequest
+      )
+
+      expect(result).toEqual(mockManualCoordinatesMarineLicence.siteDetails)
+    })
+
+    test('should log save information for each site', () => {
+      const siteDetails = [
+        {
+          coordinatesType: 'coordinates',
+          coordinatesEntry: 'single',
+          siteName: 'Test site'
+        }
+      ]
+
+      prepareManualCoordinateDataForSave(siteDetails, mockRequest)
+
+      expect(mockRequest.logger.info).toHaveBeenCalledWith(
+        {
+          coordinatesType: 'coordinates',
+          coordinatesEntry: 'single'
+        },
+        'Saving manual coordinate site details'
+      )
     })
   })
 

--- a/src/server/common/helpers/marine-licence/save-site-details.test.js
+++ b/src/server/common/helpers/marine-licence/save-site-details.test.js
@@ -242,6 +242,7 @@ describe('save-site-details', () => {
         activityDetails: null
       })
     })
+  })
 
   describe('saveSiteDetailsToBackend', () => {
     test('should save site details successfully with single site option', async () => {

--- a/src/server/common/helpers/marine-licence/save-site-details.test.js
+++ b/src/server/common/helpers/marine-licence/save-site-details.test.js
@@ -281,6 +281,45 @@ describe('save-site-details', () => {
       )
     })
 
+    test('should save manual coordinate site details successfully', async () => {
+      vi.mocked(getMarineLicenceCache).mockReturnValue(
+        mockManualCoordinatesMarineLicence
+      )
+      vi.mocked(authenticatedPatchRequest).mockResolvedValue({
+        payload: { success: true }
+      })
+
+      await saveSiteDetailsToBackend(mockRequest, mockH)
+
+      expect(authenticatedPatchRequest).toHaveBeenCalledWith(
+        mockRequest,
+        apiRoutes.UPDATE_MARINE_LICENCE_SITE_DETAILS,
+        {
+          siteDetails: mockManualCoordinatesMarineLicence.siteDetails,
+          id: mockManualCoordinatesMarineLicence.id
+        }
+      )
+
+      expect(vi.mocked(setMarineLicenceCache)).toHaveBeenCalledWith(
+        mockRequest,
+        mockH,
+        expect.objectContaining({
+          ...mockManualCoordinatesMarineLicence,
+          siteDetails: mockManualCoordinatesMarineLicence.siteDetails
+        })
+      )
+
+      expect(mockRequest.logger.info).toHaveBeenCalledWith(
+        {
+          marineLicenceId: mockManualCoordinatesMarineLicence.id,
+          siteCount: 1,
+          coordinatesType: 'coordinates',
+          isSingleSite: false
+        },
+        'Successfully saved site details to backend'
+      )
+    })
+
     test('should throw error when Marine Licence ID is missing', async () => {
       vi.mocked(getMarineLicenceCache).mockReturnValue({
         ...mockMarineLicenceApplication,

--- a/src/server/common/helpers/marine-licence/save-site-details.test.js
+++ b/src/server/common/helpers/marine-licence/save-site-details.test.js
@@ -191,10 +191,7 @@ describe('save-site-details', () => {
         }
       ]
 
-      const result = prepareManualCoordinateDataForSave(
-        siteDetails,
-        mockRequest
-      )
+      const result = prepareManualCoordinateDataForSave(siteDetails)
 
       expect(result).toHaveLength(1)
       expect(result[0]).toEqual({

--- a/src/server/marine-licence/site-details/width-of-site/controller.js
+++ b/src/server/marine-licence/site-details/width-of-site/controller.js
@@ -12,6 +12,7 @@ import {
   widthOfSiteSettings,
   widthOfSiteErrorMessages
 } from '#src/server/common/validation/width-of-site/constants.js'
+import { saveSiteDetailsToBackend } from '#src/server/common/helpers/marine-licence/save-site-details.js'
 
 const widthOfSitePageData = {
   ...widthOfSiteSettings,
@@ -71,6 +72,8 @@ export const widthOfSiteSubmitController = {
       'circleWidth',
       payload.width.trim()
     )
+
+    await saveSiteDetailsToBackend(request, h)
 
     return h.redirect(marineLicenceRoutes.MARINE_LICENCE_WIDTH_OF_SITE)
   }

--- a/src/server/marine-licence/site-details/width-of-site/controller.test.js
+++ b/src/server/marine-licence/site-details/width-of-site/controller.test.js
@@ -8,11 +8,13 @@ import {
   getMarineLicenceCache,
   updateMarineLicenceSiteDetails
 } from '#src/server/common/helpers/marine-licence/session-cache/utils.js'
+import { saveSiteDetailsToBackend } from '#src/server/common/helpers/marine-licence/save-site-details.js'
 import { mockMarineLicenceApplication } from '#src/server/test-helpers/mocks/marine-licence-mocks.js'
 import { createMockRequest } from '#src/server/test-helpers/mocks/helpers.js'
 import { marineLicenceRoutes } from '#src/server/common/constants/routes.js'
 
 vi.mock('#src/server/common/helpers/marine-licence/session-cache/utils.js')
+vi.mock('#src/server/common/helpers/marine-licence/save-site-details.js')
 
 const mockApplicationWithWidth = {
   ...mockMarineLicenceApplication,
@@ -85,6 +87,7 @@ describe('#widthOfSite (marine licence)', () => {
         'circleWidth',
         '500'
       )
+      expect(saveSiteDetailsToBackend).toHaveBeenCalledWith(request, h)
       expect(h.redirect).toHaveBeenCalledWith(
         marineLicenceRoutes.MARINE_LICENCE_WIDTH_OF_SITE
       )


### PR DESCRIPTION
This PR adds the ability to save the manual coordinates to the backend for ML-1197.

This just adds a call to save manual coordinate entry in the controller and updates the save-site-details.js