### PR TITLE
Add dev container for Node 24 local development

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,43 @@
+{
+  "name": "marine-licensing-frontend",
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:24-bookworm",
+  "runArgs": ["--add-host=host.docker.internal:host-gateway"],
+  "containerEnv": {
+    "TZ": "Europe/London",
+    "DEFRA_ID_OIDC_CONFIGURATION_URL": "http://host.docker.internal:3200/cdp-defra-id-stub/.well-known/openid-configuration",
+    "ENTRA_ID_OIDC_CONFIGURATION_URL": "http://host.docker.internal:3200/cdp-defra-id-stub/.well-known/openid-configuration",
+    "APP_BASE_URL": "http://localhost:3000"
+  },
+  "privileged": true,
+  "mounts": [
+    "source=${localEnv:HOME}${localEnv:USERPROFILE}/.ssh,target=/home/node/.ssh,readonly,type=bind,consistency=cached",
+    "source=${localEnv:HOME}/.gitconfig,target=/home/node/.gitconfig,type=bind,readonly"
+  ],
+  "features": {
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+      "dockerDashComposeVersion": "v2"
+    }
+  },
+  "forwardPorts": [9229],
+  "portsAttributes": {
+    "3000": {
+      "label": "Application",
+      "onAutoForward": "notify"
+    },
+    "9229": {
+      "label": "Node debug",
+      "onAutoForward": "silent"
+    }
+  },
+  "postCreateCommand": "npm install",
+  "postAttachCommand": "bash scripts/devcontainer-stub-proxy.sh",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode",
+        "stylelint.vscode-stylelint"
+      ]
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -169,12 +169,12 @@ using port `3000`, or run only `redis-frontend` and `defra-id-stub` while develo
 
 #### Troubleshooting
 
-| Symptom | What to try |
-| --- | --- |
-| `ERR_TOO_MANY_REDIRECTS` on `/signin` | Run `bash scripts/devcontainer-stub-proxy.sh`, confirm `curl http://127.0.0.1:3200/health` returns 200, clear cookies for `localhost`, restart `npm run dev`. |
-| `ECONNREFUSED` to `127.0.0.1:3200` on startup | Start stub: `docker compose up -d defra-id-stub`. Run the proxy script. |
-| `Cannot connect to the Docker daemon` | Start Docker on the host. Rebuild the dev container after changing `.devcontainer/devcontainer.json`. |
-| Port `3000` already in use | Stop `npm run dev` or the Compose frontend container before starting the other. |
+| Symptom                                       | What to try                                                                                                                                                   |
+| --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ERR_TOO_MANY_REDIRECTS` on `/signin`         | Run `bash scripts/devcontainer-stub-proxy.sh`, confirm `curl http://127.0.0.1:3200/health` returns 200, clear cookies for `localhost`, restart `npm run dev`. |
+| `ECONNREFUSED` to `127.0.0.1:3200` on startup | Start stub: `docker compose up -d defra-id-stub`. Run the proxy script.                                                                                       |
+| `Cannot connect to the Docker daemon`         | Start Docker on the host. Rebuild the dev container after changing `.devcontainer/devcontainer.json`.                                                         |
+| Port `3000` already in use                    | Stop `npm run dev` or the Compose frontend container before starting the other.                                                                               |
 
 ### Production
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ ability to create licence exemption notifications.
 - [Local development](#local-development)
   - [Setup](#setup)
   - [Development](#development)
+  - [Dev container](#dev-container)
   - [Production](#production)
   - [Npm scripts](#npm-scripts)
   - [Routes](#routes)
@@ -63,6 +64,117 @@ npm run dev
 and hit <http://localhost:3000> in your browser. This will
 use [Defra ID stub](https://github.com/DEFRA/cdp-defra-id-stub?tab=readme-ov-file#cdp-defra-id-stub)
 for login.
+
+If you use the [dev container](#dev-container), follow that section for Defra ID stub and sign-in
+setup.
+
+### Dev container
+
+Configuration lives in [.devcontainer/devcontainer.json](./.devcontainer/devcontainer.json). It
+uses the Node 24 dev container image, forwards port `9229` for debugging, and enables
+[Docker-outside-of-Docker](https://github.com/devcontainers/features/tree/main/src/docker-outside-of-docker)
+so `docker` and `docker compose` run against the Docker daemon on your host.
+
+#### Open the dev container
+
+1. Install [Docker](https://www.docker.com/) on your machine and ensure it is running.
+2. In VS Code or Cursor, install the **Dev Containers** extension.
+3. Open this repository and run **Dev Containers: Reopen in Container**.
+
+On first open (or after config changes), the container runs `npm install`. Each time you attach,
+`scripts/devcontainer-stub-proxy.sh` starts if it is not already running.
+
+#### Local development inside the dev container
+
+The recommended workflow matches [Development mode](#development-mode): run dependent services in
+Docker on the host, then run the app with Node inside the dev container.
+
+1. Create the Compose network once (if it does not exist):
+
+   ```bash
+   docker network create cdp-tenant
+   ```
+
+2. Start Redis and the Defra ID stub (do not run the frontend service in Compose):
+
+   ```bash
+   docker compose up -d redis-frontend defra-id-stub
+   docker stop marine-licensing-frontend-marine-licensing-frontend-1 2>/dev/null || true
+   ```
+
+3. Register stub users (required for `npm run dev`; Compose does this automatically for the
+   frontend container):
+
+   ```bash
+   for f in compose/users/*.json; do
+     curl -sS -X POST -H "Content-Type: application/json" -d @"$f" \
+       "http://localhost:3200/cdp-defra-id-stub/API/register"
+   done
+   ```
+
+4. Start the app:
+
+   ```bash
+   npm run dev
+   ```
+
+   `predev` runs the stub proxy script before the dev server starts. You can also run it manually:
+
+   ```bash
+   bash scripts/devcontainer-stub-proxy.sh
+   ```
+
+5. Open <http://localhost:3000> in your browser on the host.
+
+Environment variables for OIDC and `APP_BASE_URL` are set in `devcontainer.json`. Override locally
+if needed:
+
+```bash
+export APP_BASE_URL=http://localhost:3000
+export DEFRA_ID_OIDC_CONFIGURATION_URL=http://localhost:3200/cdp-defra-id-stub/.well-known/openid-configuration
+```
+
+Use **localhost** for the app and sign-in flow. `compose.yml` sets
+`APP_BASE_URL=http://marine-licensing-frontend.local:3000` for the containerised frontend; that
+hostname is only needed when running the full Compose stack and adding a matching `/etc/hosts`
+entry on your machine.
+
+#### Defra ID stub proxy
+
+Inside the dev container, `localhost:3200` is not the stub running on the host. The stub’s OIDC
+metadata also points at `http://localhost:3200`, so the app must reach the host stub via a local
+forwarder.
+
+`scripts/devcontainer-stub-proxy.sh` uses `socat` to forward port `3200` inside the dev container to
+the host (`host.docker.internal` or `172.17.0.1`).
+
+Check the proxy and stub:
+
+```bash
+curl http://127.0.0.1:3200/health   # expect 200
+```
+
+Without the proxy, the server may start but sign-in fails with **`ERR_TOO_MANY_REDIRECTS`** on
+`/signin` because the OAuth callback never completes.
+
+#### Docker commands from the dev container
+
+`docker build` and `docker compose` use the host daemon. Ensure Docker is running on the host before
+running them.
+
+If port `3000` is already in use on the host (for example by `npm run dev` or port forwarding from
+the dev container), `docker compose up` for the frontend service will fail to bind. Stop the process
+using port `3000`, or run only `redis-frontend` and `defra-id-stub` while developing with
+`npm run dev`.
+
+#### Troubleshooting
+
+| Symptom | What to try |
+| --- | --- |
+| `ERR_TOO_MANY_REDIRECTS` on `/signin` | Run `bash scripts/devcontainer-stub-proxy.sh`, confirm `curl http://127.0.0.1:3200/health` returns 200, clear cookies for `localhost`, restart `npm run dev`. |
+| `ECONNREFUSED` to `127.0.0.1:3200` on startup | Start stub: `docker compose up -d defra-id-stub`. Run the proxy script. |
+| `Cannot connect to the Docker daemon` | Start Docker on the host. Rebuild the dev container after changing `.devcontainer/devcontainer.json`. |
+| Port `3000` already in use | Stop `npm run dev` or the Compose frontend container before starting the other. |
 
 ### Production
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "scripts": {
     "build": "npm run build:frontend",
     "build:frontend": "NODE_ENV=production webpack",
+    "predev": "bash scripts/devcontainer-stub-proxy.sh",
     "dev": "run-p frontend:watch server:watch",
     "dev:debug": "run-p frontend:watch server:debug",
     "format": "prettier --write \"src/**/*.js\" \"**/*.{js,cjs,md,json,config.js,test.js}\"",

--- a/scripts/devcontainer-stub-proxy.sh
+++ b/scripts/devcontainer-stub-proxy.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Forwards localhost:3200 inside the dev container to the Defra ID stub on the Docker host.
+# Required when using npm run dev in a dev container with docker-outside-of-docker.
+
+set -e
+
+if pgrep -f "socat TCP-LISTEN:3200" >/dev/null 2>&1; then
+  exit 0
+fi
+
+stub_host="172.17.0.1"
+if getent hosts host.docker.internal >/dev/null 2>&1; then
+  stub_host="host.docker.internal"
+fi
+
+socat "TCP-LISTEN:3200,fork,reuseaddr" "TCP:${stub_host}:3200" &


### PR DESCRIPTION
## Summary

Adds a VS Code / Cursor dev container for local development on Node 24, with Docker and Defra ID stub integration documented and automated where possible.

- **`.devcontainer/devcontainer.json`** — Node 24 (`javascript-node:24-bookworm`), Docker-outside-of-Docker, debug port `9229`, OIDC/`APP_BASE_URL` env vars, SSH and `.gitconfig` mounts, ESLint/Prettier/Stylelint extensions
- **`scripts/devcontainer-stub-proxy.sh`** — Forwards port `3200` inside the dev container to the Defra ID stub on the host (fixes sign-in redirect loops when running `npm run dev` in the container)
- **`package.json`** — `predev` hook runs the stub proxy before `npm run dev`
- **`README.md`** — New **Dev container** section (setup, workflow, proxy, Docker, troubleshooting)

## Why

Running the app in a dev container while the Defra ID stub runs via Compose on the host breaks OAuth: the stub advertises `http://localhost:3200`, which inside the container is not the host stub. Token exchange fails and sign-in loops with `ERR_TOO_MANY_REDIRECTS`. The proxy and docs address that; Docker-in-Docker was avoided in favour of the host daemon for reliability.

## Test plan

- [ ] Rebuild / reopen dev container from `.devcontainer/devcontainer.json`
- [ ] On host: `docker network create cdp-tenant` (if missing), then `docker compose up -d redis-frontend defra-id-stub`
- [ ] Register stub users and run `npm run dev`
- [ ] Confirm `curl http://127.0.0.1:3200/health` returns `200` inside the dev container
- [ ] Open http://localhost:3000, sign in via Defra ID stub (no redirect loop)
- [ ] Confirm `docker compose ps` and `docker build` work from the dev container terminal
- [ ] Read new README **Dev container** section and follow it on a clean machine if possible

---

**Suggested PR title:** `Add dev container for Node 24 local development`