### PR TITLE
IAT tool update

### DIFF
--- a/scripts/iat-graph-commands.js
+++ b/scripts/iat-graph-commands.js
@@ -1,8 +1,3 @@
-/**
- * IAT query CLI — graph-traversal subcommands (path, reach, predecessors),
- * built on the journey-graph traversal layer.
- */
-
 import { parseArgs } from 'node:util'
 import {
   getFirstQuestionRoute,

--- a/scripts/iat-graph-commands.js
+++ b/scripts/iat-graph-commands.js
@@ -5,7 +5,7 @@ import {
   hasOutcome
 } from '../src/server/journey/self-service/services/journey-data.js'
 import { shortestPath, reach, predecessors } from './journey-graph.js'
-import { parseSingleArg } from './iat-utils.js'
+import { runSingleArg, jsonResult, notFound, JSON_FLAG } from './iat-utils.js'
 
 function choiceFromLabel(label) {
   if (label.startsWith('answer ')) {
@@ -30,18 +30,12 @@ function runPath(from, to, json) {
   const steps = shortestPath(to, { from })
   if (steps === null) {
     if (json) {
-      return {
-        stdout: JSON.stringify({ from, to, found: false, steps: [] }, null, 2),
-        code: 1
-      }
+      return jsonResult({ from, to, found: false, steps: [] }, 1)
     }
     return { stdout: `No path from ${from} to ${to}`, code: 1 }
   }
   if (json) {
-    return {
-      stdout: JSON.stringify({ from, to, found: true, steps }, null, 2),
-      code: 0
-    }
+    return jsonResult({ from, to, found: true, steps })
   }
   return { stdout: formatPathHuman(steps), code: 0 }
 }
@@ -50,7 +44,7 @@ function runReach(route, json) {
   const reachable = reach(route)
   const code = reachable ? 0 : 1
   if (json) {
-    return { stdout: JSON.stringify({ route, reachable }, null, 2), code }
+    return jsonResult({ route, reachable }, code)
   }
   return {
     stdout: reachable ? `reachable: ${route}` : `not reachable: ${route}`,
@@ -60,11 +54,11 @@ function runReach(route, json) {
 
 function runPredecessors(route, json) {
   if (!hasQuestion(route) && !hasOutcome(route)) {
-    return { stdout: `Route not found: ${route}`, code: 1 }
+    return notFound('Route', route)
   }
   const callers = predecessors(route)
   if (json) {
-    return { stdout: JSON.stringify(callers, null, 2), code: 0 }
+    return jsonResult(callers)
   }
   if (callers.length === 0) {
     return { stdout: '(no predecessors — entry point or orphaned)', code: 0 }
@@ -78,7 +72,7 @@ function runPredecessors(route, json) {
 export function dispatchPath(rest) {
   const { values, positionals } = parseArgs({
     args: rest,
-    options: { json: { type: 'boolean', default: false } },
+    options: { json: JSON_FLAG },
     allowPositionals: true
   })
   if (positionals.length === 0) {
@@ -94,20 +88,13 @@ export function dispatchPath(rest) {
 }
 
 export function dispatchReach(rest) {
-  const parsed = parseSingleArg(rest, 'Usage: iat-query reach <route> [--json]')
-  if (parsed.error) {
-    return parsed.error
-  }
-  return runReach(parsed.arg, parsed.json)
+  return runSingleArg(rest, 'Usage: iat-query reach <route> [--json]', runReach)
 }
 
 export function dispatchPredecessors(rest) {
-  const parsed = parseSingleArg(
+  return runSingleArg(
     rest,
-    'Usage: iat-query predecessors <route> [--json]'
+    'Usage: iat-query predecessors <route> [--json]',
+    runPredecessors
   )
-  if (parsed.error) {
-    return parsed.error
-  }
-  return runPredecessors(parsed.arg, parsed.json)
 }

--- a/scripts/iat-graph-commands.js
+++ b/scripts/iat-graph-commands.js
@@ -7,16 +7,23 @@ import {
 import { shortestPath, reach, predecessors } from './journey-graph.js'
 import { parseSingleArg } from './iat-utils.js'
 
-function formatPathHuman(from, to, steps) {
-  const lines = [`Path ${from} -> ${to} (${steps.length} steps)`, '']
-  for (const step of steps) {
-    const head = step.fromText
-      ? `Q ${step.from}\t${step.fromText}`
-      : `[outcome ${step.from}]`
-    lines.push(head)
-    lines.push(`  -> ${step.label}\t==> ${step.kind} ${step.to}`)
+function choiceFromLabel(label) {
+  if (label.startsWith('answer ')) {
+    return label.slice('answer '.length).replace(/^"|"$/g, '')
   }
-  return lines.join('\n')
+  if (label.startsWith('continue:')) {
+    return 'Continue'
+  }
+  return label.replaceAll('"', '')
+}
+
+function formatPathHuman(steps) {
+  return steps
+    .map((step, index) => {
+      const destination = index === steps.length - 1 ? ` → ${step.to}` : ''
+      return `- ${step.from} → ${choiceFromLabel(step.label)}${destination}`
+    })
+    .join('\n')
 }
 
 function runPath(from, to, json) {
@@ -36,7 +43,7 @@ function runPath(from, to, json) {
       code: 0
     }
   }
-  return { stdout: formatPathHuman(from, to, steps), code: 0 }
+  return { stdout: formatPathHuman(steps), code: 0 }
 }
 
 function runReach(route, json) {

--- a/scripts/iat-graph-commands.js
+++ b/scripts/iat-graph-commands.js
@@ -1,0 +1,111 @@
+/**
+ * IAT query CLI — graph-traversal subcommands (path, reach, predecessors),
+ * built on the journey-graph traversal layer.
+ */
+
+import { parseArgs } from 'node:util'
+import {
+  getFirstQuestionRoute,
+  hasQuestion,
+  hasOutcome
+} from '../src/server/journey/self-service/services/journey-data.js'
+import { shortestPath, reach, predecessors } from './journey-graph.js'
+import { parseSingleArg } from './iat-utils.js'
+
+function formatPathHuman(from, to, steps) {
+  const lines = [`Path ${from} -> ${to} (${steps.length} steps)`, '']
+  for (const step of steps) {
+    const head = step.fromText
+      ? `Q ${step.from}\t${step.fromText}`
+      : `[outcome ${step.from}]`
+    lines.push(head)
+    lines.push(`  -> ${step.label}\t==> ${step.kind} ${step.to}`)
+  }
+  return lines.join('\n')
+}
+
+function runPath(from, to, json) {
+  const steps = shortestPath(to, { from })
+  if (steps === null) {
+    if (json) {
+      return {
+        stdout: JSON.stringify({ from, to, found: false, steps: [] }, null, 2),
+        code: 1
+      }
+    }
+    return { stdout: `No path from ${from} to ${to}`, code: 1 }
+  }
+  if (json) {
+    return {
+      stdout: JSON.stringify({ from, to, found: true, steps }, null, 2),
+      code: 0
+    }
+  }
+  return { stdout: formatPathHuman(from, to, steps), code: 0 }
+}
+
+function runReach(route, json) {
+  const reachable = reach(route)
+  const code = reachable ? 0 : 1
+  if (json) {
+    return { stdout: JSON.stringify({ route, reachable }, null, 2), code }
+  }
+  return {
+    stdout: reachable ? `reachable: ${route}` : `not reachable: ${route}`,
+    code
+  }
+}
+
+function runPredecessors(route, json) {
+  if (!hasQuestion(route) && !hasOutcome(route)) {
+    return { stdout: `Route not found: ${route}`, code: 1 }
+  }
+  const callers = predecessors(route)
+  if (json) {
+    return { stdout: JSON.stringify(callers, null, 2), code: 0 }
+  }
+  if (callers.length === 0) {
+    return { stdout: '(no predecessors — entry point or orphaned)', code: 0 }
+  }
+  return {
+    stdout: callers.map((c) => `${c.route}\t${c.via}`).join('\n'),
+    code: 0
+  }
+}
+
+export function dispatchPath(rest) {
+  const { values, positionals } = parseArgs({
+    args: rest,
+    options: { json: { type: 'boolean', default: false } },
+    allowPositionals: true
+  })
+  if (positionals.length === 0) {
+    return {
+      stdout: 'Usage: iat-query path <to> | path <from> <to> [--json]',
+      code: 2
+    }
+  }
+  const hasFrom = positionals.length > 1
+  const from = hasFrom ? positionals[0] : getFirstQuestionRoute()
+  const to = hasFrom ? positionals[1] : positionals[0]
+  return runPath(from, to, values.json)
+}
+
+export function dispatchReach(rest) {
+  const parsed = parseSingleArg(rest, 'Usage: iat-query reach <route> [--json]')
+  if (parsed.error) {
+    return parsed.error
+  }
+  return runReach(parsed.arg, parsed.json)
+}
+
+export function dispatchPredecessors(rest) {
+  const parsed = parseSingleArg(
+    rest,
+    'Usage: iat-query predecessors <route> [--json]'
+  )
+  if (parsed.error) {
+    return parsed.error
+  }
+  return runPredecessors(parsed.arg, parsed.json)
+}

--- a/scripts/iat-query.js
+++ b/scripts/iat-query.js
@@ -54,6 +54,28 @@ import {
 const EXCERPT_LEN = 60
 const MAX_TEXT_FOR_STRIP = 10000
 
+const USAGE = `iat-query — inspect the self-service IAT journey (self-service.json)
+
+Most common question — "how do I reach a page?":
+  npm run iat -- path /mod-permission           one shortest journey from /sea
+  npm run iat -- path /sea /mod-permission        between two routes
+  npm run iat -- reach /mod-permission            reachable? (exit 0/1)
+  npm run iat -- predecessors /activity/completion  pages that lead directly here
+
+Inspect a node:
+  question <route> | outcome <route> | outcome-type <id>
+
+List / filter:
+  outcomes | outcome-types | questions | mappings
+
+The journey is a graph of three node types (questions, outcomes,
+outcomeTypes). Routing happens four ways: single-select answers,
+multi-select pages (multiSelect.questionRoute / outcomeRoute), and
+outcome forks (outcomeType.nextQuestionRoute). All documented in:
+  src/server/journey/self-service/data/README.data.md
+
+Add --json to any subcommand for machine-readable output.`
+
 function excerpt(text) {
   if (!text) {
     return '-'
@@ -564,7 +586,7 @@ const DISPATCH = {
 export function runCommand(argv) {
   const [subcommand, ...rest] = argv
   if (!subcommand) {
-    return { stdout: 'Usage: iat-query <subcommand> [args] [--json]', code: 2 }
+    return { stdout: USAGE, code: 2 }
   }
   const handler = DISPATCH[subcommand]
   if (!handler) {
@@ -579,5 +601,5 @@ if (isMain) {
   const { stdout, code } = runCommand(process.argv.slice(2))
   // eslint-disable-next-line no-console
   console.log(stdout)
-  process.exit(code)
+  process.exitCode = code
 }

--- a/scripts/iat-query.js
+++ b/scripts/iat-query.js
@@ -50,11 +50,7 @@ import {
 } from '../src/server/journey/self-service/services/journey-data.js'
 import { classifyOutcome } from '../src/server/journey/self-service/outcome/utils.js'
 import { calculateNextRoute } from '../src/server/journey/self-service/services/journey-router.js'
-import {
-  shortestPath,
-  reach,
-  predecessors
-} from './journey-graph.js'
+import { shortestPath, reach, predecessors } from './journey-graph.js'
 
 const EXCERPT_LEN = 60
 const MAX_TEXT_FOR_STRIP = 10000
@@ -422,7 +418,10 @@ function runPredecessors(route, json) {
   if (callers.length === 0) {
     return { stdout: '(no predecessors — entry point or orphaned)', code: 0 }
   }
-  return { stdout: callers.map((c) => `${c.route}\t${c.via}`).join('\n'), code: 0 }
+  return {
+    stdout: callers.map((c) => `${c.route}\t${c.via}`).join('\n'),
+    code: 0
+  }
 }
 
 function parseSingleArg(rest, usage) {

--- a/scripts/iat-query.js
+++ b/scripts/iat-query.js
@@ -44,6 +44,7 @@ import {
   hasOutcome
 } from '../src/server/journey/self-service/services/journey-data.js'
 import { classifyOutcome } from '../src/server/journey/self-service/outcome/utils.js'
+import { calculateNextRoute } from '../src/server/journey/self-service/services/journey-router.js'
 import {
   shortestPath,
   reach,
@@ -73,14 +74,13 @@ function dash(value) {
   return String(value)
 }
 
-function targetForAnswer(answer) {
-  if (answer.nextQuestionRoute) {
-    return `question ${answer.nextQuestionRoute}`
+function targetForAnswer(answer, question) {
+  try {
+    const next = calculateNextRoute(question, [answer.id])
+    return `${next.type} ${next.route}`
+  } catch {
+    return 'terminal'
   }
-  if (answer.outcomeRoute) {
-    return `outcome ${answer.outcomeRoute}`
-  }
-  return 'terminal'
 }
 
 function paramsFlat(outcomeType) {
@@ -106,7 +106,7 @@ function runQuestion(route, json) {
       answers: q.answers.map((a) => ({
         id: a.id,
         text: a.text,
-        target: targetForAnswer(a)
+        target: targetForAnswer(a, q)
       }))
     }
     return { stdout: JSON.stringify(doc, null, 2), code: 0 }
@@ -122,7 +122,7 @@ function runQuestion(route, json) {
     '  id\ttext\ttarget'
   ]
   for (const a of q.answers) {
-    lines.push(`  ${a.id}\t${excerpt(a.text)}\t${targetForAnswer(a)}`)
+    lines.push(`  ${a.id}\t${excerpt(a.text)}\t${targetForAnswer(a, q)}`)
   }
   return { stdout: lines.join('\n'), code: 0 }
 }

--- a/scripts/iat-query.js
+++ b/scripts/iat-query.js
@@ -51,8 +51,12 @@ import {
   dash,
   paramsFlat,
   targetForAnswer,
-  parseSingleArg,
-  parseHasParam
+  parseHasParam,
+  runSingleArg,
+  jsonResult,
+  notFound,
+  alignKeyValues,
+  JSON_FLAG
 } from './iat-utils.js'
 import {
   dispatchPath,
@@ -85,7 +89,7 @@ Add --json to any subcommand for machine-readable output.`
 function runQuestion(route, json) {
   const q = getQuestion(route)
   if (!q) {
-    return { stdout: `Question not found: ${route}`, code: 1 }
+    return notFound('Question', route)
   }
   if (json) {
     const doc = {
@@ -100,14 +104,16 @@ function runQuestion(route, json) {
         target: targetForAnswer(a, q)
       }))
     }
-    return { stdout: JSON.stringify(doc, null, 2), code: 0 }
+    return jsonResult(doc)
   }
   const lines = [
-    `route          ${q.route}`,
-    `text           ${q.text}`,
-    `mapping        ${dash(q.mcmsAppFormMapping)}`,
-    `multiSelect    ${q.multiSelect ? 'yes' : 'no'}`,
-    `section        ${dash(q.section)}`,
+    ...alignKeyValues([
+      ['route', q.route],
+      ['text', q.text],
+      ['mapping', dash(q.mcmsAppFormMapping)],
+      ['multiSelect', q.multiSelect ? 'yes' : 'no'],
+      ['section', dash(q.section)]
+    ]),
     '',
     '  ANSWERS',
     '  id\ttext\ttarget'
@@ -121,7 +127,7 @@ function runQuestion(route, json) {
 function runOutcome(route, json) {
   const o = getOutcome(route)
   if (!o) {
-    return { stdout: `Outcome not found: ${route}`, code: 1 }
+    return notFound('Outcome', route)
   }
   const classification = classifyOutcome(o)
   const types = getOutcomeTypesForOutcome(o)
@@ -138,13 +144,15 @@ function runOutcome(route, json) {
         nextQuestionRoute: ot.nextQuestionRoute ?? null
       }))
     }
-    return { stdout: JSON.stringify(doc, null, 2), code: 0 }
+    return jsonResult(doc)
   }
   const lines = [
-    `route            ${o.route}`,
-    `heading          ${o.heading}`,
-    `text             ${excerpt(o.text)}`,
-    `classification   ${classification}`,
+    ...alignKeyValues([
+      ['route', o.route],
+      ['heading', o.heading],
+      ['text', excerpt(o.text)],
+      ['classification', classification]
+    ]),
     '',
     '  OUTCOME TYPES',
     '  id\ttext\tparams\tnextQuestionRoute'
@@ -160,7 +168,7 @@ function runOutcome(route, json) {
 function runOutcomeType(id, json) {
   const ot = getOutcomeType(id)
   if (!ot) {
-    return { stdout: `OutcomeType not found: ${id}`, code: 1 }
+    return notFound('OutcomeType', id)
   }
   if (json) {
     const doc = {
@@ -174,31 +182,20 @@ function runOutcomeType(id, json) {
       entryTheme: ot.entryTheme ?? null,
       overrideCtaButtonText: ot.overrideCtaButtonText ?? null
     }
-    return { stdout: JSON.stringify(doc, null, 2), code: 0 }
+    return jsonResult(doc)
   }
-  const lines = [
-    `id                    ${ot.id}`,
-    `heading               ${ot.heading}`,
-    `text                  ${excerpt(ot.text)}`,
-    `params                ${paramsFlat(ot)}`,
-    `nextQuestionRoute     ${dash(ot.nextQuestionRoute)}`,
-    `link                  ${dash(ot.link)}`,
-    `module                ${dash(ot.module)}`,
-    `entryTheme            ${dash(ot.entryTheme)}`,
-    `overrideCtaButtonText ${dash(ot.overrideCtaButtonText)}`
-  ]
+  const lines = alignKeyValues([
+    ['id', ot.id],
+    ['heading', ot.heading],
+    ['text', excerpt(ot.text)],
+    ['params', paramsFlat(ot)],
+    ['nextQuestionRoute', dash(ot.nextQuestionRoute)],
+    ['link', dash(ot.link)],
+    ['module', dash(ot.module)],
+    ['entryTheme', dash(ot.entryTheme)],
+    ['overrideCtaButtonText', dash(ot.overrideCtaButtonText)]
+  ])
   return { stdout: lines.join('\n'), code: 0 }
-}
-
-function outcomeMatchesHasParam(outcome, paramName, paramValue) {
-  const types = getOutcomeTypesForOutcome(outcome)
-  return types.some((ot) =>
-    outcomeTypeMatchesHasParam(ot, paramName, paramValue)
-  )
-}
-
-function outcomeHasLink(outcome) {
-  return getOutcomeTypesForOutcome(outcome).some((ot) => Boolean(ot.link))
 }
 
 function outcomeTypeMatchesHasParam(ot, paramName, paramValue) {
@@ -211,6 +208,17 @@ function outcomeTypeMatchesHasParam(ot, paramName, paramValue) {
     }
     return paramValue === null || p.value === paramValue
   })
+}
+
+function outcomeMatchesHasParam(outcome, paramName, paramValue) {
+  const types = getOutcomeTypesForOutcome(outcome)
+  return types.some((ot) =>
+    outcomeTypeMatchesHasParam(ot, paramName, paramValue)
+  )
+}
+
+function outcomeHasLink(outcome) {
+  return getOutcomeTypesForOutcome(outcome).some((ot) => Boolean(ot.link))
 }
 
 function runOutcomes(flags, json) {
@@ -236,7 +244,7 @@ function runOutcomes(flags, json) {
       classification: classifyOutcome(o),
       outcomeTypeIds: o.outcomeTypes ?? []
     }))
-    return { stdout: JSON.stringify(docs, null, 2), code: 0 }
+    return jsonResult(docs)
   }
   const lines = filtered.map((o) => {
     const classification = classifyOutcome(o)
@@ -263,7 +271,7 @@ function runOutcomeTypes(flags, json) {
     return true
   })
   if (json) {
-    return { stdout: JSON.stringify(filtered, null, 2), code: 0 }
+    return jsonResult(filtered)
   }
   const lines = filtered.map((ot) => {
     return `${ot.id}\t${paramsFlat(ot)}\t${dash(ot.nextQuestionRoute)}`
@@ -284,7 +292,7 @@ function runQuestions(flags, json) {
     return true
   })
   if (json) {
-    return { stdout: JSON.stringify(filtered, null, 2), code: 0 }
+    return jsonResult(filtered)
   }
   const lines = filtered.map((q) => {
     return `${q.route}\t${dash(q.mcmsAppFormMapping)}\t${q.multiSelect ? 'yes' : 'no'}\t${excerpt(q.text)}`
@@ -312,7 +320,7 @@ function runMappings(json) {
     for (const key of sortedKeys) {
       doc[key] = mappingMap.get(key)
     }
-    return { stdout: JSON.stringify(doc, null, 2), code: 0 }
+    return jsonResult(doc)
   }
   const lines = sortedKeys.map(
     (key) => `${key}\t${mappingMap.get(key).join(',')}`
@@ -321,43 +329,34 @@ function runMappings(json) {
 }
 
 function dispatchQuestion(rest) {
-  const parsed = parseSingleArg(
+  return runSingleArg(
     rest,
-    'Usage: iat-query question <route> [--json]'
+    'Usage: iat-query question <route> [--json]',
+    runQuestion
   )
-  if (parsed.error) {
-    return parsed.error
-  }
-  return runQuestion(parsed.arg, parsed.json)
 }
 
 function dispatchOutcome(rest) {
-  const parsed = parseSingleArg(
+  return runSingleArg(
     rest,
-    'Usage: iat-query outcome <route> [--json]'
+    'Usage: iat-query outcome <route> [--json]',
+    runOutcome
   )
-  if (parsed.error) {
-    return parsed.error
-  }
-  return runOutcome(parsed.arg, parsed.json)
 }
 
 function dispatchOutcomeType(rest) {
-  const parsed = parseSingleArg(
+  return runSingleArg(
     rest,
-    'Usage: iat-query outcome-type <id> [--json]'
+    'Usage: iat-query outcome-type <id> [--json]',
+    runOutcomeType
   )
-  if (parsed.error) {
-    return parsed.error
-  }
-  return runOutcomeType(parsed.arg, parsed.json)
 }
 
 function dispatchOutcomes(rest) {
   const { values } = parseArgs({
     args: rest,
     options: {
-      json: { type: 'boolean', default: false },
+      json: JSON_FLAG,
       classify: { type: 'string' },
       'has-param': { type: 'string' },
       'has-link': { type: 'boolean', default: false }
@@ -378,7 +377,7 @@ function dispatchOutcomeTypes(rest) {
   const { values } = parseArgs({
     args: rest,
     options: {
-      json: { type: 'boolean', default: false },
+      json: JSON_FLAG,
       'has-param': { type: 'string' },
       'has-next-question': { type: 'boolean', default: false },
       'has-link': { type: 'boolean', default: false }
@@ -399,7 +398,7 @@ function dispatchQuestions(rest) {
   const { values } = parseArgs({
     args: rest,
     options: {
-      json: { type: 'boolean', default: false },
+      json: JSON_FLAG,
       mapping: { type: 'string' },
       'has-mapping': { type: 'boolean', default: false }
     },
@@ -414,7 +413,7 @@ function dispatchQuestions(rest) {
 function dispatchMappings(rest) {
   const { values } = parseArgs({
     args: rest,
-    options: { json: { type: 'boolean', default: false } },
+    options: { json: JSON_FLAG },
     allowPositionals: false
   })
   return runMappings(values.json)

--- a/scripts/iat-query.js
+++ b/scripts/iat-query.js
@@ -13,8 +13,13 @@
  *   outcome-types [--has-param N[=V]] [--has-next-question] [--has-link]
  *   questions [--mapping N] [--has-mapping]           list questions by mcmsAppFormMapping
  *   mappings                                          distinct mappings + carrier question routes
+ *   path [<from>] <to>                                shortest journey through the graph (from defaults to /sea)
+ *   reach <route>                                     reachable from /sea? (exit 0 reachable, 1 not)
+ *   predecessors <route>                              pages that route directly into this node
  *
  * Examples:
+ *   npm run iat -- path /mod-permission
+ *       print one shortest click-by-click journey from /sea to a page
  *   npm run iat -- question /activity-type
  *       inspect one question, its answers, and where each answer branches to
  *   npm run iat -- outcome /scaffolding-impede-navigation

--- a/scripts/iat-query.js
+++ b/scripts/iat-query.js
@@ -38,9 +38,17 @@ import {
   getQuestion,
   getOutcome,
   getOutcomeType,
-  getOutcomeTypesForOutcome
+  getOutcomeTypesForOutcome,
+  getFirstQuestionRoute,
+  hasQuestion,
+  hasOutcome
 } from '../src/server/journey/self-service/services/journey-data.js'
 import { classifyOutcome } from '../src/server/journey/self-service/outcome/utils.js'
+import {
+  shortestPath,
+  reach,
+  predecessors
+} from './journey-graph.js'
 
 const EXCERPT_LEN = 60
 const MAX_TEXT_FOR_STRIP = 10000
@@ -332,6 +340,64 @@ function runMappings(json) {
   return { stdout: lines.join('\n'), code: 0 }
 }
 
+function formatPathHuman(from, to, steps) {
+  const lines = [`Path ${from} -> ${to} (${steps.length} steps)`, '']
+  for (const step of steps) {
+    const head = step.fromText
+      ? `Q ${step.from}\t${step.fromText}`
+      : `[outcome ${step.from}]`
+    lines.push(head)
+    lines.push(`  -> ${step.label}\t==> ${step.kind} ${step.to}`)
+  }
+  return lines.join('\n')
+}
+
+function runPath(from, to, json) {
+  const steps = shortestPath(to, { from })
+  if (steps === null) {
+    if (json) {
+      return {
+        stdout: JSON.stringify({ from, to, found: false, steps: [] }, null, 2),
+        code: 1
+      }
+    }
+    return { stdout: `No path from ${from} to ${to}`, code: 1 }
+  }
+  if (json) {
+    return {
+      stdout: JSON.stringify({ from, to, found: true, steps }, null, 2),
+      code: 0
+    }
+  }
+  return { stdout: formatPathHuman(from, to, steps), code: 0 }
+}
+
+function runReach(route, json) {
+  const reachable = reach(route)
+  const code = reachable ? 0 : 1
+  if (json) {
+    return { stdout: JSON.stringify({ route, reachable }, null, 2), code }
+  }
+  return {
+    stdout: reachable ? `reachable: ${route}` : `not reachable: ${route}`,
+    code
+  }
+}
+
+function runPredecessors(route, json) {
+  if (!hasQuestion(route) && !hasOutcome(route)) {
+    return { stdout: `Route not found: ${route}`, code: 1 }
+  }
+  const callers = predecessors(route)
+  if (json) {
+    return { stdout: JSON.stringify(callers, null, 2), code: 0 }
+  }
+  if (callers.length === 0) {
+    return { stdout: '(no predecessors — entry point or orphaned)', code: 0 }
+  }
+  return { stdout: callers.map((c) => `${c.route}\t${c.via}`).join('\n'), code: 0 }
+}
+
 function parseSingleArg(rest, usage) {
   const { values, positionals } = parseArgs({
     args: rest,
@@ -445,6 +511,43 @@ function dispatchMappings(rest) {
   return runMappings(values.json)
 }
 
+function dispatchPath(rest) {
+  const { values, positionals } = parseArgs({
+    args: rest,
+    options: { json: { type: 'boolean', default: false } },
+    allowPositionals: true
+  })
+  if (positionals.length === 0) {
+    return {
+      stdout: 'Usage: iat-query path <to> | path <from> <to> [--json]',
+      code: 2
+    }
+  }
+  const hasFrom = positionals.length > 1
+  const from = hasFrom ? positionals[0] : getFirstQuestionRoute()
+  const to = hasFrom ? positionals[1] : positionals[0]
+  return runPath(from, to, values.json)
+}
+
+function dispatchReach(rest) {
+  const parsed = parseSingleArg(rest, 'Usage: iat-query reach <route> [--json]')
+  if (parsed.error) {
+    return parsed.error
+  }
+  return runReach(parsed.arg, parsed.json)
+}
+
+function dispatchPredecessors(rest) {
+  const parsed = parseSingleArg(
+    rest,
+    'Usage: iat-query predecessors <route> [--json]'
+  )
+  if (parsed.error) {
+    return parsed.error
+  }
+  return runPredecessors(parsed.arg, parsed.json)
+}
+
 const DISPATCH = {
   question: dispatchQuestion,
   outcome: dispatchOutcome,
@@ -452,7 +555,10 @@ const DISPATCH = {
   outcomes: dispatchOutcomes,
   'outcome-types': dispatchOutcomeTypes,
   questions: dispatchQuestions,
-  mappings: dispatchMappings
+  mappings: dispatchMappings,
+  path: dispatchPath,
+  reach: dispatchReach,
+  predecessors: dispatchPredecessors
 }
 
 export function runCommand(argv) {

--- a/scripts/iat-query.js
+++ b/scripts/iat-query.js
@@ -43,17 +43,22 @@ import {
   getQuestion,
   getOutcome,
   getOutcomeType,
-  getOutcomeTypesForOutcome,
-  getFirstQuestionRoute,
-  hasQuestion,
-  hasOutcome
+  getOutcomeTypesForOutcome
 } from '../src/server/journey/self-service/services/journey-data.js'
 import { classifyOutcome } from '../src/server/journey/self-service/outcome/utils.js'
-import { calculateNextRoute } from '../src/server/journey/self-service/services/journey-router.js'
-import { shortestPath, reach, predecessors } from './journey-graph.js'
-
-const EXCERPT_LEN = 60
-const MAX_TEXT_FOR_STRIP = 10000
+import {
+  excerpt,
+  dash,
+  paramsFlat,
+  targetForAnswer,
+  parseSingleArg,
+  parseHasParam
+} from './iat-utils.js'
+import {
+  dispatchPath,
+  dispatchReach,
+  dispatchPredecessors
+} from './iat-graph-commands.js'
 
 const USAGE = `iat-query — inspect the self-service IAT journey (self-service.json)
 
@@ -76,43 +81,6 @@ outcome forks (outcomeType.nextQuestionRoute). All documented in:
   src/server/journey/self-service/data/README.data.md
 
 Add --json to any subcommand for machine-readable output.`
-
-function excerpt(text) {
-  if (!text) {
-    return '-'
-  }
-  const bounded =
-    text.length > MAX_TEXT_FOR_STRIP ? text.slice(0, MAX_TEXT_FOR_STRIP) : text
-  const stripped = bounded.replaceAll(/<[^>]+>/g, '').trim()
-  if (stripped.length <= EXCERPT_LEN) {
-    return stripped
-  }
-  return stripped.slice(0, EXCERPT_LEN) + '…'
-}
-
-function dash(value) {
-  if (value === null || value === undefined || value === '') {
-    return '-'
-  }
-  return String(value)
-}
-
-function targetForAnswer(answer, question) {
-  try {
-    const next = calculateNextRoute(question, [answer.id])
-    return `${next.type} ${next.route}`
-  } catch {
-    return 'terminal'
-  }
-}
-
-function paramsFlat(outcomeType) {
-  const params = outcomeType.params
-  if (!params || params.length === 0) {
-    return '-'
-  }
-  return params.map((p) => `${p.name}=${p.value}`).join(' ')
-}
 
 function runQuestion(route, json) {
   const q = getQuestion(route)
@@ -278,17 +246,6 @@ function runOutcomes(flags, json) {
   return { stdout: lines.join('\n'), code: 0 }
 }
 
-function parseHasParam(hasParam) {
-  if (!hasParam) {
-    return { name: null, value: null }
-  }
-  const eqIdx = hasParam.indexOf('=')
-  if (eqIdx === -1) {
-    return { name: hasParam, value: null }
-  }
-  return { name: hasParam.slice(0, eqIdx), value: hasParam.slice(eqIdx + 1) }
-}
-
 function runOutcomeTypes(flags, json) {
   const { hasParam, hasNextQuestion, hasLink } = flags
   const { name: paramName, value: paramValue } = parseHasParam(hasParam)
@@ -361,80 +318,6 @@ function runMappings(json) {
     (key) => `${key}\t${mappingMap.get(key).join(',')}`
   )
   return { stdout: lines.join('\n'), code: 0 }
-}
-
-function formatPathHuman(from, to, steps) {
-  const lines = [`Path ${from} -> ${to} (${steps.length} steps)`, '']
-  for (const step of steps) {
-    const head = step.fromText
-      ? `Q ${step.from}\t${step.fromText}`
-      : `[outcome ${step.from}]`
-    lines.push(head)
-    lines.push(`  -> ${step.label}\t==> ${step.kind} ${step.to}`)
-  }
-  return lines.join('\n')
-}
-
-function runPath(from, to, json) {
-  const steps = shortestPath(to, { from })
-  if (steps === null) {
-    if (json) {
-      return {
-        stdout: JSON.stringify({ from, to, found: false, steps: [] }, null, 2),
-        code: 1
-      }
-    }
-    return { stdout: `No path from ${from} to ${to}`, code: 1 }
-  }
-  if (json) {
-    return {
-      stdout: JSON.stringify({ from, to, found: true, steps }, null, 2),
-      code: 0
-    }
-  }
-  return { stdout: formatPathHuman(from, to, steps), code: 0 }
-}
-
-function runReach(route, json) {
-  const reachable = reach(route)
-  const code = reachable ? 0 : 1
-  if (json) {
-    return { stdout: JSON.stringify({ route, reachable }, null, 2), code }
-  }
-  return {
-    stdout: reachable ? `reachable: ${route}` : `not reachable: ${route}`,
-    code
-  }
-}
-
-function runPredecessors(route, json) {
-  if (!hasQuestion(route) && !hasOutcome(route)) {
-    return { stdout: `Route not found: ${route}`, code: 1 }
-  }
-  const callers = predecessors(route)
-  if (json) {
-    return { stdout: JSON.stringify(callers, null, 2), code: 0 }
-  }
-  if (callers.length === 0) {
-    return { stdout: '(no predecessors — entry point or orphaned)', code: 0 }
-  }
-  return {
-    stdout: callers.map((c) => `${c.route}\t${c.via}`).join('\n'),
-    code: 0
-  }
-}
-
-function parseSingleArg(rest, usage) {
-  const { values, positionals } = parseArgs({
-    args: rest,
-    options: { json: { type: 'boolean', default: false } },
-    allowPositionals: true
-  })
-  const arg = positionals[0]
-  if (!arg) {
-    return { error: { stdout: usage, code: 2 } }
-  }
-  return { arg, json: values.json }
 }
 
 function dispatchQuestion(rest) {
@@ -535,43 +418,6 @@ function dispatchMappings(rest) {
     allowPositionals: false
   })
   return runMappings(values.json)
-}
-
-function dispatchPath(rest) {
-  const { values, positionals } = parseArgs({
-    args: rest,
-    options: { json: { type: 'boolean', default: false } },
-    allowPositionals: true
-  })
-  if (positionals.length === 0) {
-    return {
-      stdout: 'Usage: iat-query path <to> | path <from> <to> [--json]',
-      code: 2
-    }
-  }
-  const hasFrom = positionals.length > 1
-  const from = hasFrom ? positionals[0] : getFirstQuestionRoute()
-  const to = hasFrom ? positionals[1] : positionals[0]
-  return runPath(from, to, values.json)
-}
-
-function dispatchReach(rest) {
-  const parsed = parseSingleArg(rest, 'Usage: iat-query reach <route> [--json]')
-  if (parsed.error) {
-    return parsed.error
-  }
-  return runReach(parsed.arg, parsed.json)
-}
-
-function dispatchPredecessors(rest) {
-  const parsed = parseSingleArg(
-    rest,
-    'Usage: iat-query predecessors <route> [--json]'
-  )
-  if (parsed.error) {
-    return parsed.error
-  }
-  return runPredecessors(parsed.arg, parsed.json)
 }
 
 const DISPATCH = {

--- a/scripts/iat-query.test.js
+++ b/scripts/iat-query.test.js
@@ -292,10 +292,16 @@ describe('iat-query', () => {
       expect(stdout).toContain('/mod-permission')
     })
 
-    it('accepts an explicit from and to', () => {
-      const { stdout, code } = runCommand(['path', '/sea', '/fast-track-mla'])
+    it('accepts an explicit from below /sea and uses it as the start', () => {
+      const { stdout, code } = runCommand([
+        'path',
+        '/jurisdiction',
+        '/fast-track-mla'
+      ])
       expect(code).toBe(0)
       expect(stdout).toContain('/fast-track-mla')
+      // started at the explicit from, not the default /sea
+      expect(stdout).toContain('Path /jurisdiction -> /fast-track-mla')
     })
 
     it('exits 1 when the target is unreachable', () => {
@@ -314,11 +320,15 @@ describe('iat-query', () => {
   })
 
   describe('reach', () => {
-    it('exits 0 for a reachable route', () => {
-      expect(runCommand(['reach', '/mod-permission']).code).toBe(0)
+    it('exits 0 and reports reachable for a reachable route', () => {
+      const { stdout, code } = runCommand(['reach', '/mod-permission'])
+      expect(code).toBe(0)
+      expect(stdout).toContain('reachable: /mod-permission')
     })
-    it('exits 1 for an unreachable route', () => {
-      expect(runCommand(['reach', '/no-such-route']).code).toBe(1)
+    it('exits 1 and reports not reachable for an unreachable route', () => {
+      const { stdout, code } = runCommand(['reach', '/no-such-route'])
+      expect(code).toBe(1)
+      expect(stdout).toContain('not reachable: /no-such-route')
     })
   })
 

--- a/scripts/iat-query.test.js
+++ b/scripts/iat-query.test.js
@@ -309,6 +309,12 @@ describe('iat-query', () => {
       expect(code).toBe(1)
     })
 
+    it('exits 2 with usage when no target is given', () => {
+      const { stdout, code } = runCommand(['path'])
+      expect(code).toBe(2)
+      expect(stdout).toContain('Usage: iat-query path')
+    })
+
     it('--json emits found and an ordered steps array', () => {
       const { stdout, code } = runCommand(['path', '/mod-permission', '--json'])
       expect(code).toBe(0)
@@ -330,6 +336,17 @@ describe('iat-query', () => {
       expect(code).toBe(1)
       expect(stdout).toContain('not reachable: /no-such-route')
     })
+
+    it('--json emits route and reachable boolean', () => {
+      const { stdout, code } = runCommand([
+        'reach',
+        '/mod-permission',
+        '--json'
+      ])
+      expect(code).toBe(0)
+      const parsed = JSON.parse(stdout)
+      expect(parsed).toEqual({ route: '/mod-permission', reachable: true })
+    })
   })
 
   describe('predecessors', () => {
@@ -343,6 +360,25 @@ describe('iat-query', () => {
     })
     it('exits 1 for an unknown route', () => {
       expect(runCommand(['predecessors', '/no-such-route']).code).toBe(1)
+    })
+
+    it('reports no predecessors for the entry point /sea', () => {
+      const { stdout, code } = runCommand(['predecessors', '/sea'])
+      expect(code).toBe(0)
+      expect(stdout).toContain('no predecessors')
+    })
+
+    it('--json emits an array of { route, via } callers', () => {
+      const { stdout, code } = runCommand([
+        'predecessors',
+        '/military-defence-area',
+        '--json'
+      ])
+      expect(code).toBe(0)
+      const parsed = JSON.parse(stdout)
+      expect(Array.isArray(parsed)).toBe(true)
+      expect(parsed.some((c) => c.route === '/single-location')).toBe(true)
+      expect(parsed[0]).toHaveProperty('via')
     })
   })
 

--- a/scripts/iat-query.test.js
+++ b/scripts/iat-query.test.js
@@ -333,6 +333,23 @@ describe('iat-query', () => {
     })
   })
 
+  describe('multi-select question view', () => {
+    it('shows the multi-select routing targets instead of terminal', () => {
+      const { stdout, code } = runCommand(['question', '/dredging/activities'])
+      expect(code).toBe(0)
+      expect(stdout).toContain('/activity/completion')
+      expect(stdout).toContain('/standard-marine-licence-application/other-clearance-dredging')
+    })
+
+    it('--json answer targets reflect multi-select routing', () => {
+      const { stdout } = runCommand(['question', '/dredging/activities', '--json'])
+      const parsed = JSON.parse(stdout)
+      const targets = parsed.answers.map((a) => a.target)
+      expect(targets).not.toContain('terminal')
+      expect(targets.some((t) => t.includes('/activity/completion'))).toBe(true)
+    })
+  })
+
   describe('error handling', () => {
     it('exits 2 for unknown subcommand', () => {
       const { stdout, code } = runCommand(['nonexistent'])

--- a/scripts/iat-query.test.js
+++ b/scripts/iat-query.test.js
@@ -284,6 +284,55 @@ describe('iat-query', () => {
     })
   })
 
+  describe('path', () => {
+    it('prints a shortest journey from /sea to a deep page', () => {
+      const { stdout, code } = runCommand(['path', '/mod-permission'])
+      expect(code).toBe(0)
+      expect(stdout).toContain('/sea')
+      expect(stdout).toContain('/mod-permission')
+    })
+
+    it('accepts an explicit from and to', () => {
+      const { stdout, code } = runCommand(['path', '/sea', '/fast-track-mla'])
+      expect(code).toBe(0)
+      expect(stdout).toContain('/fast-track-mla')
+    })
+
+    it('exits 1 when the target is unreachable', () => {
+      const { code } = runCommand(['path', '/no-such-route'])
+      expect(code).toBe(1)
+    })
+
+    it('--json emits found and an ordered steps array', () => {
+      const { stdout, code } = runCommand(['path', '/mod-permission', '--json'])
+      expect(code).toBe(0)
+      const parsed = JSON.parse(stdout)
+      expect(parsed.found).toBe(true)
+      expect(Array.isArray(parsed.steps)).toBe(true)
+      expect(parsed.steps.at(-1).to).toBe('/mod-permission')
+    })
+  })
+
+  describe('reach', () => {
+    it('exits 0 for a reachable route', () => {
+      expect(runCommand(['reach', '/mod-permission']).code).toBe(0)
+    })
+    it('exits 1 for an unreachable route', () => {
+      expect(runCommand(['reach', '/no-such-route']).code).toBe(1)
+    })
+  })
+
+  describe('predecessors', () => {
+    it('lists direct callers of a page', () => {
+      const { stdout, code } = runCommand(['predecessors', '/military-defence-area'])
+      expect(code).toBe(0)
+      expect(stdout).toContain('/single-location')
+    })
+    it('exits 1 for an unknown route', () => {
+      expect(runCommand(['predecessors', '/no-such-route']).code).toBe(1)
+    })
+  })
+
   describe('error handling', () => {
     it('exits 2 for unknown subcommand', () => {
       const { stdout, code } = runCommand(['nonexistent'])

--- a/scripts/iat-query.test.js
+++ b/scripts/iat-query.test.js
@@ -334,7 +334,10 @@ describe('iat-query', () => {
 
   describe('predecessors', () => {
     it('lists direct callers of a page', () => {
-      const { stdout, code } = runCommand(['predecessors', '/military-defence-area'])
+      const { stdout, code } = runCommand([
+        'predecessors',
+        '/military-defence-area'
+      ])
       expect(code).toBe(0)
       expect(stdout).toContain('/single-location')
     })
@@ -348,11 +351,17 @@ describe('iat-query', () => {
       const { stdout, code } = runCommand(['question', '/dredging/activities'])
       expect(code).toBe(0)
       expect(stdout).toContain('/activity/completion')
-      expect(stdout).toContain('/standard-marine-licence-application/other-clearance-dredging')
+      expect(stdout).toContain(
+        '/standard-marine-licence-application/other-clearance-dredging'
+      )
     })
 
     it('--json answer targets reflect multi-select routing', () => {
-      const { stdout } = runCommand(['question', '/dredging/activities', '--json'])
+      const { stdout } = runCommand([
+        'question',
+        '/dredging/activities',
+        '--json'
+      ])
       const parsed = JSON.parse(stdout)
       const targets = parsed.answers.map((a) => a.target)
       expect(targets).not.toContain('terminal')

--- a/scripts/iat-query.test.js
+++ b/scripts/iat-query.test.js
@@ -350,6 +350,15 @@ describe('iat-query', () => {
     })
   })
 
+  describe('usage', () => {
+    it('no subcommand prints self-teaching usage pointing at path and the README', () => {
+      const { stdout, code } = runCommand([])
+      expect(code).toBe(2)
+      expect(stdout).toContain('path')
+      expect(stdout).toContain('README.data.md')
+    })
+  })
+
   describe('error handling', () => {
     it('exits 2 for unknown subcommand', () => {
       const { stdout, code } = runCommand(['nonexistent'])

--- a/scripts/iat-query.test.js
+++ b/scripts/iat-query.test.js
@@ -288,8 +288,18 @@ describe('iat-query', () => {
     it('prints a shortest journey from /sea to a deep page', () => {
       const { stdout, code } = runCommand(['path', '/mod-permission'])
       expect(code).toBe(0)
-      expect(stdout).toContain('/sea')
-      expect(stdout).toContain('/mod-permission')
+      const lines = stdout.split('\n')
+      // one bullet per step: "- <route> → <choice>"; last line appends the target
+      expect(lines[0]).toMatch(/^- \/sea → /)
+      expect(lines.at(-1)).toMatch(/→ \/mod-permission$/)
+      // intermediate-outcome forks render as "Continue"
+      expect(stdout).toContain(
+        '- /exemption/dredging-exe-not-available-continue → Continue'
+      )
+      // multi-select renders the tick choice without quotes
+      expect(stdout).toContain(
+        '- /dredging/activities → tick any activity except OTHER_CLEARANCE_DREDGING'
+      )
     })
 
     it('accepts an explicit from below /sea and uses it as the start', () => {
@@ -299,9 +309,10 @@ describe('iat-query', () => {
         '/fast-track-mla'
       ])
       expect(code).toBe(0)
-      expect(stdout).toContain('/fast-track-mla')
+      const lines = stdout.split('\n')
       // started at the explicit from, not the default /sea
-      expect(stdout).toContain('Path /jurisdiction -> /fast-track-mla')
+      expect(lines[0]).toMatch(/^- \/jurisdiction → /)
+      expect(lines.at(-1)).toMatch(/→ \/fast-track-mla$/)
     })
 
     it('exits 1 when the target is unreachable', () => {

--- a/scripts/iat-utils.js
+++ b/scripts/iat-utils.js
@@ -1,0 +1,70 @@
+/**
+ * Shared formatting and argument-parsing helpers for the IAT query CLI.
+ */
+
+import { parseArgs } from 'node:util'
+import { calculateNextRoute } from '../src/server/journey/self-service/services/journey-router.js'
+
+const EXCERPT_LEN = 60
+const MAX_TEXT_FOR_STRIP = 10000
+
+export function excerpt(text) {
+  if (!text) {
+    return '-'
+  }
+  const bounded =
+    text.length > MAX_TEXT_FOR_STRIP ? text.slice(0, MAX_TEXT_FOR_STRIP) : text
+  const stripped = bounded.replaceAll(/<[^>]+>/g, '').trim()
+  if (stripped.length <= EXCERPT_LEN) {
+    return stripped
+  }
+  return stripped.slice(0, EXCERPT_LEN) + '…'
+}
+
+export function dash(value) {
+  if (value === null || value === undefined || value === '') {
+    return '-'
+  }
+  return String(value)
+}
+
+export function targetForAnswer(answer, question) {
+  try {
+    const next = calculateNextRoute(question, [answer.id])
+    return `${next.type} ${next.route}`
+  } catch {
+    return 'terminal'
+  }
+}
+
+export function paramsFlat(outcomeType) {
+  const params = outcomeType.params
+  if (!params || params.length === 0) {
+    return '-'
+  }
+  return params.map((p) => `${p.name}=${p.value}`).join(' ')
+}
+
+export function parseSingleArg(rest, usage) {
+  const { values, positionals } = parseArgs({
+    args: rest,
+    options: { json: { type: 'boolean', default: false } },
+    allowPositionals: true
+  })
+  const arg = positionals[0]
+  if (!arg) {
+    return { error: { stdout: usage, code: 2 } }
+  }
+  return { arg, json: values.json }
+}
+
+export function parseHasParam(hasParam) {
+  if (!hasParam) {
+    return { name: null, value: null }
+  }
+  const eqIdx = hasParam.indexOf('=')
+  if (eqIdx === -1) {
+    return { name: hasParam, value: null }
+  }
+  return { name: hasParam.slice(0, eqIdx), value: hasParam.slice(eqIdx + 1) }
+}

--- a/scripts/iat-utils.js
+++ b/scripts/iat-utils.js
@@ -4,6 +4,23 @@ import { calculateNextRoute } from '../src/server/journey/self-service/services/
 const EXCERPT_LEN = 60
 const MAX_TEXT_FOR_STRIP = 10000
 
+export const JSON_FLAG = { type: 'boolean', default: false }
+
+export function jsonResult(value, code = 0) {
+  return { stdout: JSON.stringify(value, null, 2), code }
+}
+
+export function notFound(label, id) {
+  return { stdout: `${label} not found: ${id}`, code: 1 }
+}
+
+const KEY_VALUE_GAP = 2
+
+export function alignKeyValues(rows) {
+  const width = Math.max(...rows.map(([key]) => key.length)) + KEY_VALUE_GAP
+  return rows.map(([key, value]) => `${key.padEnd(width)}${value}`)
+}
+
 export function excerpt(text) {
   if (!text) {
     return '-'
@@ -41,10 +58,10 @@ export function paramsFlat(outcomeType) {
   return params.map((p) => `${p.name}=${p.value}`).join(' ')
 }
 
-export function parseSingleArg(rest, usage) {
+function parseSingleArg(rest, usage) {
   const { values, positionals } = parseArgs({
     args: rest,
-    options: { json: { type: 'boolean', default: false } },
+    options: { json: JSON_FLAG },
     allowPositionals: true
   })
   const arg = positionals[0]
@@ -52,6 +69,14 @@ export function parseSingleArg(rest, usage) {
     return { error: { stdout: usage, code: 2 } }
   }
   return { arg, json: values.json }
+}
+
+export function runSingleArg(rest, usage, run) {
+  const parsed = parseSingleArg(rest, usage)
+  if (parsed.error) {
+    return parsed.error
+  }
+  return run(parsed.arg, parsed.json)
 }
 
 export function parseHasParam(hasParam) {

--- a/scripts/iat-utils.js
+++ b/scripts/iat-utils.js
@@ -1,7 +1,3 @@
-/**
- * Shared formatting and argument-parsing helpers for the IAT query CLI.
- */
-
 import { parseArgs } from 'node:util'
 import { calculateNextRoute } from '../src/server/journey/self-service/services/journey-router.js'
 

--- a/scripts/journey-graph.js
+++ b/scripts/journey-graph.js
@@ -1,7 +1,8 @@
 import {
   getQuestion,
   getOutcome,
-  getOutcomeTypesForOutcome
+  getOutcomeTypesForOutcome,
+  getFirstQuestionRoute
 } from '../src/server/journey/self-service/services/journey-data.js'
 import { calculateNextRoute } from '../src/server/journey/self-service/services/journey-router.js'
 
@@ -78,4 +79,49 @@ export function edgesFrom(route) {
     return outcomeForkEdges(outcome)
   }
   return []
+}
+
+function reconstruct(prev, to) {
+  const steps = []
+  let cursor = to
+  while (prev.get(cursor)) {
+    const { from, edge } = prev.get(cursor)
+    const question = getQuestion(from)
+    steps.unshift({
+      from,
+      fromText: question ? question.text : null,
+      label: edge.label,
+      to: edge.to,
+      kind: edge.kind
+    })
+    cursor = from
+  }
+  return steps
+}
+
+export function shortestPath(to, options = {}) {
+  const from = options.from ?? getFirstQuestionRoute()
+  if (from === to) {
+    return []
+  }
+  const prev = new Map([[from, null]])
+  const queue = [from]
+  while (queue.length > 0) {
+    const node = queue.shift()
+    for (const edge of edgesFrom(node)) {
+      if (prev.has(edge.to)) {
+        continue
+      }
+      prev.set(edge.to, { from: node, edge })
+      if (edge.to === to) {
+        return reconstruct(prev, to)
+      }
+      queue.push(edge.to)
+    }
+  }
+  return null
+}
+
+export function reach(to, options = {}) {
+  return shortestPath(to, options) !== null
 }

--- a/scripts/journey-graph.js
+++ b/scripts/journey-graph.js
@@ -1,4 +1,5 @@
 import {
+  getJourneyData,
   getQuestion,
   getOutcome,
   getOutcomeTypesForOutcome,
@@ -124,4 +125,21 @@ export function shortestPath(to, options = {}) {
 
 export function reach(to, options = {}) {
   return shortestPath(to, options) !== null
+}
+
+export function predecessors(route) {
+  const data = getJourneyData()
+  const nodes = [
+    ...data.questions.map((q) => q.route),
+    ...data.outcomes.map((o) => o.route)
+  ]
+  const callers = []
+  for (const node of nodes) {
+    for (const edge of edgesFrom(node)) {
+      if (edge.to === route) {
+        callers.push({ route: node, via: edge.label })
+      }
+    }
+  }
+  return callers
 }

--- a/scripts/journey-graph.js
+++ b/scripts/journey-graph.js
@@ -84,9 +84,9 @@ export function edgesFrom(route) {
 
 function reconstruct(prev, to) {
   const steps = []
-  let cursor = to
-  while (prev.get(cursor)) {
-    const { from, edge } = prev.get(cursor)
+  let entry = prev.get(to)
+  while (entry) {
+    const { from, edge } = entry
     const question = getQuestion(from)
     steps.unshift({
       from,
@@ -95,7 +95,7 @@ function reconstruct(prev, to) {
       to: edge.to,
       kind: edge.kind
     })
-    cursor = from
+    entry = prev.get(from)
   }
   return steps
 }

--- a/scripts/journey-graph.js
+++ b/scripts/journey-graph.js
@@ -1,0 +1,81 @@
+import {
+  getQuestion,
+  getOutcome,
+  getOutcomeTypesForOutcome
+} from '../src/server/journey/self-service/services/journey-data.js'
+import { calculateNextRoute } from '../src/server/journey/self-service/services/journey-router.js'
+
+const HEADING_LEN = 50
+
+function truncate(text) {
+  if (!text) {
+    return ''
+  }
+  return text.length > HEADING_LEN ? text.slice(0, HEADING_LEN) + '…' : text
+}
+
+function safeNext(question, ids) {
+  try {
+    return calculateNextRoute(question, ids)
+  } catch {
+    return null
+  }
+}
+
+function multiSelectEdges(question) {
+  const { outcomeAnswerId } = question.multiSelect
+  const edges = []
+  const other = question.answers.find((a) => a.id !== outcomeAnswerId)
+  if (other) {
+    const next = safeNext(question, [other.id])
+    if (next) {
+      edges.push({
+        label: `tick any activity except "${outcomeAnswerId}"`,
+        to: next.route,
+        kind: next.type
+      })
+    }
+  }
+  const special = safeNext(question, [outcomeAnswerId])
+  if (special) {
+    edges.push({ label: `tick "${outcomeAnswerId}"`, to: special.route, kind: special.type })
+  }
+  return edges
+}
+
+function singleSelectEdges(question) {
+  const edges = []
+  for (const answer of question.answers) {
+    const next = safeNext(question, [answer.id])
+    if (next) {
+      edges.push({ label: `answer "${answer.text}"`, to: next.route, kind: next.type })
+    }
+  }
+  return edges
+}
+
+function outcomeForkEdges(outcome) {
+  const edges = []
+  for (const ot of getOutcomeTypesForOutcome(outcome)) {
+    if (ot.nextQuestionRoute) {
+      edges.push({
+        label: `continue: "${truncate(ot.heading)}"`,
+        to: ot.nextQuestionRoute,
+        kind: 'question'
+      })
+    }
+  }
+  return edges
+}
+
+export function edgesFrom(route) {
+  const question = getQuestion(route)
+  if (question) {
+    return question.multiSelect ? multiSelectEdges(question) : singleSelectEdges(question)
+  }
+  const outcome = getOutcome(route)
+  if (outcome) {
+    return outcomeForkEdges(outcome)
+  }
+  return []
+}

--- a/scripts/journey-graph.js
+++ b/scripts/journey-graph.js
@@ -40,7 +40,11 @@ function multiSelectEdges(question) {
   }
   const special = safeNext(question, [outcomeAnswerId])
   if (special) {
-    edges.push({ label: `tick "${outcomeAnswerId}"`, to: special.route, kind: special.type })
+    edges.push({
+      label: `tick "${outcomeAnswerId}"`,
+      to: special.route,
+      kind: special.type
+    })
   }
   return edges
 }
@@ -50,7 +54,11 @@ function singleSelectEdges(question) {
   for (const answer of question.answers) {
     const next = safeNext(question, [answer.id])
     if (next) {
-      edges.push({ label: `answer "${answer.text}"`, to: next.route, kind: next.type })
+      edges.push({
+        label: `answer "${answer.text}"`,
+        to: next.route,
+        kind: next.type
+      })
     }
   }
   return edges
@@ -73,7 +81,9 @@ function outcomeForkEdges(outcome) {
 export function edgesFrom(route) {
   const question = getQuestion(route)
   if (question) {
-    return question.multiSelect ? multiSelectEdges(question) : singleSelectEdges(question)
+    return question.multiSelect
+      ? multiSelectEdges(question)
+      : singleSelectEdges(question)
   }
   const outcome = getOutcome(route)
   if (outcome) {

--- a/scripts/journey-graph.test.js
+++ b/scripts/journey-graph.test.js
@@ -10,11 +10,15 @@ describe('journey-graph edgesFrom', () => {
   it('follows multi-select routing instead of treating answers as terminal', () => {
     const targets = edgesFrom('/dredging/activities').map((e) => e.to)
     expect(targets).toContain('/activity/completion')
-    expect(targets).toContain('/standard-marine-licence-application/other-clearance-dredging')
+    expect(targets).toContain(
+      '/standard-marine-licence-application/other-clearance-dredging'
+    )
   })
 
   it('follows outcome-fork (intermediate outcome) nextQuestionRoute', () => {
-    const targets = edgesFrom('/exemption/dredging-exe-not-available-continue').map((e) => e.to)
+    const targets = edgesFrom(
+      '/exemption/dredging-exe-not-available-continue'
+    ).map((e) => e.to)
     expect(targets).toContain('/dredging/activity')
   })
 

--- a/scripts/journey-graph.test.js
+++ b/scripts/journey-graph.test.js
@@ -7,10 +7,23 @@ import {
 } from './journey-graph.js'
 
 describe('journey-graph edgesFrom', () => {
-  it('follows multi-select routing instead of treating answers as terminal', () => {
-    const targets = edgesFrom('/dredging/activities').map((e) => e.to)
-    expect(targets).toContain('/activity/completion')
-    expect(targets).toContain(
+  it('models a multi-select page as exactly two labelled tick branches', () => {
+    // multiSelectEdges produces precisely two edges with "tick …" labels — one
+    // edge per checkbox would be the single-select fallback. Pinning the count
+    // and labels here is the real regression guard: delete multiSelectEdges and
+    // edgesFrom falls through to singleSelectEdges (which still resolves the
+    // same .to targets via the router), so only this assertion catches it.
+    const edges = edgesFrom('/dredging/activities')
+    expect(edges).toHaveLength(2)
+
+    const tickAny = edges.find((e) =>
+      e.label.startsWith('tick any activity except')
+    )
+    const tickOther = edges.find(
+      (e) => e.label === 'tick "OTHER_CLEARANCE_DREDGING"'
+    )
+    expect(tickAny?.to).toBe('/activity/completion')
+    expect(tickOther?.to).toBe(
       '/standard-marine-licence-application/other-clearance-dredging'
     )
   })

--- a/scripts/journey-graph.test.js
+++ b/scripts/journey-graph.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { edgesFrom } from './journey-graph.js'
+import { shortestPath, reach } from './journey-graph.js'
 
 describe('journey-graph edgesFrom', () => {
   it('follows multi-select routing instead of treating answers as terminal', () => {
@@ -20,5 +21,39 @@ describe('journey-graph edgesFrom', () => {
 
   it('returns no edges for an unknown route', () => {
     expect(edgesFrom('/no-such-route')).toEqual([])
+  })
+})
+
+describe('journey-graph shortestPath', () => {
+  it('reaches /mod-permission from /sea via the multi-select bridge', () => {
+    const steps = shortestPath('/mod-permission')
+    expect(steps).not.toBeNull()
+    expect(steps[0].from).toBe('/sea')
+    expect(steps.at(-1).to).toBe('/mod-permission')
+    // regression guard: without multi-select edges this page is unreachable
+    expect(steps.some((s) => s.to === '/activity/completion')).toBe(true)
+  })
+
+  it('reaches the self-service grant /fast-track-mla from /sea', () => {
+    const steps = shortestPath('/fast-track-mla')
+    expect(steps).not.toBeNull()
+    expect(steps.at(-1).to).toBe('/fast-track-mla')
+  })
+
+  it('returns null for an unreachable route', () => {
+    expect(shortestPath('/no-such-route')).toBeNull()
+  })
+
+  it('returns an empty path when from === to', () => {
+    expect(shortestPath('/sea', { from: '/sea' })).toEqual([])
+  })
+})
+
+describe('journey-graph reach', () => {
+  it('is true for a deep reachable page', () => {
+    expect(reach('/mod-permission')).toBe(true)
+  })
+  it('is false for an unknown route', () => {
+    expect(reach('/no-such-route')).toBe(false)
   })
 })

--- a/scripts/journey-graph.test.js
+++ b/scripts/journey-graph.test.js
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { edgesFrom } from './journey-graph.js'
 import { shortestPath, reach } from './journey-graph.js'
+import { predecessors } from './journey-graph.js'
 
 describe('journey-graph edgesFrom', () => {
   it('follows multi-select routing instead of treating answers as terminal', () => {
@@ -55,5 +56,16 @@ describe('journey-graph reach', () => {
   })
   it('is false for an unknown route', () => {
     expect(reach('/no-such-route')).toBe(false)
+  })
+})
+
+describe('journey-graph predecessors', () => {
+  it('lists pages that route directly into /military-defence-area', () => {
+    const callers = predecessors('/military-defence-area').map((c) => c.route)
+    expect(callers).toContain('/single-location')
+  })
+
+  it('returns an empty array for the entry point /sea', () => {
+    expect(predecessors('/sea')).toEqual([])
   })
 })

--- a/scripts/journey-graph.test.js
+++ b/scripts/journey-graph.test.js
@@ -1,7 +1,10 @@
 import { describe, it, expect } from 'vitest'
-import { edgesFrom } from './journey-graph.js'
-import { shortestPath, reach } from './journey-graph.js'
-import { predecessors } from './journey-graph.js'
+import {
+  edgesFrom,
+  shortestPath,
+  reach,
+  predecessors
+} from './journey-graph.js'
 
 describe('journey-graph edgesFrom', () => {
   it('follows multi-select routing instead of treating answers as terminal', () => {

--- a/scripts/journey-graph.test.js
+++ b/scripts/journey-graph.test.js
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest'
+import { edgesFrom } from './journey-graph.js'
+
+describe('journey-graph edgesFrom', () => {
+  it('follows multi-select routing instead of treating answers as terminal', () => {
+    const targets = edgesFrom('/dredging/activities').map((e) => e.to)
+    expect(targets).toContain('/activity/completion')
+    expect(targets).toContain('/standard-marine-licence-application/other-clearance-dredging')
+  })
+
+  it('follows outcome-fork (intermediate outcome) nextQuestionRoute', () => {
+    const targets = edgesFrom('/exemption/dredging-exe-not-available-continue').map((e) => e.to)
+    expect(targets).toContain('/dredging/activity')
+  })
+
+  it('emits one edge per answer for a single-select question', () => {
+    const targets = edgesFrom('/sea').map((e) => e.to)
+    expect(targets).toContain('/jurisdiction')
+  })
+
+  it('returns no edges for an unknown route', () => {
+    expect(edgesFrom('/no-such-route')).toEqual([])
+  })
+})

--- a/src/server/journey/README.md
+++ b/src/server/journey/README.md
@@ -9,8 +9,11 @@ decision-tree experience.
 
 The IAT is a decision tree that asks the user a series of questions
 about their activity and tells them what kind of licence or permission
-they need (if any). It is a lift-and-shift from the legacy Java
-application in `mmo/iat/iat-source-code/`.
+they need (if any). It is a port of the legacy Java application (Fivium
+MCMS), whose source and API spec live in `mmo/Fivium source code/iat/`.
+The persistence model was reworked during the port — see
+[`self-service/README.md`](./self-service/README.md) for the current
+context/snapshot design.
 
 The IAT is **temporarily hosted inside `marine-licensing-frontend`**.
 Once the port is complete and tested, it may move to its own
@@ -21,21 +24,30 @@ patterns, and avoid reaching into unrelated feature directories.
 
 ### Pages
 
-| URL                                            | Directory                | Ticket           |
-| ---------------------------------------------- | ------------------------ | ---------------- |
-| `/journey/self-service/start`                  | `self-service/start/`    | ML-1162          |
-| `/journey/self-service/outcome/{outcomePath*}` | `self-service/outcome/`  | ML-1164          |
-| `/journey/self-service/{questionPath*}`        | `self-service/question/` | ML-1186, ML-1269 |
+The walkthrough is slug-prefixed (`c/{slug}/…`) once started. The
+authoritative routes table — with methods and purpose — lives in
+[`self-service/README.md`](./self-service/README.md#routes). Summary:
 
-More terminal outcome pages will land under `self-service/outcome/` as
-follow-up tickets complete.
+| URL                                                     | Directory                        |
+| ------------------------------------------------------- | -------------------------------- |
+| `/journey/self-service/start`                           | `self-service/start/`            |
+| `/journey/self-service/invalid`                         | `self-service/invalid/`          |
+| `/journey/self-service/c/{slug}/{questionPath*}`        | `self-service/question/`         |
+| `/journey/self-service/c/{slug}/outcome/{outcomePath*}` | `self-service/outcome/`          |
+| `/journey/self-service/outcome-document/{slug}`         | `self-service/outcome-document/` |
+
+A read-only developer CLI (`npm run iat`) inspects the journey config — see
+[`self-service/README.iat-query.md`](./self-service/README.iat-query.md).
 
 ### Related tickets
 
 - **ML-1157** — spike / parent for the IAT port
 - **ML-1162** — IAT start page (this directory's first page)
 - **ML-1186** — wires the "Start now" button behaviour on the start page
-- Further tickets will add the question journey and outcome pages
+- The question journey, outcome pages, the View-answers snapshot model
+  (ML-1164/1165/1269/1304/1306) and the `npm run iat` tooling have since
+  landed. See the per-page tickets in
+  [`self-service/README.md`](./self-service/README.md#file-map).
 
 ## Conventions for files in this tree
 

--- a/src/server/journey/README.md
+++ b/src/server/journey/README.md
@@ -9,9 +9,8 @@ decision-tree experience.
 
 The IAT is a decision tree that asks the user a series of questions
 about their activity and tells them what kind of licence or permission
-they need (if any). It is a port of the legacy Java application (Fivium
-MCMS), whose source and API spec live in `mmo/Fivium source code/iat/`.
-The persistence model was reworked during the port — see
+they need (if any). It is a port of the legacy Fivium MCMS Java
+application. The persistence model was reworked during the port — see
 [`self-service/README.md`](./self-service/README.md) for the current
 context/snapshot design.
 

--- a/src/server/journey/self-service/README.iat-query.md
+++ b/src/server/journey/self-service/README.iat-query.md
@@ -1,0 +1,194 @@
+# IAT query CLI (`npm run iat`)
+
+A read-only developer CLI for inspecting the IAT journey defined in
+[`data/self-service.json`](./data/self-service.json). The file is large
+(~5000 lines) and relational — questions point at answers, answers route to
+other questions or outcomes, outcomes fan out into outcomeTypes, and
+outcomeTypes can route forward again. Hand-grepping or `jq`-ing it is
+error-prone, and it does not show you where a node actually leads at
+runtime.
+
+The CLI reuses the **same parsed/sanitised view the running app sees**
+([`services/journey-data.js`](./services/journey-data.js)) and the **real
+router** ([`services/journey-router.js`](./services/journey-router.js),
+`calculateNextRoute`). So "where does this answer go?" is computed exactly
+the way the live handler computes it — what you see matches what runs.
+
+This README is the home for the CLI. It is linked from the
+[top-level IAT README](./README.md). For the routing _rules_ the CLI
+surfaces (single-select, multi-select, outcome forks), see
+[`data/README.data.md`](./data/README.data.md).
+
+## Running
+
+```bash
+npm run iat                              # prints usage (exit 2)
+npm run iat -- <subcommand> [args] [--json]
+```
+
+- Always use the `npm run iat -- …` form (the `--` passes args through the
+  npm script). The bare `npm run iat` prints the usage banner.
+- Every subcommand accepts `--json` for machine-readable output.
+- **Exit codes:** `0` success · `1` not-found / unreachable · `2` invalid
+  args, unknown subcommand, or no subcommand. These make the CLI scriptable
+  — e.g. `npm run iat -- reach /some-page` returns `1` if a page is
+  orphaned.
+
+## Two command families
+
+### 1. Inspect / list a node
+
+Questions, outcomes and outcomeTypes by id or filter.
+
+| Subcommand                                                             | Purpose                                                                                     |
+| ---------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| `question <route>`                                                     | One question: its answers and the runtime target of each answer                             |
+| `outcome <route>`                                                      | One outcome: heading, classification, and inline outcomeTypes                               |
+| `outcome-type <id>`                                                    | One outcomeType: params, link, module, nextQuestionRoute, CTA overrides                     |
+| `outcomes [--classify X] [--has-param N[=V]] [--has-link]`             | List outcomes; filter by `intermediate` / `terminal-single` / `terminal-multi`, param, link |
+| `outcome-types [--has-param N[=V]] [--has-next-question] [--has-link]` | List outcomeTypes; find ones that route forward or carry a downloadable asset               |
+| `questions [--mapping N] [--has-mapping]`                              | List questions; filter by `mcmsAppFormMapping`                                              |
+| `mappings`                                                             | Distinct `mcmsAppFormMapping` values + the question route(s) carrying each                  |
+
+`--classify` accepts `intermediate`, `terminal-single`, or `terminal-multi`
+(the same buckets `classifyOutcome` produces). `--has-param N` matches an
+outcomeType param by name; `--has-param N=V` also pins its value.
+`--has-link` (added on this branch) filters to nodes whose outcomeType
+carries a `link` — handy for finding the outcomes that surface a
+downloadable `.docx` template.
+
+### 2. Traverse the journey graph
+
+The journey is a directed graph. These commands (added on this branch via
+[`iat-graph-commands.js`](../../../../scripts/iat-graph-commands.js) +
+[`journey-graph.js`](../../../../scripts/journey-graph.js)) answer "how do I
+get to / out of a page?".
+
+| Subcommand             | Purpose                                                                    |
+| ---------------------- | -------------------------------------------------------------------------- |
+| `path [<from>] <to>`   | One shortest click-by-click journey. `from` defaults to the first question |
+| `reach <route>`        | Is `<route>` reachable from the start? Exit `0` reachable, `1` not         |
+| `predecessors <route>` | Which pages route **directly into** this node, and via which choice        |
+
+`path <to>` starts from the first question (`/sea`); `path <from> <to>`
+starts from an explicit route. `reach` is the boolean form of `path` and is
+designed for scripting on its exit code. `predecessors` is the reverse
+lookup — it scans every node's outgoing edges for ones that land on
+`<route>`.
+
+## The graph model
+
+Three node types and four ways of routing between them. The model lives in
+[`journey-graph.js`](../../../../scripts/journey-graph.js); each edge is
+derived by asking the **real router** where a choice leads, so the graph can
+never drift from runtime behaviour.
+
+| Node                     | Outgoing edges                                                                                                                                                              |
+| ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Question (single-select) | One edge per answer, labelled `answer "<text>"`, to the answer's resolved next route                                                                                        |
+| Question (multi-select)  | Exactly **two** edges: `tick any activity except "<outcomeAnswerId>"` (continue via `questionRoute`) and `tick "<outcomeAnswerId>"` (go to the multi-select `outcomeRoute`) |
+| Outcome (intermediate)   | One edge per outcomeType that has a `nextQuestionRoute`, labelled `continue: "<heading>"`                                                                                   |
+| Outcome (terminal)       | None — terminal-single / terminal-multi outcomes are sinks                                                                                                                  |
+
+`shortestPath` is a breadth-first search from `from`, so the first path it
+finds is a shortest one (fewest clicks). It is **a** shortest path, not the
+only one — multi-select bridges and outcome forks mean several equal-length
+routes can exist. `reach` is `shortestPath(...) !== null`. `predecessors`
+walks every question + outcome node and collects the ones whose edges target
+the requested route.
+
+## Worked examples
+
+```bash
+# How does a user actually reach the MOD-permission outcome?
+npm run iat -- path /mod-permission
+```
+
+```
+- /sea → In or over the sea
+- /jurisdiction → English waters or Northern Ireland offshore waters
+- /activity-type → Dredging
+- /exemption/dredging → Something else
+- /exemption/dredging-exe-not-available-continue → Continue
+- /dredging/activity → Non-navigational clearance dredging
+- /dredging/activities → tick any activity except OTHER_CLEARANCE_DREDGING
+- /activity/completion → Yes
+- /public-register → No
+- /part-of-larger-project → No
+- /single-location → Yes
+- /military-defence-area → Yes
+- /ministry-of-defence → No
+- /ministry-of-defence/permission → No → /mod-permission
+```
+
+Each line is one click: `- <from> → <choice you make there>`. The final
+line appends ` → <destination>`. Note the mix of single-select answers
+(`In or over the sea`), an intermediate-outcome fork (`Continue`), and a
+multi-select tick branch (`tick any activity except …`) — all three routing
+mechanisms appear in one journey.
+
+```bash
+# Which pages lead straight into /military-defence-area?
+npm run iat -- predecessors /military-defence-area
+```
+
+```
+/single-location	answer "Yes"
+/multiple-locations	answer "Yes"
+```
+
+```bash
+# Is a page reachable at all? (scriptable on exit code)
+npm run iat -- reach /mod-permission        # → "reachable: /mod-permission", exit 0
+
+# A terminal-single outcome whose ADV_TYPE is EXE — handy when writing a test
+npm run iat -- outcomes --classify terminal-single --has-param ADV_TYPE=EXE
+
+# Every outcome that surfaces a downloadable asset (e.g. .docx templates)
+npm run iat -- outcomes --has-link
+
+# Resolve the link-bearing outcomeTypes to their actual asset URLs
+npm run iat -- outcome-types --has-link --json
+
+# Every mcmsAppFormMapping in the JSON, with the question carrying it
+npm run iat -- mappings
+
+# A specific question and where each answer branches to
+npm run iat -- question /activity-type
+```
+
+## `--json` output
+
+`--json` is supported on every subcommand. Shapes worth knowing:
+
+- `path --json` → `{ from, to, found, steps: [{ from, fromText, label, to, kind }] }`.
+  `found` is `false` (and exit `1`) when there is no path.
+- `reach --json` → `{ route, reachable }`.
+- `predecessors --json` → `[{ route, via }]`.
+
+The inspect/list commands emit the same fields as their human output as
+JSON objects/arrays. `--json` does not change exit codes.
+
+## Source files
+
+The tool was split out of a single script on this branch to keep each file
+under the SonarCloud file-length limit and to separate concerns:
+
+| File                                                                         | Responsibility                                                                                 |
+| ---------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| [`scripts/iat-query.js`](../../../../scripts/iat-query.js)                   | Subcommand dispatch + the node inspect/list commands; the entry point                          |
+| [`scripts/iat-graph-commands.js`](../../../../scripts/iat-graph-commands.js) | The `path` / `reach` / `predecessors` command handlers + formatting                            |
+| [`scripts/journey-graph.js`](../../../../scripts/journey-graph.js)           | The graph model: `edgesFrom`, `shortestPath`, `reach`, `predecessors`                          |
+| [`scripts/iat-utils.js`](../../../../scripts/iat-utils.js)                   | Shared arg-parsing and formatting helpers (`excerpt`, `dash`, `runSingleArg`, `jsonResult`, …) |
+
+Tests are colocated:
+[`scripts/iat-query.test.js`](../../../../scripts/iat-query.test.js) (command
+surface, exit codes, `--json`) and
+[`scripts/journey-graph.test.js`](../../../../scripts/journey-graph.test.js)
+(edge model + traversal).
+
+> The CLI lives in `scripts/` — outside the `self-service/` tree it
+> inspects — so it imports `journey-data.js` / `journey-router.js` across the
+> tree boundary. If the IAT is later extracted to its own service, these
+> scripts move with it (they have no dependency on anything outside
+> `self-service/`).

--- a/src/server/journey/self-service/README.md
+++ b/src/server/journey/self-service/README.md
@@ -5,7 +5,7 @@ walkthrough that helps members of the public determine whether their
 planned marine activity needs a marine licence. It is anonymous (no Defra
 ID) and driven entirely by a JSON configuration file.
 
-This README is the top-level entry point for IAT engineers. For the two
+This README is the top-level entry point for IAT engineers. For the
 deeper-dive areas, see:
 
 - [`data/README.data.md`](./data/README.data.md) — the `self-service.json`
@@ -15,6 +15,9 @@ deeper-dive areas, see:
   the load-time and runtime config-defect logger
   (`runLoadTimeScan` / `reportRuntimeIssue`), its ECS log shape, and the
   bounded `seenRuntimeIssues` set.
+- [`README.iat-query.md`](./README.iat-query.md) — the `npm run iat`
+  developer CLI for inspecting `self-service.json`: node inspect/list
+  commands and the `path` / `reach` / `predecessors` graph traversal.
 
 ## File map
 
@@ -25,7 +28,8 @@ src/server/journey/self-service/
 ├── question/          # GET/POST /journey/self-service/c/{slug}/{questionPath*}              (ML-1186, ML-1304/1306)
 ├── outcome/           # GET/POST /journey/self-service/c/{slug}/outcome/{outcomePath*}       (ML-1164, ML-1304/1306)
 │                      # GET      /journey/self-service/c/{slug}/view-answers/{...}           (ML-1165, ML-1304/1306)
-├── outcome-document/  # GET      /outcome-documents/{snapshotSlug}                            (ML-1306)
+│                      # GET      /journey/self-service/c/{slug}/continue/{...}                (ML-1166)
+├── outcome-document/  # GET      /journey/self-service/outcome-document/{snapshotSlug}        (ML-1306)
 ├── data/              # self-service.json + load-time parser/sanitiser
 └── services/          # journey-data, journey-router, journey-answer-log,
                        # load-iat-context, data-quality, sanitise
@@ -40,7 +44,7 @@ convention:
   URL while the user is navigating.
 - A **snapshot slug** identifies an immutable "View answers" snapshot
   (`iat-outcome-documents` collection, no TTL — permanent). It appears
-  only in the public `/outcome-documents/{slug}` URL.
+  only in the public `/journey/self-service/outcome-document/{slug}` URL.
 
 Both are 22-char base64url UUIDv7s generated server-side. They never
 overlap and never coexist on the same URL.
@@ -58,21 +62,30 @@ true. Frontend routes are `auth: false`; backend `/iat-contexts` and
 
 ## Routes
 
-| Method | Path                                                                         | Purpose                                                                                                                | Source              |
-| ------ | ---------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- | ------------------- |
-| GET    | `/journey/self-service/start`                                                | Pre-walkthrough landing page                                                                                           | `start/`            |
-| POST   | `/journey/self-service/start`                                                | Mint a context slug; redirect to first question under slug-prefixed URL                                                | `start/`            |
-| GET    | `/journey/self-service/invalid`                                              | "This check has expired or could not be found" page                                                                    | `invalid/`          |
-| GET    | `/journey/self-service/c/{slug}/{questionPath*}`                             | Render a question; pre-select answers from the context's questionLog                                                   | `question/`         |
-| POST   | `/journey/self-service/c/{slug}/{questionPath*}`                             | PATCH the context's questionLog with the new answer entry, redirect to next node                                       | `question/`         |
-| GET    | `/journey/self-service/c/{slug}/outcome/{outcomePath*}`                      | Render outcome (intermediate fork, terminal-single, or terminal-multi). No mint — view only.                           | `outcome/`          |
-| POST   | `/journey/self-service/c/{slug}/outcome/{outcomePath*}`                      | Intermediate selection — PATCH chosen outcomeType into questionLog, redirect to its `nextQuestionRoute`                | `outcome/`          |
-| GET    | `/journey/self-service/c/{slug}/view-answers/{outcomeTypeId}/{outcomePath*}` | **Mint** a new outcome-document snapshot from the current context + focused outcomeType; 302 to `/outcome-documents/…` | `outcome/`          |
-| GET    | `/outcome-documents/{slug}`                                                  | Render an immutable snapshot. Public, permanent, slug-only — no context required.                                      | `outcome-document/` |
+| Method | Path                                                                         | Purpose                                                                                                                                                                                                               | Source              |
+| ------ | ---------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------- |
+| GET    | `/journey/self-service/start`                                                | Pre-walkthrough landing page                                                                                                                                                                                          | `start/`            |
+| POST   | `/journey/self-service/start`                                                | Mint a context slug; redirect to first question under slug-prefixed URL                                                                                                                                               | `start/`            |
+| GET    | `/journey/self-service/invalid`                                              | "This check has expired or could not be found" page                                                                                                                                                                   | `invalid/`          |
+| GET    | `/journey/self-service/c/{slug}/{questionPath*}`                             | Render a question; pre-select answers from the context's questionLog                                                                                                                                                  | `question/`         |
+| POST   | `/journey/self-service/c/{slug}/{questionPath*}`                             | PATCH the context's questionLog with the new answer entry, redirect to next node                                                                                                                                      | `question/`         |
+| GET    | `/journey/self-service/c/{slug}/outcome/{outcomePath*}`                      | Render outcome (intermediate fork, terminal-single, or terminal-multi). No mint — view only.                                                                                                                          | `outcome/`          |
+| POST   | `/journey/self-service/c/{slug}/outcome/{outcomePath*}`                      | Intermediate selection — PATCH chosen outcomeType into questionLog, redirect to its `nextQuestionRoute`                                                                                                               | `outcome/`          |
+| GET    | `/journey/self-service/c/{slug}/view-answers/{outcomeTypeId}/{outcomePath*}` | **Mint** a new outcome-document snapshot from the current context + focused outcomeType; 302 to `/journey/self-service/outcome-document/…`                                                                            | `outcome/`          |
+| GET    | `/journey/self-service/c/{slug}/continue/{outcomeTypeId}/{outcomePath*}`     | **Mint** a snapshot, then hand off to the exemption journey: 302 to the focused outcomeType's `overrideCtaButtonUrl` with the answers passed as a query string. 404 if the outcomeType has no `overrideCtaButtonUrl`. | `outcome/`          |
+| GET    | `/journey/self-service/outcome-document/{slug}`                              | Render an immutable snapshot. Public, permanent, slug-only — no context required.                                                                                                                                     | `outcome-document/` |
 
 The catch-all paths on question and outcome resolve through
 `services/journey-data.js` and `services/journey-router.js`; see
 [`data/README.data.md`](./data/README.data.md) for the routing rules.
+
+`view-answers` and `continue` both **mint** an immutable snapshot from the
+current context — they differ only in where they send the user next.
+`view-answers` redirects to the public snapshot page; `continue` (ML-1166)
+hands off into the Defra exemption application journey, redirecting to the
+focused outcomeType's `overrideCtaButtonUrl` with the answers (and a link
+back to the snapshot) as a query string. Only outcomeTypes that carry an
+`overrideCtaButtonUrl` are valid `continue` targets.
 
 ## Request lifecycle
 
@@ -136,12 +149,12 @@ sequenceDiagram
         API->>API: generateSlug() (snapshot slug)
         API->>MS: insertOne({slug: snapSlug, contextSlug: ctxSlug,<br/>questionLog: copy, preamble, focusedOption, capturedAt})
         API-->>F: 201 { slug: snapSlug, viewUrl }
-        F-->>B: 302 /outcome-documents/{snapSlug}
+        F-->>B: 302 /journey/self-service/outcome-document/{snapSlug}
     end
 
     rect rgb(240,255,240)
         note over B,MS: Public snapshot page (forever)
-        B->>F: GET /outcome-documents/{snapSlug}
+        B->>F: GET /journey/self-service/outcome-document/{snapSlug}
         F->>API: GET /outcome-documents/{snapSlug}
         API->>MS: findOne({slug: snapSlug})
         MS-->>API: snap
@@ -156,7 +169,7 @@ sequenceDiagram
         B->>F: GET .../view-answers/...
         F->>API: POST /iat-contexts/{ctxSlug}/outcome-documents  (mint #2)
         API->>MS: insertOne({slug: snapSlug2, …})
-        F-->>B: 302 /outcome-documents/{snapSlug2}
+        F-->>B: 302 /journey/self-service/outcome-document/{snapSlug2}
         note over MS: snapSlug1 still resolves to its original content forever
     end
 ```
@@ -256,38 +269,21 @@ the JSON-replacement test in
 
 ## Querying `self-service.json`
 
-The JSON is large (~5000 lines) and relational. Use the in-repo CLI rather than ad-hoc grep/jq — it reuses the same parsed/sanitised view the running app sees, so what you see matches what runs.
+The JSON is large (~5000 lines) and relational. Use the in-repo CLI
+(`npm run iat`) rather than ad-hoc grep/jq — it reuses the same
+parsed/sanitised view the running app sees and the real router, so what you
+see matches what runs. It can inspect a single node, filter the lists, and
+**traverse the journey graph** (`path` / `reach` / `predecessors`).
 
 ```bash
-npm run iat -- <subcommand> [args] [--json]
-```
-
-| Subcommand                                                | Purpose                                                                                     |
-| --------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| `question <route>`                                        | Show one question with its answers and where each leads                                     |
-| `outcome <route>`                                         | Show one outcome with its outcomeTypes inline                                               |
-| `outcome-type <id>`                                       | Show one outcomeType (params, link, module, nextQuestionRoute)                              |
-| `outcomes [--classify X] [--has-param N[=V]]`             | List outcomes filtered by `intermediate`/`terminal-single`/`terminal-multi` and/or by param |
-| `outcome-types [--has-param N[=V]] [--has-next-question]` | List outcomeTypes; useful for finding ones that route forward vs. terminal                  |
-| `questions [--mapping N] [--has-mapping]`                 | List questions; filter by `mcmsAppFormMapping`                                              |
-| `mappings`                                                | Distinct `mcmsAppFormMapping` values + the question route(s) that carry each                |
-
-Every subcommand accepts `--json` for machine-readable output. Exit codes: `0` success, `1` not-found, `2` invalid args.
-
-Examples:
-
-```bash
-# A terminal-single outcome whose ADV_TYPE is EXE — handy when writing a test
-npm run iat -- outcomes --classify terminal-single --has-param ADV_TYPE=EXE
-
-# Every mcmsAppFormMapping in the JSON, with the question carrying it
-npm run iat -- mappings
-
-# A specific question and where each answer leads
+# How does a user actually reach a page?
+npm run iat -- path /mod-permission
+# Inspect one question and where each answer branches to
 npm run iat -- question /activity-type
 ```
 
-Source: [`marine-licensing-frontend/scripts/iat-query.js`](../../../../scripts/iat-query.js). Tests colocated in `scripts/iat-query.test.js`.
+Full subcommand reference, the graph model, exit codes, `--json` contract,
+and the source-file map live in **[`README.iat-query.md`](./README.iat-query.md)**.
 
 ## Security: defence in depth
 


### PR DESCRIPTION
# Changes

* Add new cli arg `path` to find out how to reach a certain outcome, e.g. 

```
npm run iat -- path /mod-permission

> marine-licensing-frontend@0.0.0 iat
> node scripts/iat-query.js path /mod-permission

- /sea → In or over the sea
- /jurisdiction → English waters or Northern Ireland offshore waters
- /activity-type → Dredging
- /exemption/dredging → Something else
- /exemption/dredging-exe-not-available-continue → Continue
- /dredging/activity → Non-navigational clearance dredging
- /dredging/activities → tick any activity except OTHER_CLEARANCE_DREDGING
- /activity/completion → Yes
- /public-register → No
- /part-of-larger-project → No
- /single-location → Yes
- /military-defence-area → Yes
- /ministry-of-defence → No
- /ministry-of-defence/permission → No → /mod-permission
```