### PR TITLE
ML-1291: Add internal admin exemptions summary report page

### DIFF
--- a/src/server/common/constants/routes.js
+++ b/src/server/common/constants/routes.js
@@ -36,6 +36,7 @@ export const exemptionRoutes = {
   ADMIN_EXEMPTIONS: '/admin/exemptions',
   ADMIN_EMP: '/admin/emp',
   ADMIN_BACKFILL: '/admin/backfill-areas',
+  ADMIN_REPORTS: '/admin/reports',
   EXEMPTION: '/exemption'
 }
 
@@ -119,6 +120,7 @@ export const entraIdRoutes = [
   routes.VIEW_DETAILS_INTERNAL_USER,
   routes.ADMIN_BACKFILL,
   routes.ADMIN_EMP,
+  routes.ADMIN_REPORTS,
   marineLicenceRoutes.MARINE_LICENCE_VIEW_DETAILS_INTERNAL_USER,
   routes.ADMIN_EXEMPTIONS
 ]

--- a/src/server/internal-user-admin/exemptions/index.js
+++ b/src/server/internal-user-admin/exemptions/index.js
@@ -1,9 +1,11 @@
 import { internalBackfillUserAdminRoutes } from './backfill-areas/index.js'
 import { internalEmpUserAdminRoutes } from './emp/index.js'
 import { internalExemptionLandingUserAdminRoutes } from './landing/index.js'
+import { internalReportsUserAdminRoutes } from './reports/index.js'
 
 export const internalExemptionsUserAdminRoutes = [
   ...internalBackfillUserAdminRoutes,
   ...internalEmpUserAdminRoutes,
+  ...internalReportsUserAdminRoutes,
   ...internalExemptionLandingUserAdminRoutes
 ]

--- a/src/server/internal-user-admin/exemptions/landing/index.njk
+++ b/src/server/internal-user-admin/exemptions/landing/index.njk
@@ -28,6 +28,14 @@
           </a>
         </li>
 
+        <li class="govuk-grid-column-one-half-from-desktop card-group__item">
+          <a href="/admin/reports" class="card card--clickable">
+            <h2 class="govuk-heading-m card__heading">
+              Summary report
+            </h2>
+          </a>
+        </li>
+
       </ul>
 </div>
 

--- a/src/server/internal-user-admin/exemptions/landing/index.njk
+++ b/src/server/internal-user-admin/exemptions/landing/index.njk
@@ -12,7 +12,7 @@
       <ul class="card-group">
 
         <li class="govuk-grid-column-one-half-from-desktop card-group__item">
-          <a href="/admin/emp" class="card card--clickable">
+          <a href="{{ routes.ADMIN_EMP }}" class="card card--clickable">
             <h2 class="govuk-heading-m card__heading">
               Exemptions not sent to EMP
             </h2>
@@ -21,7 +21,7 @@
 
 
         <li class="govuk-grid-column-one-half-from-desktop card-group__item">
-          <a href="/admin/backfill-areas" class="card card--clickable">
+          <a href="{{ routes.ADMIN_BACKFILL }}" class="card card--clickable">
             <h2 class="govuk-heading-m card__heading">
               Exemptions without Marine Plan or Coastal Operations Areas
             </h2>
@@ -29,7 +29,7 @@
         </li>
 
         <li class="govuk-grid-column-one-half-from-desktop card-group__item">
-          <a href="/admin/reports" class="card card--clickable">
+          <a href="{{ routes.ADMIN_REPORTS }}" class="card card--clickable">
             <h2 class="govuk-heading-m card__heading">
               Summary report
             </h2>

--- a/src/server/internal-user-admin/exemptions/reports/controller.js
+++ b/src/server/internal-user-admin/exemptions/reports/controller.js
@@ -24,7 +24,8 @@ export const adminReportsController = {
       return h.view(DASHBOARD_VIEW_ROUTE, {
         pageTitle: DASHBOARD_PAGE_TITLE,
         heading: DASHBOARD_PAGE_TITLE,
-        summary: mapSummaryReport(payload?.value)
+        summary: mapSummaryReport(payload?.value),
+        hasApiError: false
       })
     } catch (error) {
       request.logger.error(
@@ -35,7 +36,8 @@ export const adminReportsController = {
       return h.view(DASHBOARD_VIEW_ROUTE, {
         pageTitle: DASHBOARD_PAGE_TITLE,
         heading: DASHBOARD_PAGE_TITLE,
-        summary: mapSummaryReport()
+        summary: mapSummaryReport(),
+        hasApiError: true
       })
     }
   }

--- a/src/server/internal-user-admin/exemptions/reports/controller.js
+++ b/src/server/internal-user-admin/exemptions/reports/controller.js
@@ -1,7 +1,8 @@
 import { authenticatedGetRequest } from '#src/server/common/helpers/authenticated-requests.js'
 import { validateTeamAdminSession } from '#src/server/common/helpers/user-session-validators.js'
 
-export const DASHBOARD_VIEW_ROUTE = 'internal-user-admin/exemptions/reports/index.njk'
+export const DASHBOARD_VIEW_ROUTE =
+  'internal-user-admin/exemptions/reports/index.njk'
 const DASHBOARD_PAGE_TITLE = 'Exemptions summary report'
 
 const mapSummaryReport = (value) => ({
@@ -16,7 +17,10 @@ export const adminReportsController = {
   },
   handler: async (request, h) => {
     try {
-      const { payload } = await authenticatedGetRequest(request, '/exemptions/summary')
+      const { payload } = await authenticatedGetRequest(
+        request,
+        '/exemptions/summary'
+      )
       return h.view(DASHBOARD_VIEW_ROUTE, {
         pageTitle: DASHBOARD_PAGE_TITLE,
         heading: DASHBOARD_PAGE_TITLE,

--- a/src/server/internal-user-admin/exemptions/reports/controller.js
+++ b/src/server/internal-user-admin/exemptions/reports/controller.js
@@ -1,0 +1,38 @@
+import { authenticatedGetRequest } from '#src/server/common/helpers/authenticated-requests.js'
+import { validateTeamAdminSession } from '#src/server/common/helpers/user-session-validators.js'
+
+export const DASHBOARD_VIEW_ROUTE = 'internal-user-admin/exemptions/reports/index.njk'
+const DASHBOARD_PAGE_TITLE = 'Exemptions summary report'
+
+const mapSummaryReport = (value) => ({
+  submittedExemptions: value?.submittedExemptions ?? 0,
+  unsubmittedExemptions: value?.unsubmittedExemptions ?? 0,
+  withdrawnExemptions: value?.withdrawnExemptions ?? 0
+})
+
+export const adminReportsController = {
+  options: {
+    pre: [validateTeamAdminSession]
+  },
+  handler: async (request, h) => {
+    try {
+      const { payload } = await authenticatedGetRequest(request, '/exemptions/summary')
+      return h.view(DASHBOARD_VIEW_ROUTE, {
+        pageTitle: DASHBOARD_PAGE_TITLE,
+        heading: DASHBOARD_PAGE_TITLE,
+        summary: mapSummaryReport(payload?.value)
+      })
+    } catch (error) {
+      request.logger.error(
+        { err: error },
+        'Error rendering internal admin summary report page'
+      )
+
+      return h.view(DASHBOARD_VIEW_ROUTE, {
+        pageTitle: DASHBOARD_PAGE_TITLE,
+        heading: DASHBOARD_PAGE_TITLE,
+        summary: mapSummaryReport()
+      })
+    }
+  }
+}

--- a/src/server/internal-user-admin/exemptions/reports/controller.test.js
+++ b/src/server/internal-user-admin/exemptions/reports/controller.test.js
@@ -4,6 +4,8 @@ import { adminReportsController, DASHBOARD_VIEW_ROUTE } from './controller.js'
 
 vi.mock('~/src/server/common/helpers/authenticated-requests.js')
 
+const DASHBOARD_PAGE_TITLE = 'Exemptions summary report'
+
 const createRequest = () => ({
   h: { view: vi.fn() },
   request: {
@@ -12,7 +14,14 @@ const createRequest = () => ({
   }
 })
 
-describe('Admin exemptions summary report', () => {
+const createExpectedViewModel = (summary, hasApiError = false) => ({
+  pageTitle: DASHBOARD_PAGE_TITLE,
+  heading: DASHBOARD_PAGE_TITLE,
+  summary,
+  hasApiError
+})
+
+describe('Admin exemptions summary report success handling', () => {
   const authenticatedGetRequestMock = vi.mocked(authenticatedGetRequest)
 
   test('Should render summary report with API response values', async () => {
@@ -33,15 +42,14 @@ describe('Admin exemptions summary report', () => {
       request,
       '/exemptions/summary'
     )
-    expect(h.view).toHaveBeenCalledWith(DASHBOARD_VIEW_ROUTE, {
-      pageTitle: 'Exemptions summary report',
-      heading: 'Exemptions summary report',
-      summary: {
+    expect(h.view).toHaveBeenCalledWith(
+      DASHBOARD_VIEW_ROUTE,
+      createExpectedViewModel({
         submittedExemptions: 12,
         unsubmittedExemptions: 7,
         withdrawnExemptions: 2
-      }
-    })
+      })
+    )
   })
 
   test('Should fallback to zero values when payload is missing', async () => {
@@ -50,16 +58,41 @@ describe('Admin exemptions summary report', () => {
     const { h, request } = createRequest()
     await adminReportsController.handler(request, h)
 
-    expect(h.view).toHaveBeenCalledWith(DASHBOARD_VIEW_ROUTE, {
-      pageTitle: 'Exemptions summary report',
-      heading: 'Exemptions summary report',
-      summary: {
+    expect(h.view).toHaveBeenCalledWith(
+      DASHBOARD_VIEW_ROUTE,
+      createExpectedViewModel({
         submittedExemptions: 0,
         unsubmittedExemptions: 0,
         withdrawnExemptions: 0
+      })
+    )
+  })
+
+  test('Should default missing values to zero for partial payloads', async () => {
+    authenticatedGetRequestMock.mockResolvedValueOnce({
+      payload: {
+        value: {
+          submittedExemptions: 5
+        }
       }
     })
+
+    const { h, request } = createRequest()
+    await adminReportsController.handler(request, h)
+
+    expect(h.view).toHaveBeenCalledWith(
+      DASHBOARD_VIEW_ROUTE,
+      createExpectedViewModel({
+        submittedExemptions: 5,
+        unsubmittedExemptions: 0,
+        withdrawnExemptions: 0
+      })
+    )
   })
+})
+
+describe('Admin exemptions summary report error handling', () => {
+  const authenticatedGetRequestMock = vi.mocked(authenticatedGetRequest)
 
   test('Should handle API errors gracefully', async () => {
     authenticatedGetRequestMock.mockRejectedValueOnce(new Error('API Error'))
@@ -71,14 +104,16 @@ describe('Admin exemptions summary report', () => {
       { err: expect.any(Error) },
       'Error rendering internal admin summary report page'
     )
-    expect(h.view).toHaveBeenCalledWith(DASHBOARD_VIEW_ROUTE, {
-      pageTitle: 'Exemptions summary report',
-      heading: 'Exemptions summary report',
-      summary: {
+    expect(h.view).toHaveBeenCalledWith(
+      DASHBOARD_VIEW_ROUTE,
+      createExpectedViewModel(
+        {
         submittedExemptions: 0,
         unsubmittedExemptions: 0,
         withdrawnExemptions: 0
-      }
-    })
+        },
+        true
+      )
+    )
   })
 })

--- a/src/server/internal-user-admin/exemptions/reports/controller.test.js
+++ b/src/server/internal-user-admin/exemptions/reports/controller.test.js
@@ -108,9 +108,9 @@ describe('Admin exemptions summary report error handling', () => {
       DASHBOARD_VIEW_ROUTE,
       createExpectedViewModel(
         {
-        submittedExemptions: 0,
-        unsubmittedExemptions: 0,
-        withdrawnExemptions: 0
+          submittedExemptions: 0,
+          unsubmittedExemptions: 0,
+          withdrawnExemptions: 0
         },
         true
       )

--- a/src/server/internal-user-admin/exemptions/reports/controller.test.js
+++ b/src/server/internal-user-admin/exemptions/reports/controller.test.js
@@ -1,0 +1,84 @@
+import { vi } from 'vitest'
+import { authenticatedGetRequest } from '#src/server/common/helpers/authenticated-requests.js'
+import { adminReportsController, DASHBOARD_VIEW_ROUTE } from './controller.js'
+
+vi.mock('~/src/server/common/helpers/authenticated-requests.js')
+
+const createRequest = () => ({
+  h: { view: vi.fn() },
+  request: {
+    logger: { error: vi.fn() },
+    auth: { credentials: { isTeamAdmin: true } }
+  }
+})
+
+describe('Admin exemptions summary report', () => {
+  const authenticatedGetRequestMock = vi.mocked(authenticatedGetRequest)
+
+  test('Should render summary report with API response values', async () => {
+    authenticatedGetRequestMock.mockResolvedValueOnce({
+      payload: {
+        value: {
+          submittedExemptions: 12,
+          unsubmittedExemptions: 7,
+          withdrawnExemptions: 2
+        }
+      }
+    })
+
+    const { h, request } = createRequest()
+    await adminReportsController.handler(request, h)
+
+    expect(authenticatedGetRequestMock).toHaveBeenCalledWith(
+      request,
+      '/exemptions/summary'
+    )
+    expect(h.view).toHaveBeenCalledWith(DASHBOARD_VIEW_ROUTE, {
+      pageTitle: 'Exemptions summary report',
+      heading: 'Exemptions summary report',
+      summary: {
+        submittedExemptions: 12,
+        unsubmittedExemptions: 7,
+        withdrawnExemptions: 2
+      }
+    })
+  })
+
+  test('Should fallback to zero values when payload is missing', async () => {
+    authenticatedGetRequestMock.mockResolvedValueOnce({ payload: {} })
+
+    const { h, request } = createRequest()
+    await adminReportsController.handler(request, h)
+
+    expect(h.view).toHaveBeenCalledWith(DASHBOARD_VIEW_ROUTE, {
+      pageTitle: 'Exemptions summary report',
+      heading: 'Exemptions summary report',
+      summary: {
+        submittedExemptions: 0,
+        unsubmittedExemptions: 0,
+        withdrawnExemptions: 0
+      }
+    })
+  })
+
+  test('Should handle API errors gracefully', async () => {
+    authenticatedGetRequestMock.mockRejectedValueOnce(new Error('API Error'))
+
+    const { h, request } = createRequest()
+    await adminReportsController.handler(request, h)
+
+    expect(request.logger.error).toHaveBeenCalledWith(
+      { err: expect.any(Error) },
+      'Error rendering internal admin summary report page'
+    )
+    expect(h.view).toHaveBeenCalledWith(DASHBOARD_VIEW_ROUTE, {
+      pageTitle: 'Exemptions summary report',
+      heading: 'Exemptions summary report',
+      summary: {
+        submittedExemptions: 0,
+        unsubmittedExemptions: 0,
+        withdrawnExemptions: 0
+      }
+    })
+  })
+})

--- a/src/server/internal-user-admin/exemptions/reports/index.js
+++ b/src/server/internal-user-admin/exemptions/reports/index.js
@@ -1,0 +1,10 @@
+import { routes } from '#src/server/common/constants/routes.js'
+import { adminReportsController } from './controller.js'
+
+export const internalReportsUserAdminRoutes = [
+  {
+    method: 'GET',
+    path: routes.ADMIN_REPORTS,
+    ...adminReportsController
+  }
+]

--- a/src/server/internal-user-admin/exemptions/reports/index.njk
+++ b/src/server/internal-user-admin/exemptions/reports/index.njk
@@ -5,6 +5,11 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">{{ heading }}</h1>
+      {% if hasApiError %}
+        <p class="govuk-body govuk-!-margin-bottom-6">
+          We could not retrieve the latest report values. Showing zero values instead.
+        </p>
+      {% endif %}
 
       {{ govukSummaryList({
         rows: [

--- a/src/server/internal-user-admin/exemptions/reports/index.njk
+++ b/src/server/internal-user-admin/exemptions/reports/index.njk
@@ -1,0 +1,39 @@
+{%- from "govuk/components/summary-list/macro.njk" import govukSummaryList -%}
+{% extends "layouts/page.njk" %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">{{ heading }}</h1>
+
+      {{ govukSummaryList({
+        rows: [
+          {
+            key: {
+              text: "Submitted exemptions"
+            },
+            value: {
+              text: summary.submittedExemptions
+            }
+          },
+          {
+            key: {
+              text: "Unsubmitted exemptions"
+            },
+            value: {
+              text: summary.unsubmittedExemptions
+            }
+          },
+          {
+            key: {
+              text: "Withdrawn exemptions"
+            },
+            value: {
+              text: summary.withdrawnExemptions
+            }
+          }
+        ]
+      }) }}
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
Adds a new internal admin /admin/reports route and view that displays submitted, unsubmitted, and withdrawn exemption totals from /exemptions/summary, with safe zero-value fallbacks on missing/failed API responses. 

It also wires the page into exemptions admin routing/navigation and includes controller tests for success, missing payload, and error scenarios.

Agreed with PO on the look and feel on the ticket with screenshots