### PR TITLE
chore(security) - override shell-quote

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15245,9 +15245,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
     "picomatch": "^4.0.4",
     "vite": "^8.0.5",
     "@babel/plugin-transform-modules-systemjs": "^7.29.4",
-    "fast-uri": "^3.1.2"
+    "fast-uri": "^3.1.2",
+    "shell-quote": "^1.8.4"
   }
 }


### PR DESCRIPTION
`npm-run-all` is at v4.1.5 and is using a vulnerable version of shell-quote.

Adding to `overrides` section for now to fix.