### PR TITLE
ML-1286: Handle IAT session timeouts

### DIFF
--- a/src/client/stylesheets/components/iat-option/_iat-option.scss
+++ b/src/client/stylesheets/components/iat-option/_iat-option.scss
@@ -2,7 +2,11 @@
 
 .app-iat-option {
   border: $govuk-border-width solid $govuk-border-colour;
-  padding: govuk-spacing(4) govuk-spacing(4) govuk-spacing(7);
+  padding: govuk-spacing(4);
+
+  > :last-child {
+    margin-bottom: 0;
+  }
 }
 
 .app-iat-option__actions {

--- a/src/server/journey/self-service/invalid/controller.integration.test.js
+++ b/src/server/journey/self-service/invalid/controller.integration.test.js
@@ -1,0 +1,71 @@
+import { vi } from 'vitest'
+
+vi.mock('#src/services/iat-service/iat-context.service.js', () => ({
+  iatContextService: {
+    create: vi.fn(),
+    get: vi.fn(),
+    patch: vi.fn()
+  }
+}))
+
+const { iatContextService } = await import(
+  '#src/services/iat-service/iat-context.service.js'
+)
+
+import { JSDOM } from 'jsdom'
+import { statusCodes } from '#src/server/common/constants/status-codes.js'
+import { routes } from '#src/server/common/constants/routes.js'
+import {
+  setupTestServer,
+  mockIatContext
+} from '#tests/integration/shared/test-setup-helpers.js'
+import { makeGetRequest } from '#src/server/test-helpers/server-requests.js'
+import { config } from '#src/config/config.js'
+
+describe('#invalidController IAT timeout page (integration)', () => {
+  config.set('selfService.enabled', true)
+  const getServer = setupTestServer()
+
+  beforeEach(() => {
+    mockIatContext(iatContextService)
+  })
+
+  const getPage = async () => {
+    const response = await makeGetRequest({
+      url: routes.IAT_INVALID,
+      server: getServer()
+    })
+    return {
+      response,
+      document: new JSDOM(response.result).window.document
+    }
+  }
+
+  test('returns 200', async () => {
+    const { response } = await getPage()
+    expect(response.statusCode).toBe(statusCodes.ok)
+  })
+
+  test('renders the "Your session has timed out" heading', async () => {
+    const { document } = await getPage()
+    expect(document.querySelector('h1').textContent).toContain(
+      'Your session has timed out'
+    )
+  })
+
+  test('renders the 24-hour save / resume body copy', async () => {
+    const { document } = await getPage()
+    expect(document.body.textContent).toContain(
+      'Any answers will be saved for 24 hours. To resume, you need to go back to the start.'
+    )
+  })
+
+  test('renders a "Return to start" button linking to the IAT start page', async () => {
+    const { document } = await getPage()
+    const button = Array.from(
+      document.querySelectorAll('.govuk-button')
+    ).find((b) => b.textContent.includes('Return to start'))
+    expect(button).toBeTruthy()
+    expect(button.getAttribute('href')).toBe(routes.IAT_START)
+  })
+})

--- a/src/server/journey/self-service/invalid/controller.integration.test.js
+++ b/src/server/journey/self-service/invalid/controller.integration.test.js
@@ -67,4 +67,9 @@ describe('#invalidController IAT timeout page (integration)', () => {
     expect(button).toBeTruthy()
     expect(button.getAttribute('href')).toBe(routes.IAT_START)
   })
+
+  test('does not render the GOV.UK phase banner', async () => {
+    const { document } = await getPage()
+    expect(document.querySelectorAll('.govuk-phase-banner').length).toBe(0)
+  })
 })

--- a/src/server/journey/self-service/invalid/controller.integration.test.js
+++ b/src/server/journey/self-service/invalid/controller.integration.test.js
@@ -8,9 +8,8 @@ vi.mock('#src/services/iat-service/iat-context.service.js', () => ({
   }
 }))
 
-const { iatContextService } = await import(
-  '#src/services/iat-service/iat-context.service.js'
-)
+const { iatContextService } =
+  await import('#src/services/iat-service/iat-context.service.js')
 
 import { JSDOM } from 'jsdom'
 import { statusCodes } from '#src/server/common/constants/status-codes.js'
@@ -62,9 +61,9 @@ describe('#invalidController IAT timeout page (integration)', () => {
 
   test('renders a "Return to start" button linking to the IAT start page', async () => {
     const { document } = await getPage()
-    const button = Array.from(
-      document.querySelectorAll('.govuk-button')
-    ).find((b) => b.textContent.includes('Return to start'))
+    const button = Array.from(document.querySelectorAll('.govuk-button')).find(
+      (b) => b.textContent.includes('Return to start')
+    )
     expect(button).toBeTruthy()
     expect(button.getAttribute('href')).toBe(routes.IAT_START)
   })

--- a/src/server/journey/self-service/invalid/controller.js
+++ b/src/server/journey/self-service/invalid/controller.js
@@ -5,7 +5,7 @@ const VIEW_PATH = 'journey/self-service/invalid/index'
 export const invalidController = {
   handler(_request, h) {
     return h.view(VIEW_PATH, {
-      pageTitle: 'This check has expired or could not be found',
+      pageTitle: 'Your session has timed out',
       startUrl: routes.IAT_START
     })
   }

--- a/src/server/journey/self-service/invalid/controller.test.js
+++ b/src/server/journey/self-service/invalid/controller.test.js
@@ -2,15 +2,15 @@ import { describe, it, expect, vi } from 'vitest'
 import { invalidController } from './controller.js'
 import { routes } from '#src/server/common/constants/routes.js'
 
-describe('invalidController', () => {
-  it('renders the invalid-journey view with a Start-again link', () => {
+describe('invalidController (IAT timeout page)', () => {
+  it('renders the timeout view with the start url for the Return to start button', () => {
     const view = vi.fn()
     const h = { view }
     invalidController.handler({}, h)
     expect(view).toHaveBeenCalledWith(
       'journey/self-service/invalid/index',
       expect.objectContaining({
-        pageTitle: expect.stringMatching(/expired|invalid|could not be found/i),
+        pageTitle: 'Your session has timed out',
         startUrl: routes.IAT_START
       })
     )

--- a/src/server/journey/self-service/invalid/index.njk
+++ b/src/server/journey/self-service/invalid/index.njk
@@ -2,6 +2,8 @@
 
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
+{% block beforeContent %}{% endblock %}
+
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/src/server/journey/self-service/invalid/index.njk
+++ b/src/server/journey/self-service/invalid/index.njk
@@ -1,15 +1,18 @@
 {% extends 'layouts/page.njk' %}
 
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl">This check has expired or could not be found</h1>
+      <h1 class="govuk-heading-xl">Your session has timed out</h1>
       <p class="govuk-body">
-        Start a new check to find out if you need a marine licence.
+        Any answers will be saved for 24 hours. To resume, you need to go back to the start.
       </p>
-      <p class="govuk-body">
-        <a class="govuk-link" href="{{ startUrl }}">Start again</a>
-      </p>
+      {{ govukButton({
+        text: "Return to start",
+        href: startUrl
+      }) }}
     </div>
   </div>
 {% endblock %}

--- a/src/server/journey/self-service/outcome/controller.integration.test.js
+++ b/src/server/journey/self-service/outcome/controller.integration.test.js
@@ -94,6 +94,16 @@ describe('#outcomeController (integration)', () => {
       expect(response.statusCode).toBe(statusCodes.ok)
     })
 
+    test('renders content in a two-thirds column, not full width', async () => {
+      const { document } = await getPage(
+        journey.journeyUrl('/outcome' + OUTCOME_JOURNEY_SELECT)
+      )
+      expect(
+        document.querySelector('main .govuk-grid-column-two-thirds')
+      ).not.toBeNull()
+      expect(document.querySelector('main .govuk-grid-column-full')).toBeNull()
+    })
+
     test('renders the H1 from outcome.heading', async () => {
       const { document } = await getPage(
         journey.journeyUrl('/outcome' + OUTCOME_JOURNEY_SELECT)
@@ -369,6 +379,14 @@ describe('GET terminal-single', () => {
     expect(response.statusCode).toBe(statusCodes.ok)
   })
 
+  test('renders content in a two-thirds column, not full width', async () => {
+    const { document } = await getPage(journey.journeyUrl(SINGLE_PATH))
+    expect(
+      document.querySelector('main .govuk-grid-column-two-thirds')
+    ).not.toBeNull()
+    expect(document.querySelector('main .govuk-grid-column-full')).toBeNull()
+  })
+
   test('renders the H1 from outcome.heading', async () => {
     const { document } = await getPage(journey.journeyUrl(SINGLE_PATH))
     expect(document.querySelector('h1').textContent).toContain(
@@ -378,7 +396,9 @@ describe('GET terminal-single', () => {
 
   test('renders the body with sanitised anchor links', async () => {
     const { document } = await getPage(journey.journeyUrl(SINGLE_PATH))
-    const body = document.querySelector('.govuk-grid-column-full .govuk-body')
+    const body = document.querySelector(
+      'main .govuk-grid-column-two-thirds .govuk-body'
+    )
     expect(body).not.toBeNull()
     const anchors = body.querySelectorAll('a')
     expect(anchors.length).toBeGreaterThanOrEqual(1)
@@ -510,6 +530,14 @@ describe('GET terminal-multi', () => {
     expect(response.statusCode).toBe(statusCodes.ok)
   })
 
+  test('renders content in a two-thirds column, not full width', async () => {
+    const { document } = await getPage(journey.journeyUrl(MULTI_PATH))
+    expect(
+      document.querySelector('main .govuk-grid-column-two-thirds')
+    ).not.toBeNull()
+    expect(document.querySelector('main .govuk-grid-column-full')).toBeNull()
+  })
+
   test('renders the H1 from outcome.heading', async () => {
     const { document } = await getPage(journey.journeyUrl(MULTI_PATH))
     expect(document.querySelector('h1').textContent).toContain(
@@ -635,7 +663,9 @@ describe('GET licence-not-required (terminal-single, info-only)', () => {
 
   test('renders the body from the outcomeType text', async () => {
     const { document } = await getPage(journey.journeyUrl(ROUTE_PATH))
-    const body = document.querySelector('.govuk-grid-column-full .govuk-body')
+    const body = document.querySelector(
+      'main .govuk-grid-column-two-thirds .govuk-body'
+    )
     expect(body).not.toBeNull()
     expect(body.textContent).toContain('relevant devolved administration')
   })

--- a/src/server/journey/self-service/outcome/index.njk
+++ b/src/server/journey/self-service/outcome/index.njk
@@ -6,7 +6,7 @@
 
 {% block content %}
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
+    <div class="govuk-grid-column-two-thirds">
       {% if classification == 'intermediate' %}
         {% include "journey/self-service/outcome/_intermediate.njk" %}
       {% elif classification == 'terminal-single' %}

--- a/src/server/journey/self-service/question/controller.integration.test.js
+++ b/src/server/journey/self-service/question/controller.integration.test.js
@@ -13,6 +13,7 @@ const { iatContextService } =
 
 import { JSDOM } from 'jsdom'
 import { statusCodes } from '#src/server/common/constants/status-codes.js'
+import { routes } from '#src/server/common/constants/routes.js'
 import {
   setupTestServer,
   mockIatContext
@@ -290,6 +291,21 @@ describe('#questionController (integration)', () => {
         'input[type="radio"][checked]'
       )
       expect(checkedRadio).toBeNull()
+    })
+  })
+
+  describe('POST after timeout', () => {
+    test('a timed-out session cannot save a further answer and is redirected to the timeout page', async () => {
+      // The 24h TTL has deleted the backend context, so get() now returns null.
+      vi.mocked(iatContextService.get).mockResolvedValue(null)
+
+      const { response } = await postPage(journey.journeyUrl('/sea'), {
+        answer: 'inSea'
+      })
+
+      expect(response.statusCode).toBe(statusCodes.redirect)
+      expect(response.headers.location).toBe(routes.IAT_INVALID)
+      expect(iatContextService.patch).not.toHaveBeenCalled()
     })
   })
 


### PR DESCRIPTION
 ## Description

  When an IAT (Is a licence required?) self-service session times out — its
  backing `iat-answers` context document is removed by the 24-hour TTL — the
  user was landed on a generic "This check has expired or could not be found"
  page. This reworks that page into a clear session-timeout treatment and pins
  the behaviour that a timed-out session can no longer save answers.

Changes

- **Update** look and feel of the session timeout page
- **Render IAT outcome pages at two-thirds width** instead of full width
    (`outcome/index.njk`: `govuk-grid-column-full` → `govuk-grid-column-two-thirds`),
    matching the rest of the journey.
 - **Make the IAT option box vertical spacing symmetric**
    (`_iat-option.scss`): even `govuk-spacing(4)` padding with the last child's
    bottom margin zeroed, instead of the previous asymmetric top/bottom padding.

## Session Timeout page
<img width="1614" height="1686" alt="localhost_3000_journey_self-service_invalid" src="https://github.com/user-attachments/assets/0e87b178-fd46-47cb-8843-cc27537226a2" />

## Updated Outcome document - now 2/3rds width and fixed spacing on the grey border
<img width="1614" height="3686" alt="localhost_3000_journey_self-service_c_AZ7WIAjEd4CRU1ibRUcH8Q_outcome_exemption_deposit-exe-not-available-continue" src="https://github.com/user-attachments/assets/9ebfc541-92eb-4e27-8042-dad14fdddedf" />

