### PR TITLE
Add integration tests for admin exemptions landing page

### DIFF
--- a/tests/integration/internal-user-admin/admin-exemptions-landing.test.js
+++ b/tests/integration/internal-user-admin/admin-exemptions-landing.test.js
@@ -1,0 +1,71 @@
+import { JSDOM } from 'jsdom'
+import { getByRole } from '@testing-library/dom'
+import { routes } from '~/src/server/common/constants/routes.js'
+import { statusCodes } from '~/src/server/common/constants/status-codes.js'
+import { setupTestServer } from '~/tests/integration/shared/test-setup-helpers.js'
+import { makeGetRequest } from '~/src/server/test-helpers/server-requests.js'
+
+const teamAdminAuth = {
+  credentials: { isTeamAdmin: true }
+}
+
+const loadAdminExemptionsLandingPage = async ({ server, auth = teamAdminAuth }) => {
+  const response = await makeGetRequest({
+    url: routes.ADMIN_EXEMPTIONS,
+    server,
+    auth
+  })
+
+  return {
+    response,
+    document: new JSDOM(response.result).window.document
+  }
+}
+
+describe('Admin exemptions landing page', () => {
+  const getServer = setupTestServer()
+
+  it('should render the page heading', async () => {
+    const { response, document } = await loadAdminExemptionsLandingPage({
+      server: getServer()
+    })
+
+    expect(response.statusCode).toBe(statusCodes.ok)
+    expect(getByRole(document, 'heading', { level: 1 })).toHaveTextContent(
+      'Exemptions Admin'
+    )
+  })
+
+  it.each([
+    {
+      name: 'Exemptions not sent to EMP',
+      href: routes.ADMIN_EMP
+    },
+    {
+      name: 'Exemptions without Marine Plan or Coastal Operations Areas',
+      href: routes.ADMIN_BACKFILL
+    },
+    {
+      name: 'Summary report',
+      href: routes.ADMIN_REPORTS
+    }
+  ])(
+    'should render the "$name" card link with href "$href"',
+    async ({ name, href }) => {
+      const { document } = await loadAdminExemptionsLandingPage({
+        server: getServer()
+      })
+
+      expect(getByRole(document, 'link', { name })).toHaveAttribute('href', href)
+    }
+  )
+
+  it('should return forbidden for non-team-admin users', async () => {
+    const { response } = await loadAdminExemptionsLandingPage({
+      server: getServer(),
+      auth: { credentials: { isTeamAdmin: false } }
+    })
+
+    expect(response.statusCode).toBe(statusCodes.forbidden)
+  })
+})

--- a/tests/integration/internal-user-admin/admin-exemptions-landing.test.js
+++ b/tests/integration/internal-user-admin/admin-exemptions-landing.test.js
@@ -9,7 +9,10 @@ const teamAdminAuth = {
   credentials: { isTeamAdmin: true }
 }
 
-const loadAdminExemptionsLandingPage = async ({ server, auth = teamAdminAuth }) => {
+const loadAdminExemptionsLandingPage = async ({
+  server,
+  auth = teamAdminAuth
+}) => {
   const response = await makeGetRequest({
     url: routes.ADMIN_EXEMPTIONS,
     server,
@@ -56,7 +59,10 @@ describe('Admin exemptions landing page', () => {
         server: getServer()
       })
 
-      expect(getByRole(document, 'link', { name })).toHaveAttribute('href', href)
+      expect(getByRole(document, 'link', { name })).toHaveAttribute(
+        'href',
+        href
+      )
     }
   )
 


### PR DESCRIPTION
- Adds integration tests for `/admin/exemptions` to verify the landing page renders correctly for team admin users
- Asserts all three card links resolve to the expected routes (`/admin/emp`, `/admin/backfill-areas`, `/admin/reports`)
- Verifies non-team-admin users receive a 403 response

This guards against a regression where the template was updated to use `{{ routes.ADMIN_EMP }}` (and related constants) but the controller did not pass `routes` into the view context, leaving the card links broken. The controller fix was merged in #712; these tests ensure it stays fixed.
