### PR TITLE
ML-1289: Back link on "Review site details" page behaviour

### DIFF
--- a/src/server/exemption/site-details/review-site-details/utils.js
+++ b/src/server/exemption/site-details/review-site-details/utils.js
@@ -36,11 +36,14 @@ export const getSiteDetailsBackLink = (
     return routes.TASK_LIST
   }
 
+  const siteParam = url.searchParams.get('site')
+  const queryParams = siteParam ? `?site=${siteParam}` : ''
+
   if (coordinatesEntry === 'multiple') {
-    return routes.ENTER_MULTIPLE_COORDINATES
+    return `${routes.ENTER_MULTIPLE_COORDINATES}${queryParams}`
   }
 
-  return routes.WIDTH_OF_SITE
+  return `${routes.WIDTH_OF_SITE}${queryParams}`
 }
 
 export const getFileUploadBackLink = (

--- a/src/server/exemption/site-details/review-site-details/utils.test.js
+++ b/src/server/exemption/site-details/review-site-details/utils.test.js
@@ -48,9 +48,7 @@ describe('siteDetails utils', () => {
 
     test('getSiteDetailsBackLink includes ?site= param when referer has one for WIDTH_OF_SITE', () => {
       expect(
-        getSiteDetailsBackLink(
-          `http://hostname${routes.WIDTH_OF_SITE}?site=2`
-        )
+        getSiteDetailsBackLink(`http://hostname${routes.WIDTH_OF_SITE}?site=2`)
       ).toBe(`${routes.WIDTH_OF_SITE}?site=2`)
     })
 

--- a/src/server/exemption/site-details/review-site-details/utils.test.js
+++ b/src/server/exemption/site-details/review-site-details/utils.test.js
@@ -45,6 +45,23 @@ describe('siteDetails utils', () => {
         routes.CHECK_YOUR_ANSWERS
       )
     })
+
+    test('getSiteDetailsBackLink includes ?site= param when referer has one for WIDTH_OF_SITE', () => {
+      expect(
+        getSiteDetailsBackLink(
+          `http://hostname${routes.WIDTH_OF_SITE}?site=2`
+        )
+      ).toBe(`${routes.WIDTH_OF_SITE}?site=2`)
+    })
+
+    test('getSiteDetailsBackLink includes ?site= param when referer has one for ENTER_MULTIPLE_COORDINATES', () => {
+      expect(
+        getSiteDetailsBackLink(
+          `http://hostname${routes.ENTER_MULTIPLE_COORDINATES}?site=2`,
+          'multiple'
+        )
+      ).toBe(`${routes.ENTER_MULTIPLE_COORDINATES}?site=2`)
+    })
   })
 
   describe('getFileUploadBackLink util', () => {

--- a/src/server/marine-licence/site-details/review-site-details/utils.js
+++ b/src/server/marine-licence/site-details/review-site-details/utils.js
@@ -51,16 +51,18 @@ export const getManualEntryBackLink = (
 
   const url = new URL(previousPage)
   const previousPath = url.pathname
+  const siteParam = url.searchParams.get('site')
+  const queryParams = siteParam ? `?site=${siteParam}` : ''
 
   if (
     previousPath ===
     marineLicenceRoutes.MARINE_LICENCE_ENTER_MULTIPLE_COORDINATES
   ) {
-    return marineLicenceRoutes.MARINE_LICENCE_ENTER_MULTIPLE_COORDINATES
+    return `${marineLicenceRoutes.MARINE_LICENCE_ENTER_MULTIPLE_COORDINATES}${queryParams}`
   }
 
   if (previousPath === marineLicenceRoutes.MARINE_LICENCE_WIDTH_OF_SITE) {
-    return marineLicenceRoutes.MARINE_LICENCE_WIDTH_OF_SITE
+    return `${marineLicenceRoutes.MARINE_LICENCE_WIDTH_OF_SITE}${queryParams}`
   }
 
   if (previousPath === routes.TASK_LIST) {

--- a/src/server/marine-licence/site-details/review-site-details/utils.test.js
+++ b/src/server/marine-licence/site-details/review-site-details/utils.test.js
@@ -173,6 +173,24 @@ describe('siteDetails utils', () => {
         marineLicenceRoutes.MARINE_LICENCE_CHECK_YOUR_ANSWERS
       )
     })
+
+    test('includes ?site= param when referer has one for WIDTH_OF_SITE', () => {
+      expect(
+        getManualEntryBackLink(
+          `http://hostname${marineLicenceRoutes.MARINE_LICENCE_WIDTH_OF_SITE}?site=2`
+        )
+      ).toBe(`${marineLicenceRoutes.MARINE_LICENCE_WIDTH_OF_SITE}?site=2`)
+    })
+
+    test('includes ?site= param when referer has one for ENTER_MULTIPLE_COORDINATES', () => {
+      expect(
+        getManualEntryBackLink(
+          `http://hostname${marineLicenceRoutes.MARINE_LICENCE_ENTER_MULTIPLE_COORDINATES}?site=2`
+        )
+      ).toBe(
+        `${marineLicenceRoutes.MARINE_LICENCE_ENTER_MULTIPLE_COORDINATES}?site=2`
+      )
+    })
   })
 
   describe('renderManualEntryReview util', () => {


### PR DESCRIPTION
## Description
 
Bug fix to add site number param to back link
 
## Changes
 
- Add site number to Review Site Details back link, for both Exemption and Marine Licence