### PR TITLE
feat(ml-1185): suppress primary CTA on info-only terminal outcomes

### DIFF
--- a/src/server/journey/self-service/outcome/_terminal-multi.njk
+++ b/src/server/journey/self-service/outcome/_terminal-multi.njk
@@ -8,11 +8,13 @@
     {% if option.text %}
       <div class="govuk-body">{{ option.text | safe }}</div>
     {% endif %}
-    {{ govukButton({
-      text: option.ctaLabel,
-      href: "#",
-      classes: "govuk-!-margin-bottom-0"
-    }) }}
+    {% if option.hasContinue %}
+      {{ govukButton({
+        text: option.ctaLabel,
+        href: "#",
+        classes: "govuk-!-margin-bottom-0"
+      }) }}
+    {% endif %}
   </div>
 {% endfor %}
 

--- a/src/server/journey/self-service/outcome/_terminal-single.njk
+++ b/src/server/journey/self-service/outcome/_terminal-single.njk
@@ -7,11 +7,13 @@
 {% endif %}
 
 <div class="app-iat-actions">
-  {{ govukButton({
-    text: ctaLabel,
-    href: "#",
-    classes: "govuk-!-margin-right-3"
-  }) }}
+  {% if hasContinue %}
+    {{ govukButton({
+      text: ctaLabel,
+      href: "#",
+      classes: "govuk-!-margin-right-3"
+    }) }}
+  {% endif %}
   {{ govukButton({
     text: "Download a PDF record of my answers",
     href: "#",

--- a/src/server/journey/self-service/outcome/controller.integration.test.js
+++ b/src/server/journey/self-service/outcome/controller.integration.test.js
@@ -395,6 +395,65 @@ describe('GET terminal-multi', () => {
   })
 })
 
+describe('GET licence-not-required (terminal-single, info-only)', () => {
+  config.set('selfService.enabled', true)
+  const getServer = setupTestServer()
+
+  const ROUTE = '/journey/self-service/outcome/licence-not-required-devolved'
+
+  const getPage = async (path = ROUTE) => {
+    const response = await makeGetRequest({ url: path, server: getServer() })
+    return {
+      response,
+      document: new JSDOM(response.result).window.document
+    }
+  }
+
+  test('returns 200', async () => {
+    const { response } = await getPage()
+    expect(response.statusCode).toBe(statusCodes.ok)
+  })
+
+  test('renders the H1 from outcome.heading', async () => {
+    const { document } = await getPage()
+    expect(document.querySelector('h1').textContent).toContain(
+      'Marine licence not required'
+    )
+  })
+
+  test('renders the body from the outcomeType text', async () => {
+    const { document } = await getPage()
+    const body = document.querySelector('.govuk-grid-column-full .govuk-body')
+    expect(body).not.toBeNull()
+    expect(body.textContent).toContain('relevant devolved administration')
+  })
+
+  test('renders the Download PDF button', async () => {
+    const { document } = await getPage()
+    const pdf = Array.from(
+      document.querySelectorAll('a.govuk-button--secondary')
+    ).filter((a) =>
+      a.textContent.includes('Download a PDF record of my answers')
+    )
+    expect(pdf).toHaveLength(1)
+    expect(pdf[0].getAttribute('href')).toBe('#')
+  })
+
+  test('does NOT render a primary Continue button', async () => {
+    const { document } = await getPage()
+    const buttons = Array.from(document.querySelectorAll('a.govuk-button'))
+    const primaryCount = buttons.filter(
+      (a) => !a.classList.contains('govuk-button--secondary')
+    ).length
+    expect(primaryCount).toBe(0)
+  })
+
+  test('renders a back link', async () => {
+    const { document } = await getPage()
+    expect(document.querySelector('.govuk-back-link')).not.toBeNull()
+  })
+})
+
 describe('POST to a terminal outcome route', () => {
   config.set('selfService.enabled', true)
   const getServer = setupTestServer()

--- a/src/server/journey/self-service/outcome/controller.test.js
+++ b/src/server/journey/self-service/outcome/controller.test.js
@@ -412,13 +412,15 @@ describe('#outcomeController — terminal-multi', () => {
             id: 'WO_DOWNLOAD_HA_AGREED_METHOD_TEMPLATE',
             heading: otDownload.heading,
             text: '<p>download body</p>',
-            ctaLabel: 'Download'
+            ctaLabel: 'Download',
+            hasContinue: true
           },
           {
             id: 'WO_STANDARD_TRACK_MLA',
             heading: otStandardMla.heading,
             text: '<p>standard MLA body</p>',
-            ctaLabel: 'Continue'
+            ctaLabel: 'Continue',
+            hasContinue: true
           }
         ],
         backLink: '/journey/self-service/back-here'

--- a/src/server/journey/self-service/outcome/utils.js
+++ b/src/server/journey/self-service/outcome/utils.js
@@ -25,6 +25,15 @@ export function ctaLabelFor(outcomeType) {
   return 'Continue'
 }
 
+export function hasContinueFor(outcomeType) {
+  return Boolean(
+    outcomeType.module ||
+    outcomeType.nextQuestionRoute ||
+    outcomeType.link ||
+    outcomeType.overrideCtaButtonText
+  )
+}
+
 export function buildIntermediateView(baseModel, outcome, types) {
   const section = outcome.section ? getSection(outcome.section) : null
   return {
@@ -44,7 +53,8 @@ export function buildTerminalSingleView(baseModel, terminalType) {
   return {
     ...baseModel,
     body: terminalType.text,
-    ctaLabel: ctaLabelFor(terminalType)
+    ctaLabel: ctaLabelFor(terminalType),
+    hasContinue: hasContinueFor(terminalType)
   }
 }
 
@@ -55,7 +65,8 @@ export function buildTerminalMultiView(baseModel, types) {
       id: ot.id,
       heading: ot.heading,
       text: ot.text,
-      ctaLabel: ctaLabelFor(ot)
+      ctaLabel: ctaLabelFor(ot),
+      hasContinue: hasContinueFor(ot)
     }))
   }
 }

--- a/src/server/journey/self-service/outcome/utils.test.js
+++ b/src/server/journey/self-service/outcome/utils.test.js
@@ -3,6 +3,8 @@ import { vi } from 'vitest'
 vi.mock('#src/server/journey/self-service/services/journey-data.js')
 
 import {
+  buildTerminalMultiView,
+  buildTerminalSingleView,
   classifyOutcome,
   ctaLabelFor
 } from '#src/server/journey/self-service/outcome/utils.js'
@@ -54,5 +56,52 @@ describe('#ctaLabelFor', () => {
 
   test('returns "Continue" for an info-only outcomeType (no module/link/override)', () => {
     expect(ctaLabelFor({ id: 'X' })).toBe('Continue')
+  })
+})
+
+describe('#buildTerminalSingleView — hasContinue', () => {
+  const baseModel = { heading: 'h' }
+
+  test('hasContinue=true when outcomeType has module', () => {
+    const view = buildTerminalSingleView(baseModel, {
+      id: 'X',
+      module: 'MMO_APP2_CONTROL'
+    })
+    expect(view.hasContinue).toBe(true)
+  })
+
+  test('hasContinue=true when outcomeType has link', () => {
+    const view = buildTerminalSingleView(baseModel, {
+      id: 'X',
+      link: 'https://example.gov.uk/template.docx'
+    })
+    expect(view.hasContinue).toBe(true)
+  })
+
+  test('hasContinue=true when outcomeType has overrideCtaButtonText', () => {
+    const view = buildTerminalSingleView(baseModel, {
+      id: 'X',
+      overrideCtaButtonText: 'Apply now'
+    })
+    expect(view.hasContinue).toBe(true)
+  })
+
+  test('hasContinue=false for an info-only outcomeType (no module/link/override/nextQuestionRoute)', () => {
+    const view = buildTerminalSingleView(baseModel, {
+      id: 'WO_EXE_NOT_LICENSABLE',
+      text: '<p>info</p>'
+    })
+    expect(view.hasContinue).toBe(false)
+  })
+})
+
+describe('#buildTerminalMultiView — hasContinue per option', () => {
+  test('sets hasContinue per option from module / link / override', () => {
+    const view = buildTerminalMultiView({ heading: 'h' }, [
+      { id: 'A', text: 'a', module: 'M' },
+      { id: 'B', text: 'b' },
+      { id: 'C', text: 'c', link: 'https://example.gov.uk/x.docx' }
+    ])
+    expect(view.options.map((o) => o.hasContinue)).toEqual([true, false, true])
   })
 })


### PR DESCRIPTION
Remove 'Continue' button on informational terminal outcome pages

<img width="2236" height="1958" alt="localhost_3000_journey_self-service_outcome_licence-not-required-devolved" src="https://github.com/user-attachments/assets/912d0d11-8b77-483d-b0ca-9436a19651d2" />
