### PR TITLE
ML-1340: Water Framework Directive upload page

### DIFF
--- a/src/server/common/constants/routes.js
+++ b/src/server/common/constants/routes.js
@@ -96,7 +96,11 @@ export const marineLicenceRoutes = {
     '/marine-licence/water-framework-directive-previous-assessment',
   MARINE_LICENCE_WATER_FRAMEWORK_DIRECTIVE_ASSESSMENT_CHANGED:
     '/marine-licence/water-framework-directive-assessment-changed',
-  MARINE_LICENCE_PREFERRED_DATES: '/marine-licence/start-and-end-dates'
+  MARINE_LICENCE_PREFERRED_DATES: '/marine-licence/start-and-end-dates',
+  MARINE_LICENCE_WATER_FRAMEWORK_DIRECTIVE_FILE_UPLOAD:
+    '/marine-licence/water-framework-directive-file-upload',
+  MARINE_LICENCE_WATER_FRAMEWORK_DIRECTIVE_UPLOAD_AND_WAIT:
+    '/marine-licence/water-framework-directive-upload-and-wait'
 }
 
 export const defraIdGuidanceRoutes = {

--- a/src/server/common/constants/water-framework-directive.js
+++ b/src/server/common/constants/water-framework-directive.js
@@ -1,0 +1,4 @@
+export const WFD_ACCEPT_ATTRIBUTE = '.odt,.docx'
+
+export const s3PathForWaterFrameworkDirective =
+  'marine-licence/water-framework-directive'

--- a/src/server/common/helpers/marine-licence/water-framework-directive/save-water-framework-directive.js
+++ b/src/server/common/helpers/marine-licence/water-framework-directive/save-water-framework-directive.js
@@ -15,14 +15,21 @@ export const saveWaterFrameworkDirectiveToBackend = async (
   let dataToSave = { nauticalMile }
 
   if (!nauticalMileOnly) {
-    const { assessmentChanged, excludedActivities, previousAssessment } =
-      waterFrameworkDirective
+    const {
+      assessmentChanged,
+      excludedActivities,
+      previousAssessment,
+      uploadedFile,
+      s3Location
+    } = waterFrameworkDirective
 
     dataToSave = {
       ...dataToSave,
       assessmentChanged,
       excludedActivities,
-      previousAssessment
+      previousAssessment,
+      uploadedFile,
+      s3Location
     }
   }
 

--- a/src/server/common/helpers/marine-licence/water-framework-directive/save-water-framework-directive.js
+++ b/src/server/common/helpers/marine-licence/water-framework-directive/save-water-framework-directive.js
@@ -1,0 +1,37 @@
+import { apiRoutes } from '#src/server/common/constants/routes.js'
+import { authenticatedPatchRequest } from '#src/server/common/helpers/authenticated-requests.js'
+import { getMarineLicenceCache } from '#src/server/common/helpers/marine-licence/session-cache/utils.js'
+
+export const saveWaterFrameworkDirectiveToBackend = async (
+  request,
+  nauticalMileOnly
+) => {
+  const marineLicence = getMarineLicenceCache(request)
+
+  const { waterFrameworkDirective } = marineLicence
+
+  const { nauticalMile } = waterFrameworkDirective
+
+  let dataToSave = { nauticalMile }
+
+  if (!nauticalMileOnly) {
+    const { assessmentChanged, excludedActivities, previousAssessment } =
+      waterFrameworkDirective
+
+    dataToSave = {
+      ...dataToSave,
+      assessmentChanged,
+      excludedActivities,
+      previousAssessment
+    }
+  }
+
+  await authenticatedPatchRequest(
+    request,
+    apiRoutes.UPDATE_WATER_FRAMEWORK_DIRECTIVE,
+    {
+      waterFrameworkDirective: dataToSave,
+      id: marineLicence.id
+    }
+  )
+}

--- a/src/server/common/helpers/marine-licence/water-framework-directive/save-water-framework-directive.test.js
+++ b/src/server/common/helpers/marine-licence/water-framework-directive/save-water-framework-directive.test.js
@@ -55,7 +55,9 @@ describe('saveWaterFrameworkDirectiveToBackend', () => {
           nauticalMile: wfdWithoutPreviousAssessment.nauticalMile,
           assessmentChanged: wfdWithoutPreviousAssessment.assessmentChanged,
           excludedActivities: wfdWithoutPreviousAssessment.excludedActivities,
-          previousAssessment: undefined
+          previousAssessment: undefined,
+          s3Location: wfdWithoutPreviousAssessment.s3Location,
+          uploadedFile: wfdWithoutPreviousAssessment.uploadedFile
         },
         id: mockMarineLicenceApplication.id
       }

--- a/src/server/common/helpers/marine-licence/water-framework-directive/save-water-framework-directive.test.js
+++ b/src/server/common/helpers/marine-licence/water-framework-directive/save-water-framework-directive.test.js
@@ -1,0 +1,64 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+import { saveWaterFrameworkDirectiveToBackend } from './save-water-framework-directive.js'
+import { authenticatedPatchRequest } from '#src/server/common/helpers/authenticated-requests.js'
+import { getMarineLicenceCache } from '#src/server/common/helpers/marine-licence/session-cache/utils.js'
+import { createMockRequest } from '#src/server/test-helpers/mocks/helpers.js'
+import {
+  mockMarineLicenceApplication,
+  waterFrameworkDirective
+} from '#src/server/test-helpers/mocks/marine-licence-mocks.js'
+import { apiRoutes } from '#src/server/common/constants/routes.js'
+
+vi.mock('#src/server/common/helpers/authenticated-requests.js')
+vi.mock('#src/server/common/helpers/marine-licence/session-cache/utils.js')
+
+describe('saveWaterFrameworkDirectiveToBackend', () => {
+  const mockRequest = createMockRequest()
+
+  beforeEach(() => {
+    vi.mocked(getMarineLicenceCache).mockReturnValue(
+      mockMarineLicenceApplication
+    )
+  })
+
+  test('should save only nauticalMile when nauticalMileOnly is true', async () => {
+    await saveWaterFrameworkDirectiveToBackend(mockRequest, true)
+
+    expect(authenticatedPatchRequest).toHaveBeenCalledWith(
+      mockRequest,
+      apiRoutes.UPDATE_WATER_FRAMEWORK_DIRECTIVE,
+      {
+        waterFrameworkDirective: {
+          nauticalMile: waterFrameworkDirective.nauticalMile
+        },
+        id: mockMarineLicenceApplication.id
+      }
+    )
+  })
+
+  test('should save full water framework directive', async () => {
+    const { previousAssessment, ...wfdWithoutPreviousAssessment } =
+      waterFrameworkDirective
+
+    vi.mocked(getMarineLicenceCache).mockReturnValue({
+      ...mockMarineLicenceApplication,
+      waterFrameworkDirective: wfdWithoutPreviousAssessment
+    })
+
+    await saveWaterFrameworkDirectiveToBackend(mockRequest, false)
+
+    expect(authenticatedPatchRequest).toHaveBeenCalledWith(
+      mockRequest,
+      apiRoutes.UPDATE_WATER_FRAMEWORK_DIRECTIVE,
+      {
+        waterFrameworkDirective: {
+          nauticalMile: wfdWithoutPreviousAssessment.nauticalMile,
+          assessmentChanged: wfdWithoutPreviousAssessment.assessmentChanged,
+          excludedActivities: wfdWithoutPreviousAssessment.excludedActivities,
+          previousAssessment: undefined
+        },
+        id: mockMarineLicenceApplication.id
+      }
+    )
+  })
+})

--- a/src/server/marine-licence/site-details/file-upload/controller.js
+++ b/src/server/marine-licence/site-details/file-upload/controller.js
@@ -18,6 +18,11 @@ import { getSiteDetailsBySite } from '#src/server/common/helpers/exemptions/sess
 
 const s3PathForMarineLicence = 'marine-licence'
 
+const getS3PathForMarineLicence = (fileType) =>
+  fileType === 'kml'
+    ? `${s3PathForMarineLicence}/kml-uploads`
+    : `${s3PathForMarineLicence}/shapefile-uploads`
+
 export const fileUploadController = {
   async handler(request, h) {
     const marineLicence = getMarineLicenceCache(request)
@@ -61,7 +66,7 @@ export const fileUploadController = {
       const redirectUrl = marineLicenceRoutes.MARINE_LICENCE_UPLOAD_AND_WAIT
       const uploadConfig = await cdpService.initiate({
         redirectUrl,
-        s3Path: s3PathForMarineLicence,
+        s3Path: getS3PathForMarineLicence(),
         s3Bucket
       })
 

--- a/src/server/marine-licence/site-details/file-upload/controller.js
+++ b/src/server/marine-licence/site-details/file-upload/controller.js
@@ -66,7 +66,7 @@ export const fileUploadController = {
       const redirectUrl = marineLicenceRoutes.MARINE_LICENCE_UPLOAD_AND_WAIT
       const uploadConfig = await cdpService.initiate({
         redirectUrl,
-        s3Path: getS3PathForMarineLicence(),
+        s3Path: getS3PathForMarineLicence(fileUploadType),
         s3Bucket
       })
 

--- a/src/server/marine-licence/task-list/controller.js
+++ b/src/server/marine-licence/task-list/controller.js
@@ -29,13 +29,16 @@ const taskListViewSettings = {
   heading: headingText
 }
 
-function transformTaskLists(taskList, isCitizen) {
+function transformTaskLists(taskList, isCitizen, marineLicence) {
   return {
     otherPermissions: transformOtherPermissionsTaskList(taskList, isCitizen),
     sharing: transformSharingTaskList(taskList),
     projectDetails: transformProjectDetailsTaskList(taskList),
     siteDetails: transformSiteDetailsTaskList(taskList),
-    waterFrameworkDirective: transformWaterFrameworkDirectiveTaskList(taskList)
+    waterFrameworkDirective: transformWaterFrameworkDirectiveTaskList(
+      taskList,
+      marineLicence.waterFrameworkDirective
+    )
   }
 }
 
@@ -95,7 +98,8 @@ export const taskListController = {
 
     const transformed = transformTaskLists(
       taskList,
-      userRelationshipType === USER_TYPES.CITIZEN
+      userRelationshipType === USER_TYPES.CITIZEN,
+      marineLicence
     )
     await updateLicenceSession(request, h, payload.value, hasCancel)
 

--- a/src/server/marine-licence/task-list/controller.test.js
+++ b/src/server/marine-licence/task-list/controller.test.js
@@ -192,7 +192,10 @@ describe('#taskListController', () => {
     )
     expect(
       vi.mocked(transformWaterFrameworkDirectiveTaskList)
-    ).toHaveBeenCalledWith(mockPayload.value.taskList)
+    ).toHaveBeenCalledWith(
+      mockPayload.value.taskList,
+      mockMarineLicence.waterFrameworkDirective
+    )
 
     expect(vi.mocked(setMarineLicenceCache)).toHaveBeenCalledWith(
       mockRequest,

--- a/src/server/marine-licence/task-list/utils.js
+++ b/src/server/marine-licence/task-list/utils.js
@@ -92,7 +92,10 @@ export const transformSiteDetailsTaskList = (taskList) => [
 ]
 
 const getWaterFrameworkDirectiveHref = (waterFrameworkDirective) => {
-  if (!waterFrameworkDirective?.nauticalMiles === 'no') {
+  if (
+    waterFrameworkDirective?.nauticalMiles &&
+    waterFrameworkDirective.nauticalMiles !== 'yes'
+  ) {
     return marineLicenceRoutes.MARINE_LICENCE_WATER_FRAMEWORK_DIRECTIVE_NAUTICAL_MILE
   }
 

--- a/src/server/marine-licence/task-list/utils.js
+++ b/src/server/marine-licence/task-list/utils.js
@@ -91,13 +91,27 @@ export const transformSiteDetailsTaskList = (taskList) => [
   }
 ]
 
-export const transformWaterFrameworkDirectiveTaskList = (taskList) => [
+const getWaterFrameworkDirectiveHref = (waterFrameworkDirective) => {
+  if (!waterFrameworkDirective?.nauticalMiles === 'no') {
+    return marineLicenceRoutes.MARINE_LICENCE_WATER_FRAMEWORK_DIRECTIVE_NAUTICAL_MILE
+  }
+
+  return marineLicenceRoutes.MARINE_LICENCE_WATER_FRAMEWORK_DIRECTIVE_BEFORE_YOU_START
+}
+
+export const transformWaterFrameworkDirectiveTaskList = (
+  taskList,
+  waterFrameworkDirective
+) => [
   {
     title: {
       text: 'Water Framework Directive assessment',
       classes: taskClasses
     },
-    href: marineLicenceRoutes.MARINE_LICENCE_WATER_FRAMEWORK_DIRECTIVE_BEFORE_YOU_START,
+    href:
+      taskList.waterFrameworkDirective === 'INCOMPLETE'
+        ? marineLicenceRoutes.MARINE_LICENCE_WATER_FRAMEWORK_DIRECTIVE_BEFORE_YOU_START
+        : getWaterFrameworkDirectiveHref(waterFrameworkDirective),
     status: setStatus(taskList.waterFrameworkDirective)
   }
 ]

--- a/src/server/marine-licence/task-list/utils.js
+++ b/src/server/marine-licence/task-list/utils.js
@@ -93,8 +93,8 @@ export const transformSiteDetailsTaskList = (taskList) => [
 
 const getWaterFrameworkDirectiveHref = (waterFrameworkDirective) => {
   if (
-    waterFrameworkDirective?.nauticalMiles &&
-    waterFrameworkDirective.nauticalMiles !== 'yes'
+    waterFrameworkDirective?.nauticalMile &&
+    waterFrameworkDirective.nauticalMile !== 'yes'
   ) {
     return marineLicenceRoutes.MARINE_LICENCE_WATER_FRAMEWORK_DIRECTIVE_NAUTICAL_MILE
   }

--- a/src/server/marine-licence/water-framework-directive/assessment-changed/controller.js
+++ b/src/server/marine-licence/water-framework-directive/assessment-changed/controller.js
@@ -73,7 +73,7 @@ export const assessmentChangedSubmitController = {
     )
 
     return h.redirect(
-      marineLicenceRoutes.MARINE_LICENCE_WATER_FRAMEWORK_DIRECTIVE_ASSESSMENT_CHANGED
+      marineLicenceRoutes.MARINE_LICENCE_WATER_FRAMEWORK_DIRECTIVE_FILE_UPLOAD
     )
   }
 }

--- a/src/server/marine-licence/water-framework-directive/assessment-changed/controller.test.js
+++ b/src/server/marine-licence/water-framework-directive/assessment-changed/controller.test.js
@@ -68,7 +68,7 @@ describe('#assessmentChanged', () => {
         'yes'
       )
       expect(h.redirect).toHaveBeenCalledWith(
-        marineLicenceRoutes.MARINE_LICENCE_WATER_FRAMEWORK_DIRECTIVE_ASSESSMENT_CHANGED
+        marineLicenceRoutes.MARINE_LICENCE_WATER_FRAMEWORK_DIRECTIVE_FILE_UPLOAD
       )
     })
 
@@ -85,7 +85,7 @@ describe('#assessmentChanged', () => {
         'no'
       )
       expect(h.redirect).toHaveBeenCalledWith(
-        marineLicenceRoutes.MARINE_LICENCE_WATER_FRAMEWORK_DIRECTIVE_ASSESSMENT_CHANGED
+        marineLicenceRoutes.MARINE_LICENCE_WATER_FRAMEWORK_DIRECTIVE_FILE_UPLOAD
       )
     })
 

--- a/src/server/marine-licence/water-framework-directive/file-upload/controller.js
+++ b/src/server/marine-licence/water-framework-directive/file-upload/controller.js
@@ -1,0 +1,80 @@
+import { getCdpUploadService } from '#src/services/cdp-upload-service/index.js'
+import { marineLicenceRoutes } from '#src/server/common/constants/routes.js'
+import { config } from '#src/config/config.js'
+import { createFileUploadErrorDisplay } from '#src/server/common/helpers/file-upload/file-upload.js'
+import { fileUploadPageSettings } from '#src/server/common/helpers/file-upload/constants.js'
+import { getMarineLicenceCache } from '#src/server/common/helpers/marine-licence/session-cache/utils.js'
+import { updateWaterFrameworkDirective } from '#src/server/common/helpers/marine-licence/session-cache/water-framework-directive.js'
+import {
+  s3PathForWaterFrameworkDirective,
+  WFD_ACCEPT_ATTRIBUTE
+} from '#src/server/common/constants/water-framework-directive.js'
+
+export const WATER_FRAMEWORK_DIRECTIVE_FILE_UPLOAD_VIEW_ROUTE =
+  'marine-licence/water-framework-directive/file-upload/index'
+
+export const waterFrameworkFileUploadController = {
+  async handler(request, h) {
+    const marineLicence = getMarineLicenceCache(request)
+    const { waterFrameworkDirective = {} } = marineLicence
+    const { uploadedFile, uploadError } = waterFrameworkDirective
+
+    let errorSummary, errors
+    if (uploadError) {
+      const errorDisplay = createFileUploadErrorDisplay(uploadError, request)
+      errorSummary = errorDisplay.errorSummary
+      errors = errorDisplay.errors
+
+      await updateWaterFrameworkDirective(request, h, 'uploadError', null)
+    }
+
+    if (uploadedFile && !uploadError) {
+      request.logger.debug(
+        'Uploaded file without error found, but starting a new upload session'
+      )
+    }
+
+    try {
+      const cdpService = getCdpUploadService()
+      const cdpUploadConfig = config.get('cdpUploader')
+      const s3Bucket = cdpUploadConfig.s3Bucket
+
+      const redirectUrl =
+        marineLicenceRoutes.MARINE_LICENCE_WATER_FRAMEWORK_DIRECTIVE_UPLOAD_AND_WAIT
+
+      const uploadConfig = await cdpService.initiate({
+        redirectUrl,
+        s3Path: s3PathForWaterFrameworkDirective,
+        s3Bucket
+      })
+
+      await updateWaterFrameworkDirective(request, h, 'uploadConfig', {
+        uploadId: uploadConfig.uploadId,
+        statusUrl: uploadConfig.statusUrl
+      })
+
+      return h.view(WATER_FRAMEWORK_DIRECTIVE_FILE_UPLOAD_VIEW_ROUTE, {
+        ...fileUploadPageSettings,
+        projectName: marineLicence.projectName,
+        uploadUrl: uploadConfig.uploadUrl,
+        maxFileSize: uploadConfig.maxFileSize,
+        acceptAttribute: WFD_ACCEPT_ATTRIBUTE,
+        backLink:
+          marineLicenceRoutes.MARINE_LICENCE_WATER_FRAMEWORK_DIRECTIVE_ASSESSMENT_CHANGED,
+        cancelLink: marineLicenceRoutes.MARINE_LICENCE_TASK_LIST,
+        errorSummary,
+        errors
+      })
+    } catch (error) {
+      request.logger.error(
+        {
+          err: error,
+          marineLicenceId: marineLicence.id
+        },
+        'Failed to initialize WFD file upload'
+      )
+
+      return h.redirect(marineLicenceRoutes.MARINE_LICENCE_TASK_LIST)
+    }
+  }
+}

--- a/src/server/marine-licence/water-framework-directive/file-upload/controller.js
+++ b/src/server/marine-licence/water-framework-directive/file-upload/controller.js
@@ -13,6 +13,14 @@ import {
 export const WATER_FRAMEWORK_DIRECTIVE_FILE_UPLOAD_VIEW_ROUTE =
   'marine-licence/water-framework-directive/file-upload/index'
 
+const PAGE_HEADING = 'Upload your Water Framework Directive assessment'
+
+const waterFrameworkDirectiveUploadAndWaitPageSettings = {
+  ...fileUploadPageSettings,
+  pageTitle: PAGE_HEADING,
+  heading: PAGE_HEADING
+}
+
 export const waterFrameworkFileUploadController = {
   async handler(request, h) {
     const marineLicence = getMarineLicenceCache(request)
@@ -54,7 +62,7 @@ export const waterFrameworkFileUploadController = {
       })
 
       return h.view(WATER_FRAMEWORK_DIRECTIVE_FILE_UPLOAD_VIEW_ROUTE, {
-        ...fileUploadPageSettings,
+        ...waterFrameworkDirectiveUploadAndWaitPageSettings,
         projectName: marineLicence.projectName,
         uploadUrl: uploadConfig.uploadUrl,
         maxFileSize: uploadConfig.maxFileSize,

--- a/src/server/marine-licence/water-framework-directive/file-upload/controller.js
+++ b/src/server/marine-licence/water-framework-directive/file-upload/controller.js
@@ -9,6 +9,7 @@ import {
   s3PathForWaterFrameworkDirective,
   WFD_ACCEPT_ATTRIBUTE
 } from '#src/server/common/constants/water-framework-directive.js'
+import { getBackLink } from '#src/server/marine-licence/water-framework-directive/file-upload/utils.js'
 
 export const WATER_FRAMEWORK_DIRECTIVE_FILE_UPLOAD_VIEW_ROUTE =
   'marine-licence/water-framework-directive/file-upload/index'
@@ -67,8 +68,7 @@ export const waterFrameworkFileUploadController = {
         uploadUrl: uploadConfig.uploadUrl,
         maxFileSize: uploadConfig.maxFileSize,
         acceptAttribute: WFD_ACCEPT_ATTRIBUTE,
-        backLink:
-          marineLicenceRoutes.MARINE_LICENCE_WATER_FRAMEWORK_DIRECTIVE_ASSESSMENT_CHANGED,
+        backLink: getBackLink(waterFrameworkDirective.previousAssessment),
         cancelLink: marineLicenceRoutes.MARINE_LICENCE_TASK_LIST,
         errorSummary,
         errors

--- a/src/server/marine-licence/water-framework-directive/file-upload/controller.js
+++ b/src/server/marine-licence/water-framework-directive/file-upload/controller.js
@@ -76,8 +76,7 @@ export const waterFrameworkFileUploadController = {
     } catch (error) {
       request.logger.error(
         {
-          err: error,
-          marineLicenceId: marineLicence.id
+          err: error
         },
         'Failed to initialize WFD file upload'
       )

--- a/src/server/marine-licence/water-framework-directive/file-upload/controller.test.js
+++ b/src/server/marine-licence/water-framework-directive/file-upload/controller.test.js
@@ -1,0 +1,303 @@
+import { vi } from 'vitest'
+import { config } from '#src/config/config.js'
+import { marineLicenceRoutes } from '#src/server/common/constants/routes.js'
+import * as mlCacheUtils from '#src/server/common/helpers/marine-licence/session-cache/utils.js'
+import * as wfdCacheUtils from '#src/server/common/helpers/marine-licence/session-cache/water-framework-directive.js'
+import {
+  waterFrameworkFileUploadController,
+  WATER_FRAMEWORK_DIRECTIVE_FILE_UPLOAD_VIEW_ROUTE
+} from '#src/server/marine-licence/water-framework-directive/file-upload/controller.js'
+import { mockMarineLicenceApplication } from '#src/server/test-helpers/mocks/marine-licence-mocks.js'
+import * as cdpUploadService from '#src/services/cdp-upload-service/index.js'
+import {
+  WFD_ACCEPT_ATTRIBUTE,
+  s3PathForWaterFrameworkDirective
+} from '#src/server/common/constants/water-framework-directive.js'
+
+vi.mock('~/src/server/common/helpers/marine-licence/session-cache/utils.js')
+vi.mock('~/src/services/cdp-upload-service/index.js')
+vi.mock(
+  '~/src/server/common/helpers/marine-licence/session-cache/water-framework-directive.js'
+)
+vi.mock('~/src/config/config.js')
+
+vi.mock('~/src/server/common/helpers/logging/logger-options.js', () => ({
+  loggerOptions: {
+    enabled: true,
+    ignorePaths: ['/health'],
+    redact: { paths: [] }
+  }
+}))
+
+vi.mock('~/src/server/common/helpers/logging/logger.js', () => ({
+  createLogger: vi.fn().mockReturnValue({
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn()
+  })
+}))
+
+describe('#fileUpload', () => {
+  let getMarineLicenceCacheSpy
+  let updateWaterFrameworkDirectiveSpy
+  let mockCdpService
+
+  const createMockRequest = () => ({
+    logger: {
+      debug: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn()
+    },
+    yar: {
+      get: vi.fn(),
+      set: vi.fn(),
+      commit: vi.fn()
+    }
+  })
+
+  const createMockH = () => ({
+    view: vi.fn(),
+    redirect: vi.fn()
+  })
+
+  const createStandardUploadConfig = () => ({
+    uploadId: 'test-upload-id',
+    uploadUrl: 'https://upload.example.com',
+    statusUrl: 'https://status.example.com',
+    maxFileSize: 50000000
+  })
+
+  const setupStandardFileUploadTest = async (mockRequest, mockH) => {
+    mockCdpService.initiate.mockResolvedValue(createStandardUploadConfig())
+    await waterFrameworkFileUploadController.handler(mockRequest, mockH)
+  }
+
+  const expectViewCalledWith = (mockH, expectedContent) => {
+    expect(mockH.view).toHaveBeenCalledWith(
+      WATER_FRAMEWORK_DIRECTIVE_FILE_UPLOAD_VIEW_ROUTE,
+      expect.objectContaining(expectedContent)
+    )
+  }
+
+  beforeEach(() => {
+    config.get.mockImplementation((key) => {
+      if (key === 'cdpUploader') return { s3Bucket: 'test-bucket' }
+      return undefined
+    })
+
+    getMarineLicenceCacheSpy = vi
+      .spyOn(mlCacheUtils, 'getMarineLicenceCache')
+      .mockReturnValue(mockMarineLicenceApplication)
+
+    updateWaterFrameworkDirectiveSpy = vi
+      .spyOn(wfdCacheUtils, 'updateWaterFrameworkDirective')
+      .mockResolvedValue()
+
+    mockCdpService = { initiate: vi.fn() }
+    vi.spyOn(cdpUploadService, 'getCdpUploadService').mockReturnValue(
+      mockCdpService
+    )
+  })
+
+  describe('#waterFrameworkFileUploadController', () => {
+    let mockRequest
+    let mockH
+
+    beforeEach(() => {
+      mockRequest = createMockRequest()
+      mockH = createMockH()
+    })
+
+    describe('Display upload page', () => {
+      test('should display file upload page with correct data', async () => {
+        await setupStandardFileUploadTest(mockRequest, mockH)
+
+        expectViewCalledWith(mockH, {
+          pageTitle: 'Upload a file',
+          heading: 'Upload a file',
+          projectName: mockMarineLicenceApplication.projectName,
+          uploadUrl: 'https://upload.example.com',
+          maxFileSize: 50000000,
+          acceptAttribute: WFD_ACCEPT_ATTRIBUTE,
+          backLink:
+            marineLicenceRoutes.MARINE_LICENCE_WATER_FRAMEWORK_DIRECTIVE_ASSESSMENT_CHANGED,
+          cancelLink: marineLicenceRoutes.MARINE_LICENCE_TASK_LIST
+        })
+      })
+
+      test('should use WFD accept attribute (.odt,.docx)', async () => {
+        await setupStandardFileUploadTest(mockRequest, mockH)
+
+        expectViewCalledWith(mockH, { acceptAttribute: '.odt,.docx' })
+      })
+    })
+
+    describe('CDP upload session initialisation', () => {
+      test('should initialize CDP upload with correct parameters', async () => {
+        await setupStandardFileUploadTest(mockRequest, mockH)
+
+        expect(cdpUploadService.getCdpUploadService).toHaveBeenCalledWith()
+        expect(mockCdpService.initiate).toHaveBeenCalledWith({
+          redirectUrl:
+            marineLicenceRoutes.MARINE_LICENCE_WATER_FRAMEWORK_DIRECTIVE_UPLOAD_AND_WAIT,
+          s3Path: s3PathForWaterFrameworkDirective,
+          s3Bucket: 'test-bucket'
+        })
+
+        expect(updateWaterFrameworkDirectiveSpy).toHaveBeenCalledWith(
+          mockRequest,
+          mockH,
+          'uploadConfig',
+          {
+            uploadId: 'test-upload-id',
+            statusUrl: 'https://status.example.com'
+          }
+        )
+      })
+    })
+
+    describe('Error handling', () => {
+      test('should display error from session and clear it after display', async () => {
+        getMarineLicenceCacheSpy.mockReturnValue({
+          ...mockMarineLicenceApplication,
+          waterFrameworkDirective: {
+            uploadError: {
+              message: 'The selected file contains a virus',
+              fieldName: 'file',
+              fileType: 'odt'
+            }
+          }
+        })
+        mockCdpService.initiate.mockResolvedValue(createStandardUploadConfig())
+
+        await waterFrameworkFileUploadController.handler(mockRequest, mockH)
+
+        expect(mockH.view).toHaveBeenCalledWith(
+          WATER_FRAMEWORK_DIRECTIVE_FILE_UPLOAD_VIEW_ROUTE,
+          expect.objectContaining({
+            errorSummary: expect.arrayContaining([
+              expect.objectContaining({
+                text: 'The selected file contains a virus',
+                href: '#file'
+              })
+            ]),
+            errors: expect.objectContaining({
+              file: expect.objectContaining({
+                text: 'The selected file contains a virus'
+              })
+            })
+          })
+        )
+
+        expect(updateWaterFrameworkDirectiveSpy).toHaveBeenCalledWith(
+          mockRequest,
+          mockH,
+          'uploadError',
+          null
+        )
+      })
+
+      test('should handle CDP service initialization failure and redirect to task list', async () => {
+        mockCdpService.initiate.mockRejectedValue(
+          new Error('CDP service unavailable')
+        )
+
+        await waterFrameworkFileUploadController.handler(mockRequest, mockH)
+
+        expect(mockRequest.logger.error).toHaveBeenCalledWith(
+          expect.objectContaining({
+            err: expect.any(Error),
+            marineLicenceId: mockMarineLicenceApplication.id
+          }),
+          'Failed to initialize WFD file upload'
+        )
+
+        expect(mockH.redirect).toHaveBeenCalledWith(
+          marineLicenceRoutes.MARINE_LICENCE_TASK_LIST
+        )
+      })
+    })
+
+    describe('Mutation testing coverage', () => {
+      test('should log warning when uploadedFile exists without uploadError', async () => {
+        getMarineLicenceCacheSpy.mockReturnValue({
+          ...mockMarineLicenceApplication,
+          waterFrameworkDirective: {
+            uploadedFile: { filename: 'test.odt', fileSize: 1024 },
+            uploadError: null
+          }
+        })
+        mockCdpService.initiate.mockResolvedValue(createStandardUploadConfig())
+
+        await waterFrameworkFileUploadController.handler(mockRequest, mockH)
+
+        expect(mockRequest.logger.debug).toHaveBeenCalledWith(
+          'Uploaded file without error found, but starting a new upload session'
+        )
+      })
+
+      test.each([
+        {
+          scenario: 'no uploadedFile',
+          waterFrameworkDirective: {}
+        },
+        {
+          scenario: 'uploadedFile is null',
+          waterFrameworkDirective: { uploadedFile: null }
+        },
+        {
+          scenario: 'uploadedFile with uploadError (error takes precedence)',
+          waterFrameworkDirective: {
+            uploadedFile: { filename: 'test.odt', fileSize: 1024 },
+            uploadError: {
+              message: 'The selected file contains a virus',
+              fieldName: 'file',
+              fileType: 'odt'
+            }
+          }
+        }
+      ])(
+        'should not log warning when $scenario',
+        async ({ waterFrameworkDirective }) => {
+          getMarineLicenceCacheSpy.mockReturnValue({
+            ...mockMarineLicenceApplication,
+            waterFrameworkDirective
+          })
+          mockCdpService.initiate.mockResolvedValue(
+            createStandardUploadConfig()
+          )
+
+          await waterFrameworkFileUploadController.handler(mockRequest, mockH)
+
+          expect(mockRequest.logger.debug).not.toHaveBeenCalledWith(
+            'Uploaded file without error found, but starting a new upload session'
+          )
+        }
+      )
+
+      test('should map error message correctly in error summary', async () => {
+        const testMessage = 'Test error message'
+        getMarineLicenceCacheSpy.mockReturnValue({
+          ...mockMarineLicenceApplication,
+          waterFrameworkDirective: {
+            uploadError: {
+              message: testMessage,
+              fieldName: 'file',
+              fileType: 'odt'
+            }
+          }
+        })
+        mockCdpService.initiate.mockResolvedValue(createStandardUploadConfig())
+
+        await waterFrameworkFileUploadController.handler(mockRequest, mockH)
+
+        expectViewCalledWith(mockH, {
+          errorSummary: expect.arrayContaining([
+            expect.objectContaining({ text: testMessage })
+          ])
+        })
+      })
+    })
+  })
+})

--- a/src/server/marine-licence/water-framework-directive/file-upload/controller.test.js
+++ b/src/server/marine-licence/water-framework-directive/file-upload/controller.test.js
@@ -121,7 +121,7 @@ describe('#fileUpload', () => {
           maxFileSize: 50000000,
           acceptAttribute: WFD_ACCEPT_ATTRIBUTE,
           backLink:
-            marineLicenceRoutes.MARINE_LICENCE_WATER_FRAMEWORK_DIRECTIVE_ASSESSMENT_CHANGED,
+            marineLicenceRoutes.MARINE_LICENCE_WATER_FRAMEWORK_DIRECTIVE_PREVIOUS_ASSESSMENT,
           cancelLink: marineLicenceRoutes.MARINE_LICENCE_TASK_LIST
         })
       })

--- a/src/server/marine-licence/water-framework-directive/file-upload/controller.test.js
+++ b/src/server/marine-licence/water-framework-directive/file-upload/controller.test.js
@@ -207,8 +207,7 @@ describe('#fileUpload', () => {
 
         expect(mockRequest.logger.error).toHaveBeenCalledWith(
           expect.objectContaining({
-            err: expect.any(Error),
-            marineLicenceId: mockMarineLicenceApplication.id
+            err: expect.any(Error)
           }),
           'Failed to initialize WFD file upload'
         )

--- a/src/server/marine-licence/water-framework-directive/file-upload/controller.test.js
+++ b/src/server/marine-licence/water-framework-directive/file-upload/controller.test.js
@@ -114,8 +114,8 @@ describe('#fileUpload', () => {
         await setupStandardFileUploadTest(mockRequest, mockH)
 
         expectViewCalledWith(mockH, {
-          pageTitle: 'Upload a file',
-          heading: 'Upload a file',
+          pageTitle: 'Upload your Water Framework Directive assessment',
+          heading: 'Upload your Water Framework Directive assessment',
           projectName: mockMarineLicenceApplication.projectName,
           uploadUrl: 'https://upload.example.com',
           maxFileSize: 50000000,

--- a/src/server/marine-licence/water-framework-directive/file-upload/index.js
+++ b/src/server/marine-licence/water-framework-directive/file-upload/index.js
@@ -1,0 +1,10 @@
+import { marineLicenceRoutes } from '#src/server/common/constants/routes.js'
+import { waterFrameworkFileUploadController } from '#src/server/marine-licence/water-framework-directive/file-upload/controller.js'
+
+export const waterFrameworkFileUploadRoutes = [
+  {
+    method: 'GET',
+    path: marineLicenceRoutes.MARINE_LICENCE_WATER_FRAMEWORK_DIRECTIVE_FILE_UPLOAD,
+    ...waterFrameworkFileUploadController
+  }
+]

--- a/src/server/marine-licence/water-framework-directive/file-upload/index.njk
+++ b/src/server/marine-licence/water-framework-directive/file-upload/index.njk
@@ -1,0 +1,73 @@
+{% extends 'layouts/page.njk' %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/file-upload/macro.njk" import govukFileUpload %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "cancel-button/macro.njk" import appCancelButton %}
+
+{% block beforeContent %}
+{{ super() }}
+<nav>
+  {{ govukBackLink({
+    text: "Back",
+    href: backLink
+  }) }}
+</nav>
+{% endblock %}
+
+{% set formLabel %}
+  {% if projectName %}
+    <span class="govuk-caption-l">{{ projectName }}</span>
+  {% endif %}
+
+  <h1 class="govuk-heading-l">
+    Upload your Water Framework Directive assessment
+  </h1>
+{% endset %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      {% if errorSummary %}
+        {{ govukErrorSummary({
+          titleText: "There is a problem",
+          errorList: errorSummary
+        }) }}
+      {% endif %}
+
+        <form action="{{ uploadUrl }}" method="post" enctype="multipart/form-data" novalidate>
+
+          {{ govukFileUpload({
+              id: "file-id",
+              name: "file",
+              label: {
+                html: formLabel,
+                for: "file-id"
+               },
+              multiple: false,
+              javascript: true,
+              errorMessage: { text: errors['file'].text } if errors and errors['file'] else false,
+              attributes: {
+                "accept": acceptAttribute
+              }
+          }) }}
+
+
+          <div class="govuk-button-group">
+            {{ govukButton({
+              text: "Continue",
+              type: "submit",
+              classes: "govuk-button--primary"
+            }) }}
+
+            {{ appCancelButton({
+              cancelLink: cancelLink
+            }) }}
+          </div>
+
+        </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/src/server/marine-licence/water-framework-directive/file-upload/index.njk
+++ b/src/server/marine-licence/water-framework-directive/file-upload/index.njk
@@ -21,7 +21,7 @@
   {% endif %}
 
   <h1 class="govuk-heading-l">
-    Upload your Water Framework Directive assessment
+    {{heading}}
   </h1>
 {% endset %}
 

--- a/src/server/marine-licence/water-framework-directive/file-upload/index.test.js
+++ b/src/server/marine-licence/water-framework-directive/file-upload/index.test.js
@@ -1,0 +1,13 @@
+import { waterFrameworkFileUploadRoutes } from '#src/server/marine-licence/water-framework-directive/file-upload/index.js'
+import { marineLicenceRoutes } from '#src/server/common/constants/routes.js'
+
+describe('waterFrameworkFileUploadRoutes routes', () => {
+  test('get route is formatted correctly', () => {
+    expect(waterFrameworkFileUploadRoutes[0]).toEqual(
+      expect.objectContaining({
+        method: 'GET',
+        path: marineLicenceRoutes.MARINE_LICENCE_WATER_FRAMEWORK_DIRECTIVE_FILE_UPLOAD
+      })
+    )
+  })
+})

--- a/src/server/marine-licence/water-framework-directive/file-upload/utils.js
+++ b/src/server/marine-licence/water-framework-directive/file-upload/utils.js
@@ -1,0 +1,9 @@
+import { marineLicenceRoutes } from '#src/server/common/constants/routes.js'
+
+export function getBackLink(previousAssessment) {
+  if (previousAssessment === 'no') {
+    return marineLicenceRoutes.MARINE_LICENCE_WATER_FRAMEWORK_DIRECTIVE_PREVIOUS_ASSESSMENT
+  }
+
+  return marineLicenceRoutes.MARINE_LICENCE_WATER_FRAMEWORK_DIRECTIVE_ASSESSMENT_CHANGED
+}

--- a/src/server/marine-licence/water-framework-directive/file-upload/utils.test.js
+++ b/src/server/marine-licence/water-framework-directive/file-upload/utils.test.js
@@ -1,0 +1,22 @@
+import { getBackLink } from '#src/server/marine-licence/water-framework-directive/file-upload/utils.js'
+import { marineLicenceRoutes } from '#src/server/common/constants/routes.js'
+
+describe('getBackLink', () => {
+  test('returns assessment-changed link when previousAssessment is yes', () => {
+    expect(getBackLink('yes')).toBe(
+      marineLicenceRoutes.MARINE_LICENCE_WATER_FRAMEWORK_DIRECTIVE_ASSESSMENT_CHANGED
+    )
+  })
+
+  test('returns previous-assessment link when previousAssessment is no', () => {
+    expect(getBackLink('no')).toBe(
+      marineLicenceRoutes.MARINE_LICENCE_WATER_FRAMEWORK_DIRECTIVE_PREVIOUS_ASSESSMENT
+    )
+  })
+
+  test('returns assessment-changed link when previousAssessment is undefined', () => {
+    expect(getBackLink(undefined)).toBe(
+      marineLicenceRoutes.MARINE_LICENCE_WATER_FRAMEWORK_DIRECTIVE_ASSESSMENT_CHANGED
+    )
+  })
+})

--- a/src/server/marine-licence/water-framework-directive/index.js
+++ b/src/server/marine-licence/water-framework-directive/index.js
@@ -3,11 +3,15 @@ import { waterFrameworkDirectiveNauticalMileRoutes } from '#src/server/marine-li
 import { waterFrameworkDirectiveExcludedActivitiesRoutes } from '#src/server/marine-licence/water-framework-directive/excluded-activities/index.js'
 import { waterFrameworkDirectivePreviousAssessmentRoutes } from '#src/server/marine-licence/water-framework-directive/previous-assessment/index.js'
 import { waterFrameworkDirectiveAssessmentChangedRoutes } from '#src/server/marine-licence/water-framework-directive/assessment-changed/index.js'
+import { waterFrameworkFileUploadRoutes } from '#src/server/marine-licence/water-framework-directive/file-upload/index.js'
+import { waterFrameworkDirectiveUploadAndWaitRoutes } from '#src/server/marine-licence/water-framework-directive/upload-and-wait/index.js'
 
 export const waterDirectiveRoutes = [
   ...waterFrameworkDirectiveBeforeYouStartRoutes,
   ...waterFrameworkDirectiveNauticalMileRoutes,
   ...waterFrameworkDirectiveExcludedActivitiesRoutes,
   ...waterFrameworkDirectivePreviousAssessmentRoutes,
-  ...waterFrameworkDirectiveAssessmentChangedRoutes
+  ...waterFrameworkDirectiveAssessmentChangedRoutes,
+  ...waterFrameworkFileUploadRoutes,
+  ...waterFrameworkDirectiveUploadAndWaitRoutes
 ]

--- a/src/server/marine-licence/water-framework-directive/nautical-mile/controller.js
+++ b/src/server/marine-licence/water-framework-directive/nautical-mile/controller.js
@@ -1,12 +1,9 @@
 import { getMarineLicenceCache } from '#src/server/common/helpers/marine-licence/session-cache/utils.js'
 import { updateWaterFrameworkDirective } from '#src/server/common/helpers/marine-licence/session-cache/water-framework-directive.js'
 import { createFailAction } from '#src/server/common/helpers/createFailAction.js'
-import {
-  apiRoutes,
-  marineLicenceRoutes
-} from '#src/server/common/constants/routes.js'
+import { marineLicenceRoutes } from '#src/server/common/constants/routes.js'
 import joi from 'joi'
-import { authenticatedPatchRequest } from '#src/server/common/helpers/authenticated-requests.js'
+import { saveWaterFrameworkDirectiveToBackend } from '#src/server/common/helpers/marine-licence/water-framework-directive/save-water-framework-directive.js'
 
 export const NAUTICAL_MILE_VIEW_ROUTE =
   'marine-licence/water-framework-directive/nautical-mile/index'
@@ -65,21 +62,7 @@ export const nauticalMileSubmitController = {
   async handler(request, h) {
     const { payload } = request
 
-    const marineLicence = getMarineLicenceCache(request)
-
     const { nauticalMile } = payload
-
-    if (nauticalMile === 'no') {
-      await authenticatedPatchRequest(
-        request,
-        apiRoutes.UPDATE_WATER_FRAMEWORK_DIRECTIVE,
-        {
-          waterFrameworkDirective: { nauticalMile },
-          id: marineLicence.id
-        }
-      )
-      return h.redirect(marineLicenceRoutes.MARINE_LICENCE_TASK_LIST)
-    }
 
     await updateWaterFrameworkDirective(
       request,
@@ -87,6 +70,11 @@ export const nauticalMileSubmitController = {
       'nauticalMile',
       nauticalMile
     )
+
+    if (nauticalMile === 'no') {
+      await saveWaterFrameworkDirectiveToBackend(request, true)
+      return h.redirect(marineLicenceRoutes.MARINE_LICENCE_TASK_LIST)
+    }
 
     return h.redirect(
       marineLicenceRoutes.MARINE_LICENCE_WATER_FRAMEWORK_DIRECTIVE_EXCLUDED_ACTIVITIES

--- a/src/server/marine-licence/water-framework-directive/nautical-mile/controller.test.js
+++ b/src/server/marine-licence/water-framework-directive/nautical-mile/controller.test.js
@@ -1,8 +1,5 @@
 import { vi } from 'vitest'
-import {
-  apiRoutes,
-  marineLicenceRoutes
-} from '#src/server/common/constants/routes.js'
+import { marineLicenceRoutes } from '#src/server/common/constants/routes.js'
 import {
   nauticalMileSubmitController,
   NAUTICAL_MILE_VIEW_ROUTE,
@@ -11,10 +8,12 @@ import {
 import * as cacheUtils from '#src/server/common/helpers/marine-licence/session-cache/utils.js'
 import * as wfdCache from '#src/server/common/helpers/marine-licence/session-cache/water-framework-directive.js'
 import { createMockH } from '#src/server/test-helpers/mocks/helpers.js'
-import { authenticatedPatchRequest } from '#src/server/common/helpers/authenticated-requests.js'
+import { saveWaterFrameworkDirectiveToBackend } from '#src/server/common/helpers/marine-licence/water-framework-directive/save-water-framework-directive.js'
 
 vi.mock('~/src/server/common/helpers/marine-licence/session-cache/utils.js')
-vi.mock('~/src/server/common/helpers/authenticated-requests.js')
+vi.mock(
+  '~/src/server/common/helpers/marine-licence/water-framework-directive/save-water-framework-directive.js'
+)
 
 describe('#nauticalMile', () => {
   const h = createMockH()
@@ -83,10 +82,9 @@ describe('#nauticalMile', () => {
         h
       )
 
-      expect(authenticatedPatchRequest).toHaveBeenCalledWith(
+      expect(saveWaterFrameworkDirectiveToBackend).toHaveBeenCalledWith(
         expect.any(Object),
-        apiRoutes.UPDATE_WATER_FRAMEWORK_DIRECTIVE,
-        { waterFrameworkDirective: { nauticalMile: 'no' }, id: mockLicence.id }
+        true
       )
       expect(h.redirect).toHaveBeenCalledWith(
         marineLicenceRoutes.MARINE_LICENCE_TASK_LIST

--- a/src/server/marine-licence/water-framework-directive/previous-assessment/controller.js
+++ b/src/server/marine-licence/water-framework-directive/previous-assessment/controller.js
@@ -82,8 +82,10 @@ export const previousAssessmentSubmitController = {
       )
     }
 
+    await updateWaterFrameworkDirective(request, h, 'assessmentChanged', null)
+
     return h.redirect(
-      marineLicenceRoutes.MARINE_LICENCE_WATER_FRAMEWORK_DIRECTIVE_PREVIOUS_ASSESSMENT
+      marineLicenceRoutes.MARINE_LICENCE_WATER_FRAMEWORK_DIRECTIVE_FILE_UPLOAD
     )
   }
 }

--- a/src/server/marine-licence/water-framework-directive/previous-assessment/controller.test.js
+++ b/src/server/marine-licence/water-framework-directive/previous-assessment/controller.test.js
@@ -84,8 +84,14 @@ describe('#previousAssessment', () => {
         'previousAssessment',
         'no'
       )
+      expect(wfdCache.updateWaterFrameworkDirective).toHaveBeenCalledWith(
+        expect.any(Object),
+        h,
+        'assessmentChanged',
+        null
+      )
       expect(h.redirect).toHaveBeenCalledWith(
-        marineLicenceRoutes.MARINE_LICENCE_WATER_FRAMEWORK_DIRECTIVE_PREVIOUS_ASSESSMENT
+        marineLicenceRoutes.MARINE_LICENCE_WATER_FRAMEWORK_DIRECTIVE_FILE_UPLOAD
       )
     })
 

--- a/src/server/marine-licence/water-framework-directive/upload-and-wait/controller.js
+++ b/src/server/marine-licence/water-framework-directive/upload-and-wait/controller.js
@@ -9,6 +9,7 @@ import {
   uploadAndWaitPageSettings
 } from '#src/server/common/helpers/file-upload/constants.js'
 import { saveWaterFrameworkDirectiveToBackend } from '#src/server/common/helpers/marine-licence/water-framework-directive/save-water-framework-directive.js'
+import { config } from '#src/config/config.js'
 
 const fileUploadRoute =
   marineLicenceRoutes.MARINE_LICENCE_WATER_FRAMEWORK_DIRECTIVE_FILE_UPLOAD
@@ -32,13 +33,23 @@ const handleProcessingStatus = (status, marineLicence, h) => {
   })
 }
 
-const handleReadyStatus = async (status, request, h) => {
+const handleReadyStatus = async (status, context) => {
+  const { request, h } = context
+
   await updateWaterFrameworkDirective(request, h, 'uploadedFile', {
-    filename: status.filename,
-    contentType: status.contentType,
-    fileId: status.s3Location?.fileId,
-    s3Key: status.s3Location?.s3Key
+    filename: status.filename
   })
+
+  if (status.s3Location) {
+    const cdpUploadConfig = config.get('cdpUploader')
+
+    await updateWaterFrameworkDirective(request, h, 's3Location', {
+      s3Bucket: cdpUploadConfig.s3Bucket,
+      s3Key: status.s3Location.s3Key,
+      checksumSha256: status.s3Location.checksumSha256
+    })
+  }
+
   await updateWaterFrameworkDirective(request, h, 'uploadConfig', null)
 
   await saveWaterFrameworkDirectiveToBackend(request)
@@ -76,7 +87,7 @@ const processUploadStatus = async (status, context) => {
   }
 
   if (status.status === 'ready') {
-    return handleReadyStatus(status, request, h)
+    return handleReadyStatus(status, context)
   }
 
   if (status.status === 'rejected' || status.status === 'error') {

--- a/src/server/marine-licence/water-framework-directive/upload-and-wait/controller.js
+++ b/src/server/marine-licence/water-framework-directive/upload-and-wait/controller.js
@@ -1,0 +1,124 @@
+import { marineLicenceRoutes } from '#src/server/common/constants/routes.js'
+import { getMarineLicenceCache } from '#src/server/common/helpers/marine-licence/session-cache/utils.js'
+import { updateWaterFrameworkDirective } from '#src/server/common/helpers/marine-licence/session-cache/water-framework-directive.js'
+import { getCdpUploadService } from '#src/services/cdp-upload-service/index.js'
+import { getCdpErrorMessageFromCode } from '#src/server/common/helpers/file-upload/file-upload.js'
+import { DEFAULT_ERROR_MESSAGE } from '#src/server/common/helpers/file-upload/error-messages.js'
+import {
+  UPLOAD_AND_WAIT_VIEW_ROUTE,
+  uploadAndWaitPageSettings
+} from '#src/server/common/helpers/file-upload/constants.js'
+
+const fileUploadRoute =
+  marineLicenceRoutes.MARINE_LICENCE_WATER_FRAMEWORK_DIRECTIVE_FILE_UPLOAD
+
+const storeUploadError = async (request, h, errorDetails) => {
+  await updateWaterFrameworkDirective(request, h, 'uploadError', {
+    message: errorDetails.message,
+    fieldName: errorDetails.fieldName
+  })
+  await updateWaterFrameworkDirective(request, h, 'uploadConfig', null)
+}
+
+const handleProcessingStatus = (status, marineLicence, h) => {
+  return h.view(UPLOAD_AND_WAIT_VIEW_ROUTE, {
+    ...uploadAndWaitPageSettings,
+    projectName: marineLicence.projectName,
+    isProcessing: true,
+    filename: status.filename,
+    tryAgainLink: fileUploadRoute,
+    cancelLink: marineLicenceRoutes.MARINE_LICENCE_TASK_LIST
+  })
+}
+
+const handleReadyStatus = async (status, request, h) => {
+  await updateWaterFrameworkDirective(request, h, 'uploadedFile', {
+    filename: status.filename,
+    contentType: status.contentType,
+    fileId: status.s3Location?.fileId,
+    s3Key: status.s3Location?.s3Key
+  })
+  await updateWaterFrameworkDirective(request, h, 'uploadConfig', null)
+  return h.redirect(marineLicenceRoutes.MARINE_LICENCE_TASK_LIST)
+}
+
+const handleRejectedStatus = async (status, request, h) => {
+  const errorMessage = status.errorCode
+    ? getCdpErrorMessageFromCode(status.errorCode)
+    : DEFAULT_ERROR_MESSAGE
+
+  request.logger.error(
+    { error: { code: status.errorCode, message: status.message } },
+    'WFD FileUpload: CDP rejection error'
+  )
+
+  await storeUploadError(request, h, {
+    message: errorMessage,
+    fieldName: 'file'
+  })
+
+  return h.redirect(fileUploadRoute)
+}
+
+const processUploadStatus = async (status, context) => {
+  const { uploadConfig, request, h, marineLicence } = context
+
+  request.logger.debug(
+    `WFD upload status check: ${JSON.stringify({ uploadId: uploadConfig.uploadId, status: status.status, filename: status.filename }, null, 2)}`
+  )
+
+  if (status.status === 'pending' || status.status === 'scanning') {
+    return handleProcessingStatus(status, marineLicence, h)
+  }
+
+  if (status.status === 'ready') {
+    return handleReadyStatus(status, request, h)
+  }
+
+  if (status.status === 'rejected' || status.status === 'error') {
+    return handleRejectedStatus(status, request, h)
+  }
+
+  request.logger.warn(
+    { uploadId: uploadConfig.uploadId, status: status.status },
+    'WFD FileUpload: Unknown upload status'
+  )
+
+  return h.redirect(fileUploadRoute)
+}
+
+export const waterFrameworkDirectiveUploadAndWaitController = {
+  async handler(request, h) {
+    const marineLicence = getMarineLicenceCache(request)
+    const { waterFrameworkDirective = {} } = marineLicence
+    const { uploadConfig } = waterFrameworkDirective
+
+    if (!uploadConfig) {
+      return h.redirect(fileUploadRoute)
+    }
+
+    try {
+      const cdpService = getCdpUploadService()
+      const status = await cdpService.getStatus(
+        uploadConfig.uploadId,
+        uploadConfig.statusUrl
+      )
+
+      return await processUploadStatus(status, {
+        uploadConfig,
+        request,
+        h,
+        marineLicence
+      })
+    } catch (error) {
+      request.logger.error(
+        { err: error, uploadId: uploadConfig.uploadId },
+        'WFD FileUpload: Failed to check upload status'
+      )
+
+      await updateWaterFrameworkDirective(request, h, 'uploadConfig', null)
+
+      return h.redirect(fileUploadRoute)
+    }
+  }
+}

--- a/src/server/marine-licence/water-framework-directive/upload-and-wait/controller.js
+++ b/src/server/marine-licence/water-framework-directive/upload-and-wait/controller.js
@@ -127,7 +127,7 @@ export const waterFrameworkDirectiveUploadAndWaitController = {
       })
     } catch (error) {
       request.logger.error(
-        { err: error, uploadId: uploadConfig.uploadId },
+        { err: error },
         'WFD FileUpload: Failed to check upload status'
       )
 

--- a/src/server/marine-licence/water-framework-directive/upload-and-wait/controller.js
+++ b/src/server/marine-licence/water-framework-directive/upload-and-wait/controller.js
@@ -8,6 +8,7 @@ import {
   UPLOAD_AND_WAIT_VIEW_ROUTE,
   uploadAndWaitPageSettings
 } from '#src/server/common/helpers/file-upload/constants.js'
+import { saveWaterFrameworkDirectiveToBackend } from '#src/server/common/helpers/marine-licence/water-framework-directive/save-water-framework-directive.js'
 
 const fileUploadRoute =
   marineLicenceRoutes.MARINE_LICENCE_WATER_FRAMEWORK_DIRECTIVE_FILE_UPLOAD
@@ -39,6 +40,9 @@ const handleReadyStatus = async (status, request, h) => {
     s3Key: status.s3Location?.s3Key
   })
   await updateWaterFrameworkDirective(request, h, 'uploadConfig', null)
+
+  await saveWaterFrameworkDirectiveToBackend(request)
+
   return h.redirect(marineLicenceRoutes.MARINE_LICENCE_TASK_LIST)
 }
 

--- a/src/server/marine-licence/water-framework-directive/upload-and-wait/controller.test.js
+++ b/src/server/marine-licence/water-framework-directive/upload-and-wait/controller.test.js
@@ -6,6 +6,7 @@ import * as wfdCacheUtils from '#src/server/common/helpers/marine-licence/sessio
 import * as cdpUploadService from '#src/services/cdp-upload-service/index.js'
 import { marineLicenceRoutes } from '#src/server/common/constants/routes.js'
 import { saveWaterFrameworkDirectiveToBackend } from '#src/server/common/helpers/marine-licence/water-framework-directive/save-water-framework-directive.js'
+import { config } from '#src/config/config.js'
 
 vi.mock('~/src/server/common/helpers/marine-licence/session-cache/utils.js')
 vi.mock('~/src/services/cdp-upload-service/index.js')
@@ -196,10 +197,18 @@ describe('#uploadAndWait', () => {
           h,
           'uploadedFile',
           {
-            filename: 'test.odt',
-            contentType: 'application/vnd.oasis.opendocument.text',
-            fileId: 'test-id',
-            s3Key: 'test-key'
+            filename: 'test.odt'
+          }
+        )
+
+        expect(updateWaterFrameworkDirectiveSpy).toHaveBeenCalledWith(
+          mockRequest,
+          h,
+          's3Location',
+          {
+            s3Bucket: config.get('cdpUploader').s3Bucket,
+            s3Key: 'test-key',
+            checksumSha256: 'test-checksum'
           }
         )
 
@@ -234,10 +243,7 @@ describe('#uploadAndWait', () => {
           h,
           'uploadedFile',
           {
-            filename: 'test.odt',
-            contentType: 'application/vnd.oasis.opendocument.text',
-            fileId: undefined,
-            s3Key: undefined
+            filename: 'test.odt'
           }
         )
 

--- a/src/server/marine-licence/water-framework-directive/upload-and-wait/controller.test.js
+++ b/src/server/marine-licence/water-framework-directive/upload-and-wait/controller.test.js
@@ -1,0 +1,373 @@
+import { vi } from 'vitest'
+import { waterFrameworkDirectiveUploadAndWaitController } from '#src/server/marine-licence/water-framework-directive/upload-and-wait/controller.js'
+import { UPLOAD_AND_WAIT_VIEW_ROUTE } from '#src/server/common/helpers/file-upload/constants.js'
+import * as mlCacheUtils from '#src/server/common/helpers/marine-licence/session-cache/utils.js'
+import * as wfdCacheUtils from '#src/server/common/helpers/marine-licence/session-cache/water-framework-directive.js'
+import * as cdpUploadService from '#src/services/cdp-upload-service/index.js'
+import { marineLicenceRoutes } from '#src/server/common/constants/routes.js'
+
+vi.mock('~/src/server/common/helpers/marine-licence/session-cache/utils.js')
+vi.mock('~/src/services/cdp-upload-service/index.js')
+vi.mock(
+  '~/src/server/common/helpers/marine-licence/session-cache/water-framework-directive.js'
+)
+
+vi.mock('~/src/server/common/helpers/logging/logger-options.js', () => ({
+  loggerOptions: {
+    enabled: true,
+    ignorePaths: ['/health'],
+    redact: { paths: [] }
+  }
+}))
+
+vi.mock('~/src/server/common/helpers/logging/logger.js', () => ({
+  createLogger: vi.fn().mockReturnValue({
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn()
+  })
+}))
+
+// Test Data Factories
+const createMockUploadConfig = (overrides = {}) => ({
+  uploadId: 'test-upload-id',
+  statusUrl: 'test-status-url',
+  ...overrides
+})
+
+const createMockStatusResponse = (status, overrides = {}) => ({
+  status,
+  filename: 'test.odt',
+  fileSize: 1024,
+  contentType: 'application/vnd.oasis.opendocument.text',
+  completedAt: '2025-01-01T00:00:00.000Z',
+  ...(status === 'ready' && {
+    s3Location: {
+      s3Bucket: 'test-bucket',
+      s3Key: 'test-key',
+      fileId: 'test-id',
+      s3Url: 'test-url',
+      checksumSha256: 'test-checksum'
+    }
+  }),
+  ...overrides
+})
+
+const createMockMarineLicence = (overrides = {}) => ({
+  projectName: 'Test Project',
+  waterFrameworkDirective: {
+    uploadConfig: createMockUploadConfig()
+  },
+  ...overrides
+})
+
+const createMockRequest = () => ({
+  logger: {
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn()
+  },
+  yar: { get: vi.fn(), set: vi.fn(), commit: vi.fn() }
+})
+
+const createMockResponseHandler = () => ({
+  view: vi.fn(),
+  redirect: vi.fn()
+})
+
+const wfdFileUploadRoute =
+  marineLicenceRoutes.MARINE_LICENCE_WATER_FRAMEWORK_DIRECTIVE_FILE_UPLOAD
+
+describe('#uploadAndWait', () => {
+  let getMarineLicenceCacheSpy
+  let updateWaterFrameworkDirectiveSpy
+  let mockCdpService
+
+  beforeEach(() => {
+    getMarineLicenceCacheSpy = vi
+      .spyOn(mlCacheUtils, 'getMarineLicenceCache')
+      .mockReturnValue(createMockMarineLicence())
+
+    updateWaterFrameworkDirectiveSpy = vi
+      .spyOn(wfdCacheUtils, 'updateWaterFrameworkDirective')
+      .mockResolvedValue()
+
+    mockCdpService = { getStatus: vi.fn() }
+    vi.spyOn(cdpUploadService, 'getCdpUploadService').mockReturnValue(
+      mockCdpService
+    )
+  })
+
+  describe('#waterFrameworkDirectiveUploadAndWaitController', () => {
+    let mockRequest
+    let h
+
+    beforeEach(() => {
+      mockRequest = createMockRequest()
+      h = createMockResponseHandler()
+    })
+
+    describe('when no upload config exists', () => {
+      test('should redirect to WFD file upload', async () => {
+        getMarineLicenceCacheSpy.mockReturnValue({
+          projectName: 'Test Project',
+          waterFrameworkDirective: {}
+        })
+
+        await waterFrameworkDirectiveUploadAndWaitController.handler(
+          mockRequest,
+          h
+        )
+
+        expect(h.redirect).toHaveBeenCalledWith(wfdFileUploadRoute)
+      })
+    })
+
+    describe('when checking upload status', () => {
+      test.each(['pending', 'scanning'])(
+        'should show waiting page when status is %s',
+        async (status) => {
+          mockCdpService.getStatus.mockResolvedValue(
+            createMockStatusResponse(status)
+          )
+
+          await waterFrameworkDirectiveUploadAndWaitController.handler(
+            mockRequest,
+            h
+          )
+
+          expect(mockCdpService.getStatus).toHaveBeenCalledWith(
+            'test-upload-id',
+            'test-status-url'
+          )
+
+          expect(h.view).toHaveBeenCalledWith(UPLOAD_AND_WAIT_VIEW_ROUTE, {
+            pageTitle: 'Checking your file...',
+            heading: 'Checking your file...',
+            projectName: 'Test Project',
+            isProcessing: true,
+            pageRefreshTimeInSeconds: 2,
+            filename: 'test.odt',
+            tryAgainLink: wfdFileUploadRoute,
+            cancelLink: marineLicenceRoutes.MARINE_LICENCE_TASK_LIST
+          })
+        }
+      )
+
+      test('should redirect to WFD file upload for unknown status', async () => {
+        mockCdpService.getStatus.mockResolvedValue({
+          status: 'unknown',
+          filename: 'test.odt'
+        })
+
+        await waterFrameworkDirectiveUploadAndWaitController.handler(
+          mockRequest,
+          h
+        )
+
+        expect(mockRequest.logger.warn).toHaveBeenCalledWith(
+          { uploadId: 'test-upload-id', status: 'unknown' },
+          'WFD FileUpload: Unknown upload status'
+        )
+
+        expect(h.redirect).toHaveBeenCalledWith(wfdFileUploadRoute)
+      })
+    })
+
+    describe('when file upload is ready', () => {
+      test('should save uploaded file details and redirect to task list', async () => {
+        mockCdpService.getStatus.mockResolvedValue(
+          createMockStatusResponse('ready')
+        )
+
+        await waterFrameworkDirectiveUploadAndWaitController.handler(
+          mockRequest,
+          h
+        )
+
+        expect(updateWaterFrameworkDirectiveSpy).toHaveBeenCalledWith(
+          mockRequest,
+          h,
+          'uploadedFile',
+          {
+            filename: 'test.odt',
+            contentType: 'application/vnd.oasis.opendocument.text',
+            fileId: 'test-id',
+            s3Key: 'test-key'
+          }
+        )
+
+        expect(updateWaterFrameworkDirectiveSpy).toHaveBeenCalledWith(
+          mockRequest,
+          h,
+          'uploadConfig',
+          null
+        )
+
+        expect(h.redirect).toHaveBeenCalledWith(
+          marineLicenceRoutes.MARINE_LICENCE_TASK_LIST
+        )
+      })
+
+      test('should handle missing s3Location gracefully and still redirect', async () => {
+        const statusResponse = createMockStatusResponse('ready')
+        delete statusResponse.s3Location
+        mockCdpService.getStatus.mockResolvedValue(statusResponse)
+
+        await waterFrameworkDirectiveUploadAndWaitController.handler(
+          mockRequest,
+          h
+        )
+
+        expect(updateWaterFrameworkDirectiveSpy).toHaveBeenCalledWith(
+          mockRequest,
+          h,
+          'uploadedFile',
+          {
+            filename: 'test.odt',
+            contentType: 'application/vnd.oasis.opendocument.text',
+            fileId: undefined,
+            s3Key: undefined
+          }
+        )
+
+        expect(h.redirect).toHaveBeenCalledWith(
+          marineLicenceRoutes.MARINE_LICENCE_TASK_LIST
+        )
+      })
+    })
+
+    describe('when upload is rejected', () => {
+      test('should store virus error, log it, and redirect to WFD file upload', async () => {
+        mockCdpService.getStatus.mockResolvedValue({
+          status: 'rejected',
+          errorCode: 'VIRUS_DETECTED',
+          message: 'The selected file contains a virus'
+        })
+
+        await waterFrameworkDirectiveUploadAndWaitController.handler(
+          mockRequest,
+          h
+        )
+
+        expect(mockRequest.logger.error).toHaveBeenCalledWith(
+          {
+            error: {
+              code: 'VIRUS_DETECTED',
+              message: 'The selected file contains a virus'
+            }
+          },
+          'WFD FileUpload: CDP rejection error'
+        )
+
+        expect(updateWaterFrameworkDirectiveSpy).toHaveBeenCalledWith(
+          mockRequest,
+          h,
+          'uploadError',
+          {
+            message: 'The selected file contains a virus',
+            fieldName: 'file'
+          }
+        )
+
+        expect(updateWaterFrameworkDirectiveSpy).toHaveBeenCalledWith(
+          mockRequest,
+          h,
+          'uploadConfig',
+          null
+        )
+
+        expect(h.redirect).toHaveBeenCalledWith(wfdFileUploadRoute)
+      })
+
+      test.each([
+        {
+          scenario: 'rejected status with no errorCode',
+          status: 'rejected',
+          message: 'Unknown rejection'
+        },
+        {
+          scenario: 'error status',
+          status: 'error',
+          message: 'Processing failed'
+        }
+      ])(
+        'should use default error message for $scenario',
+        async ({ status, message }) => {
+          mockCdpService.getStatus.mockResolvedValue({ status, message })
+
+          await waterFrameworkDirectiveUploadAndWaitController.handler(
+            mockRequest,
+            h
+          )
+
+          expect(updateWaterFrameworkDirectiveSpy).toHaveBeenCalledWith(
+            mockRequest,
+            h,
+            'uploadError',
+            {
+              message: 'The selected file could not be uploaded – try again',
+              fieldName: 'file'
+            }
+          )
+
+          expect(h.redirect).toHaveBeenCalledWith(wfdFileUploadRoute)
+        }
+      )
+    })
+
+    describe('when service errors occur', () => {
+      test('should handle CDP service errors gracefully', async () => {
+        mockCdpService.getStatus.mockRejectedValue(
+          new Error('Service unavailable')
+        )
+
+        await waterFrameworkDirectiveUploadAndWaitController.handler(
+          mockRequest,
+          h
+        )
+
+        expect(mockRequest.logger.error).toHaveBeenCalledWith(
+          { err: expect.any(Error), uploadId: 'test-upload-id' },
+          'WFD FileUpload: Failed to check upload status'
+        )
+
+        expect(updateWaterFrameworkDirectiveSpy).toHaveBeenCalledWith(
+          mockRequest,
+          h,
+          'uploadConfig',
+          null
+        )
+
+        expect(h.redirect).toHaveBeenCalledWith(wfdFileUploadRoute)
+      })
+    })
+
+    describe('edge cases', () => {
+      test('should handle empty filename in pending status response', async () => {
+        mockCdpService.getStatus.mockResolvedValue({
+          status: 'pending',
+          filename: ''
+        })
+
+        await waterFrameworkDirectiveUploadAndWaitController.handler(
+          mockRequest,
+          h
+        )
+
+        expect(h.view).toHaveBeenCalledWith(UPLOAD_AND_WAIT_VIEW_ROUTE, {
+          pageTitle: 'Checking your file...',
+          heading: 'Checking your file...',
+          projectName: 'Test Project',
+          isProcessing: true,
+          pageRefreshTimeInSeconds: 2,
+          filename: '',
+          tryAgainLink: wfdFileUploadRoute,
+          cancelLink: marineLicenceRoutes.MARINE_LICENCE_TASK_LIST
+        })
+      })
+    })
+  })
+})

--- a/src/server/marine-licence/water-framework-directive/upload-and-wait/controller.test.js
+++ b/src/server/marine-licence/water-framework-directive/upload-and-wait/controller.test.js
@@ -344,7 +344,7 @@ describe('#uploadAndWait', () => {
         )
 
         expect(mockRequest.logger.error).toHaveBeenCalledWith(
-          { err: expect.any(Error), uploadId: 'test-upload-id' },
+          { err: expect.any(Error) },
           'WFD FileUpload: Failed to check upload status'
         )
 

--- a/src/server/marine-licence/water-framework-directive/upload-and-wait/controller.test.js
+++ b/src/server/marine-licence/water-framework-directive/upload-and-wait/controller.test.js
@@ -5,11 +5,15 @@ import * as mlCacheUtils from '#src/server/common/helpers/marine-licence/session
 import * as wfdCacheUtils from '#src/server/common/helpers/marine-licence/session-cache/water-framework-directive.js'
 import * as cdpUploadService from '#src/services/cdp-upload-service/index.js'
 import { marineLicenceRoutes } from '#src/server/common/constants/routes.js'
+import { saveWaterFrameworkDirectiveToBackend } from '#src/server/common/helpers/marine-licence/water-framework-directive/save-water-framework-directive.js'
 
 vi.mock('~/src/server/common/helpers/marine-licence/session-cache/utils.js')
 vi.mock('~/src/services/cdp-upload-service/index.js')
 vi.mock(
   '~/src/server/common/helpers/marine-licence/session-cache/water-framework-directive.js'
+)
+vi.mock(
+  '~/src/server/common/helpers/marine-licence/water-framework-directive/save-water-framework-directive.js'
 )
 
 vi.mock('~/src/server/common/helpers/logging/logger-options.js', () => ({
@@ -204,6 +208,10 @@ describe('#uploadAndWait', () => {
           h,
           'uploadConfig',
           null
+        )
+
+        expect(saveWaterFrameworkDirectiveToBackend).toHaveBeenCalledWith(
+          expect.any(Object)
         )
 
         expect(h.redirect).toHaveBeenCalledWith(

--- a/src/server/marine-licence/water-framework-directive/upload-and-wait/index.js
+++ b/src/server/marine-licence/water-framework-directive/upload-and-wait/index.js
@@ -1,0 +1,10 @@
+import { waterFrameworkDirectiveUploadAndWaitController } from '#src/server/marine-licence/water-framework-directive/upload-and-wait/controller.js'
+import { marineLicenceRoutes } from '#src/server/common/constants/routes.js'
+
+export const waterFrameworkDirectiveUploadAndWaitRoutes = [
+  {
+    method: 'GET',
+    path: marineLicenceRoutes.MARINE_LICENCE_WATER_FRAMEWORK_DIRECTIVE_UPLOAD_AND_WAIT,
+    ...waterFrameworkDirectiveUploadAndWaitController
+  }
+]

--- a/src/server/marine-licence/water-framework-directive/upload-and-wait/index.test.js
+++ b/src/server/marine-licence/water-framework-directive/upload-and-wait/index.test.js
@@ -1,0 +1,13 @@
+import { marineLicenceRoutes } from '#src/server/common/constants/routes.js'
+import { waterFrameworkDirectiveUploadAndWaitRoutes } from '#src/server/marine-licence/water-framework-directive/upload-and-wait/index.js'
+
+describe('waterFrameworkDirectiveUploadAndWaitRoutes routes', () => {
+  test('get route is formatted correctly', () => {
+    expect(waterFrameworkDirectiveUploadAndWaitRoutes[0]).toEqual(
+      expect.objectContaining({
+        method: 'GET',
+        path: marineLicenceRoutes.MARINE_LICENCE_WATER_FRAMEWORK_DIRECTIVE_UPLOAD_AND_WAIT
+      })
+    )
+  })
+})

--- a/src/server/test-helpers/mocks/marine-licence-mocks.js
+++ b/src/server/test-helpers/mocks/marine-licence-mocks.js
@@ -50,7 +50,10 @@ export const mockOutputEmptyActivityDetails = {
 }
 
 export const waterFrameworkDirective = {
-  nauticalMile: 'yes'
+  nauticalMile: 'yes',
+  assessmentChanged: 'no',
+  excludedActivities: 'no',
+  previousAssessment: 'no'
 }
 
 export const mockMarineLicenceApplication = {

--- a/src/server/test-helpers/mocks/marine-licence-mocks.js
+++ b/src/server/test-helpers/mocks/marine-licence-mocks.js
@@ -53,7 +53,15 @@ export const waterFrameworkDirective = {
   nauticalMile: 'yes',
   assessmentChanged: 'no',
   excludedActivities: 'no',
-  previousAssessment: 'no'
+  previousAssessment: 'no',
+  uploadedFile: {
+    filename: 'test-upload-id'
+  },
+  s3Location: {
+    checksumSha256: 'test-checksum',
+    s3Bucket: 'test-bucket',
+    s3Key: 'test-key'
+  }
 }
 
 export const mockMarineLicenceApplication = {

--- a/tests/integration/marine-licence/water-framework-directive/file-upload.test.js
+++ b/tests/integration/marine-licence/water-framework-directive/file-upload.test.js
@@ -1,0 +1,60 @@
+import { vi } from 'vitest'
+import { marineLicenceRoutes } from '~/src/server/common/constants/routes.js'
+import {
+  mockMarineLicence,
+  setupTestServer
+} from '~/tests/integration/shared/test-setup-helpers.js'
+import { loadPage } from '~/tests/integration/shared/app-server.js'
+import * as cdpUploadService from '~/src/services/cdp-upload-service/index.js'
+import { mockMarineLicenceApplication } from '#src/server/test-helpers/mocks/marine-licence-mocks.js'
+import { getByLabelText, getByRole } from '@testing-library/dom'
+
+vi.mock('~/src/services/cdp-upload-service/index.js')
+
+describe('File upload page (Water Framework Directive)', () => {
+  const getServer = setupTestServer()
+
+  beforeEach(() => {
+    const mockCdpService = {
+      initiate: vi.fn().mockResolvedValue({
+        uploadId: 'test-upload-id',
+        uploadUrl: 'https://upload.example.com',
+        statusUrl: 'https://status.example.com',
+        maxFileSize: 50000000
+      })
+    }
+
+    vi.mocked(cdpUploadService.getCdpUploadService).mockReturnValue(
+      mockCdpService
+    )
+
+    mockMarineLicence(mockMarineLicenceApplication)
+  })
+
+  test('renders page content', async () => {
+    const document = await loadPage({
+      requestUrl:
+        marineLicenceRoutes.MARINE_LICENCE_WATER_FRAMEWORK_DIRECTIVE_FILE_UPLOAD,
+      server: getServer()
+    })
+
+    const h1 = getByRole(document, 'heading', { level: 1 })
+    expect(h1).toHaveTextContent(
+      'Upload your Water Framework Directive assessment'
+    )
+
+    const uploadInput = getByLabelText(
+      document,
+      /Upload your Water Framework Directive assessment/
+    )
+    expect(uploadInput).toBeInTheDocument()
+
+    const continueButton = getByRole(document, 'button', { name: 'Continue' })
+    expect(continueButton).toBeInTheDocument()
+
+    expect(getByRole(document, 'link', { name: 'Cancel' })).toHaveAttribute(
+      'href',
+      marineLicenceRoutes.MARINE_LICENCE_TASK_LIST
+    )
+  })
+})

--- a/tests/integration/marine-licence/water-framework-directive/upload-and-wait.test.js
+++ b/tests/integration/marine-licence/water-framework-directive/upload-and-wait.test.js
@@ -1,0 +1,100 @@
+import { vi } from 'vitest'
+import { marineLicenceRoutes } from '~/src/server/common/constants/routes.js'
+import {
+  mockMarineLicence,
+  setupTestServer
+} from '~/tests/integration/shared/test-setup-helpers.js'
+import { loadPage } from '~/tests/integration/shared/app-server.js'
+import { makeGetRequest } from '~/src/server/test-helpers/server-requests.js'
+import * as cdpUploadService from '~/src/services/cdp-upload-service/index.js'
+import { mockMarineLicenceApplication } from '#src/server/test-helpers/mocks/marine-licence-mocks.js'
+import { getByRole } from '@testing-library/dom'
+import { statusCodes } from '~/src/server/common/constants/status-codes.js'
+
+vi.mock('~/src/services/cdp-upload-service/index.js')
+
+describe('Upload and wait page (Water Framework Directive)', () => {
+  const getServer = setupTestServer()
+  let mockCdpService
+
+  beforeEach(() => {
+    mockCdpService = {
+      getStatus: vi.fn()
+    }
+
+    vi.mocked(cdpUploadService.getCdpUploadService).mockReturnValue(
+      mockCdpService
+    )
+  })
+
+  const loadPageWithStatus = (status) => {
+    mockMarineLicence({
+      ...mockMarineLicenceApplication,
+      waterFrameworkDirective: {
+        uploadConfig: {
+          uploadId: 'test-upload-id',
+          statusUrl: 'test-status-url',
+          fileType: 'kml'
+        }
+      }
+    })
+    mockCdpService.getStatus.mockResolvedValue({
+      status,
+      filename: 'test.kml'
+    })
+
+    return loadPage({
+      requestUrl:
+        marineLicenceRoutes.MARINE_LICENCE_WATER_FRAMEWORK_DIRECTIVE_UPLOAD_AND_WAIT,
+      server: getServer()
+    })
+  }
+
+  const fileUploadRoute =
+    marineLicenceRoutes.MARINE_LICENCE_WATER_FRAMEWORK_DIRECTIVE_FILE_UPLOAD
+
+  const getRedirectResponse = () => {
+    mockMarineLicence({
+      ...mockMarineLicenceApplication,
+      siteDetails: [{}]
+    })
+
+    return makeGetRequest({
+      url: marineLicenceRoutes.MARINE_LICENCE_WATER_FRAMEWORK_DIRECTIVE_UPLOAD_AND_WAIT,
+      server: getServer()
+    })
+  }
+
+  test('should show loading spinner when status is pending', async () => {
+    const document = await loadPageWithStatus('pending')
+
+    expect(document.querySelector('.app-loading-spinner')).toBeInTheDocument()
+    expect(
+      getByRole(document, 'heading', {
+        level: 1,
+        name: 'Checking your file...'
+      })
+    ).toBeInTheDocument()
+  })
+
+  test('should show loading spinner when status is scanning', async () => {
+    const document = await loadPageWithStatus('scanning')
+
+    expect(document.querySelector('.app-loading-spinner')).toBeInTheDocument()
+  })
+
+  test('should include meta refresh tag when processing', async () => {
+    const document = await loadPageWithStatus('pending')
+
+    const metaRefresh = document.querySelector('meta[http-equiv="refresh"]')
+    expect(metaRefresh).toBeInTheDocument()
+    expect(metaRefresh.getAttribute('content')).toBe('2')
+  })
+
+  test('should redirect to file upload when no upload config is present', async () => {
+    const { statusCode, headers } = await getRedirectResponse()
+
+    expect(statusCode).toBe(statusCodes.redirect)
+    expect(headers.location).toBe(fileUploadRoute)
+  })
+})

--- a/tests/integration/marine-licence/water-framework-directive/upload-and-wait.test.js
+++ b/tests/integration/marine-licence/water-framework-directive/upload-and-wait.test.js
@@ -12,6 +12,9 @@ import { getByRole } from '@testing-library/dom'
 import { statusCodes } from '~/src/server/common/constants/status-codes.js'
 
 vi.mock('~/src/services/cdp-upload-service/index.js')
+vi.mock(
+  '~/src/server/common/helpers/marine-licence/water-framework-directive/save-water-framework-directive.js'
+)
 
 describe('Upload and wait page (Water Framework Directive)', () => {
   const getServer = setupTestServer()


### PR DESCRIPTION
## Description

Water Framework Directive: Upload a File

 ## Changes

- If WFD 'nauticalMile' is 'yes' and the user goes through all previous pages then we show the new Upload a File page.
- Save file to the existing mmo-uploads bucket at marine-licence/water-framework-directive
- Also change existing shapefile and kml uploads to `shapefile-uploads` and `kml-uploads`
