### PR TITLE
ML-1345: Display WFD information on cya and view details pages

### DIFF
--- a/src/server/common/components/marine-licence/water-framework-directive-card/macro.njk
+++ b/src/server/common/components/marine-licence/water-framework-directive-card/macro.njk
@@ -1,0 +1,3 @@
+{% macro appMarineLicenceWaterFrameworkDirectiveCard(params) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/src/server/common/components/marine-licence/water-framework-directive-card/template.njk
+++ b/src/server/common/components/marine-licence/water-framework-directive-card/template.njk
@@ -5,11 +5,11 @@
 {% set rows = (rows.push({
   key: params.waterFrameworkDirectiveData.nauticalMile.key,
   value: params.waterFrameworkDirectiveData.nauticalMile.value
-},{
-  key: params.waterFrameworkDirectiveData.excludedActivities.key,
-  value: params.waterFrameworkDirectiveData.excludedActivities.value
 }), rows) %}
 
+{% if params.waterFrameworkDirectiveData.excludedActivities %}
+    {% set rows = (rows.push(params.waterFrameworkDirectiveData.excludedActivities), rows) %}
+{% endif %}
 
 {% if params.waterFrameworkDirectiveData.previousAssessment %}
     {% set rows = (rows.push(params.waterFrameworkDirectiveData.previousAssessment), rows) %}

--- a/src/server/common/components/marine-licence/water-framework-directive-card/template.njk
+++ b/src/server/common/components/marine-licence/water-framework-directive-card/template.njk
@@ -1,5 +1,6 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 
+{% if params.waterFrameworkDirectiveData.nauticalMile %}
 {% set rows = [] %}
 
 {% set rows = (rows.push({
@@ -23,7 +24,6 @@
     {% set rows = (rows.push(params.waterFrameworkDirectiveData.uploadedFile), rows) %}
 {% endif %}
 
-
 {{ govukSummaryList({
   card: {
     title: {
@@ -42,6 +42,7 @@
         }
       ]
     } if not params.isReadOnly
-  },      
+  },
   rows: rows
 }) }}
+{% endif %}

--- a/src/server/common/components/marine-licence/water-framework-directive-card/template.njk
+++ b/src/server/common/components/marine-licence/water-framework-directive-card/template.njk
@@ -1,0 +1,47 @@
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+
+{% set rows = [] %}
+
+{% set rows = (rows.push({
+  key: params.waterFrameworkDirectiveData.nauticalMile.key,
+  value: params.waterFrameworkDirectiveData.nauticalMile.value
+},{
+  key: params.waterFrameworkDirectiveData.excludedActivities.key,
+  value: params.waterFrameworkDirectiveData.excludedActivities.value
+}), rows) %}
+
+
+{% if params.waterFrameworkDirectiveData.previousAssessment %}
+    {% set rows = (rows.push(params.waterFrameworkDirectiveData.previousAssessment), rows) %}
+{% endif %}
+
+{% if params.waterFrameworkDirectiveData.assessmentChanged %}
+    {% set rows = (rows.push(params.waterFrameworkDirectiveData.assessmentChanged), rows) %}
+{% endif %}
+
+{% if params.waterFrameworkDirectiveData.uploadedFile %}
+    {% set rows = (rows.push(params.waterFrameworkDirectiveData.uploadedFile), rows) %}
+{% endif %}
+
+
+{{ govukSummaryList({
+  card: {
+    title: {
+      text: "Water Framework Directive assessment"
+    },
+    attributes: {
+      id: "water-framework-directive-card"
+    },
+    actions: {
+      items: [
+        {
+          href: params.changeLink ~ "?from=check-your-answers",
+          text: "Change",
+          visuallyHiddenText: " water framework directive assessment",
+          classes: "govuk-link--no-visited-state"
+        }
+      ]
+    } if not params.isReadOnly
+  },      
+  rows: rows
+}) }}

--- a/src/server/common/components/marine-licence/water-framework-directive-card/template.test.js
+++ b/src/server/common/components/marine-licence/water-framework-directive-card/template.test.js
@@ -1,0 +1,86 @@
+import { renderComponent } from '#src/server/test-helpers/component-helpers.js'
+import {
+  NAUTICAL_MILE_HEADING,
+  EXCLUDED_ACTIVITIES_HEADING,
+  PREVIOUS_ASSESSMENT_HEADING,
+  ASSESSMENT_CHANGED_HEADING,
+  FILE_UPLOAD_HEADING
+} from '#src/server/common/helpers/marine-licence/water-framework-directive/water-framework-review-data.js'
+
+describe('Marine Licence Water Framework Directive Component', () => {
+  let $component
+
+  beforeEach(() => {
+    $component = renderComponent(
+      'marine-licence/water-framework-directive-card',
+      {
+        waterFrameworkDirectiveData: {
+          nauticalMile: {
+            key: { text: NAUTICAL_MILE_HEADING },
+            value: { text: 'Yes' }
+          },
+          excludedActivities: {
+            key: { text: EXCLUDED_ACTIVITIES_HEADING },
+            value: { text: 'No' }
+          },
+          assessmentChanged: {
+            key: { text: ASSESSMENT_CHANGED_HEADING },
+            value: { text: 'Yes' }
+          },
+          previousAssessment: {
+            key: { text: PREVIOUS_ASSESSMENT_HEADING },
+            value: { text: 'Yes' }
+          },
+          uploadedFile: {
+            key: { text: FILE_UPLOAD_HEADING },
+            value: { text: 'test-upload-id' }
+          }
+        }
+      }
+    )
+  })
+
+  test('Should render card component', () => {
+    expect($component('#water-framework-directive-card')).toHaveLength(1)
+
+    expect($component('.govuk-summary-card__title').text().trim()).toBe(
+      'Water Framework Directive assessment'
+    )
+  })
+
+  test('Should display all details', () => {
+    expect($component.html()).toContain(NAUTICAL_MILE_HEADING)
+    expect($component.html()).toContain(EXCLUDED_ACTIVITIES_HEADING)
+    expect($component.html()).toContain(PREVIOUS_ASSESSMENT_HEADING)
+    expect($component.html()).toContain(ASSESSMENT_CHANGED_HEADING)
+    expect($component.html()).toContain(FILE_UPLOAD_HEADING)
+  })
+
+  test('Should show change link when not read only', () => {
+    const $comp = renderComponent(
+      'marine-licence/water-framework-directive-card',
+      {
+        changeLink:
+          '/marine-licence/water-framework-directive-review-your-answers',
+        isReadOnly: false
+      }
+    )
+    expect($comp.html()).toContain(
+      '/marine-licence/water-framework-directive-review-your-answers?from=check-your-answers'
+    )
+  })
+
+  test('Should not show change link when read only', () => {
+    const $comp = renderComponent(
+      'marine-licence/water-framework-directive-card',
+      {
+        changeLink:
+          '/marine-licence/water-framework-directive-review-your-answers',
+        isReadOnly: true
+      }
+    )
+    expect($comp.html()).not.toContain(
+      '/marine-licence/water-framework-directive-review-your-answers?from=check-your-answers'
+    )
+  })
+})

--- a/src/server/common/components/marine-licence/water-framework-directive-card/template.test.js
+++ b/src/server/common/components/marine-licence/water-framework-directive-card/template.test.js
@@ -56,10 +56,27 @@ describe('Marine Licence Water Framework Directive Component', () => {
     expect($component.html()).toContain(FILE_UPLOAD_HEADING)
   })
 
+  test('Should not render when nautical mile data is absent', () => {
+    const $comp = renderComponent(
+      'marine-licence/water-framework-directive-card',
+      {
+        waterFrameworkDirectiveData: {}
+      }
+    )
+
+    expect($comp('#water-framework-directive-card')).toHaveLength(0)
+  })
+
   test('Should show change link when not read only', () => {
     const $comp = renderComponent(
       'marine-licence/water-framework-directive-card',
       {
+        waterFrameworkDirectiveData: {
+          nauticalMile: {
+            key: { text: NAUTICAL_MILE_HEADING },
+            value: { text: 'Yes' }
+          }
+        },
         changeLink:
           '/marine-licence/water-framework-directive-review-your-answers',
         isReadOnly: false
@@ -74,6 +91,12 @@ describe('Marine Licence Water Framework Directive Component', () => {
     const $comp = renderComponent(
       'marine-licence/water-framework-directive-card',
       {
+        waterFrameworkDirectiveData: {
+          nauticalMile: {
+            key: { text: NAUTICAL_MILE_HEADING },
+            value: { text: 'Yes' }
+          }
+        },
         changeLink:
           '/marine-licence/water-framework-directive-review-your-answers',
         isReadOnly: true

--- a/src/server/common/helpers/marine-licence/session-cache/return-to-cache.js
+++ b/src/server/common/helpers/marine-licence/session-cache/return-to-cache.js
@@ -1,0 +1,23 @@
+import { RETURN_TO_CACHE_KEY } from '#src/server/common/constants/cache.js'
+
+/**
+ * Stores a return path in session so users can navigate back from change flows.
+ *
+ * RETURN_TO_CACHE_KEY is written in two forms:
+ * - flash: consumed by site-details and other one-time redirect handlers
+ * - session value: read non-destructively by WFD pages for back links and continue
+ */
+export const setReturnToCache = async (request, h, returnPath) => {
+  request.yar.clear(RETURN_TO_CACHE_KEY)
+  request.yar.flash(RETURN_TO_CACHE_KEY, returnPath, true)
+  request.yar.set(RETURN_TO_CACHE_KEY, returnPath)
+  await request.yar.commit(h)
+}
+
+/**
+ * Clears both flash and session values for RETURN_TO_CACHE_KEY.
+ */
+export const clearReturnToCache = (request) => {
+  request.yar.flash(RETURN_TO_CACHE_KEY)
+  request.yar.clear(RETURN_TO_CACHE_KEY)
+}

--- a/src/server/common/helpers/marine-licence/session-cache/return-to-cache.test.js
+++ b/src/server/common/helpers/marine-licence/session-cache/return-to-cache.test.js
@@ -1,0 +1,55 @@
+import { vi } from 'vitest'
+import { RETURN_TO_CACHE_KEY } from '#src/server/common/constants/cache.js'
+import { marineLicenceRoutes } from '#src/server/common/constants/routes.js'
+import {
+  clearReturnToCache,
+  setReturnToCache
+} from '#src/server/common/helpers/marine-licence/session-cache/return-to-cache.js'
+
+describe('return-to-cache', () => {
+  let mockRequest
+  let mockH
+
+  beforeEach(() => {
+    mockH = {}
+    mockRequest = {
+      yar: {
+        clear: vi.fn(),
+        flash: vi.fn(),
+        set: vi.fn(),
+        commit: vi.fn()
+      }
+    }
+  })
+
+  describe('setReturnToCache', () => {
+    test('clears, sets flash and session values, then commits', async () => {
+      await setReturnToCache(
+        mockRequest,
+        mockH,
+        marineLicenceRoutes.MARINE_LICENCE_CHECK_YOUR_ANSWERS
+      )
+
+      expect(mockRequest.yar.clear).toHaveBeenCalledWith(RETURN_TO_CACHE_KEY)
+      expect(mockRequest.yar.flash).toHaveBeenCalledWith(
+        RETURN_TO_CACHE_KEY,
+        marineLicenceRoutes.MARINE_LICENCE_CHECK_YOUR_ANSWERS,
+        true
+      )
+      expect(mockRequest.yar.set).toHaveBeenCalledWith(
+        RETURN_TO_CACHE_KEY,
+        marineLicenceRoutes.MARINE_LICENCE_CHECK_YOUR_ANSWERS
+      )
+      expect(mockRequest.yar.commit).toHaveBeenCalledWith(mockH)
+    })
+  })
+
+  describe('clearReturnToCache', () => {
+    test('clears both flash and session values', () => {
+      clearReturnToCache(mockRequest)
+
+      expect(mockRequest.yar.flash).toHaveBeenCalledWith(RETURN_TO_CACHE_KEY)
+      expect(mockRequest.yar.clear).toHaveBeenCalledWith(RETURN_TO_CACHE_KEY)
+    })
+  })
+})

--- a/src/server/common/helpers/marine-licence/water-framework-directive/water-framework-review-data.js
+++ b/src/server/common/helpers/marine-licence/water-framework-directive/water-framework-review-data.js
@@ -50,7 +50,7 @@ const getDisplayValue = (key, value) => {
 
 export const waterFrameworkReviewData = (waterFrameworkDirective) => {
   if (!waterFrameworkDirective) {
-    return []
+    return {}
   }
 
   return Object.entries(waterFrameworkDirective)

--- a/src/server/common/helpers/marine-licence/water-framework-directive/water-framework-review-data.js
+++ b/src/server/common/helpers/marine-licence/water-framework-directive/water-framework-review-data.js
@@ -49,6 +49,10 @@ const getDisplayValue = (key, value) => {
 }
 
 export const waterFrameworkReviewData = (waterFrameworkDirective) => {
+  if (!waterFrameworkDirective) {
+    return []
+  }
+
   return Object.entries(waterFrameworkDirective)
     .filter(([key]) => !EXCLUDED_DISPLAY_KEYS.has(key))
     .reduce((acc, [key, value]) => {

--- a/src/server/common/helpers/marine-licence/water-framework-directive/water-framework-review-data.test.js
+++ b/src/server/common/helpers/marine-licence/water-framework-directive/water-framework-review-data.test.js
@@ -105,9 +105,9 @@ describe('waterFrameworkReviewData', () => {
     })
   })
 
-  test('returns empty array for null value', () => {
+  test('returns empty object for null value', () => {
     const result = waterFrameworkReviewData()
 
-    expect(result).toEqual([])
+    expect(result).toEqual({})
   })
 })

--- a/src/server/common/helpers/marine-licence/water-framework-directive/water-framework-review-data.test.js
+++ b/src/server/common/helpers/marine-licence/water-framework-directive/water-framework-review-data.test.js
@@ -104,4 +104,10 @@ describe('waterFrameworkReviewData', () => {
       value: { text: undefined }
     })
   })
+
+  test('returns empty array for null value', () => {
+    const result = waterFrameworkReviewData()
+
+    expect(result).toEqual([])
+  })
 })

--- a/src/server/marine-licence/check-your-answers/controller.js
+++ b/src/server/marine-licence/check-your-answers/controller.js
@@ -1,11 +1,14 @@
-import { getMarineLicenceCache } from '#src/server/common/helpers/marine-licence/session-cache/utils.js'
+import {
+  getMarineLicenceCache,
+  setMarineLicenceCache
+} from '#src/server/common/helpers/marine-licence/session-cache/utils.js'
 import {
   marineLicenceRoutes,
   routes
 } from '#src/server/common/constants/routes.js'
 import { buildSiteData } from '#src/server/common/helpers/marine-licence/site-data.js'
 import { buildSummaryData } from '#src/server/common/helpers/marine-licence/summary-data.js'
-import { RETURN_TO_CACHE_KEY } from '#src/server/common/constants/cache.js'
+import { setReturnToCache } from '#src/server/common/helpers/marine-licence/session-cache/return-to-cache.js'
 import { getMarineLicenceService } from '#src/services/marine-licence-service/index.js'
 import { waterFrameworkReviewData } from '#src/server/common/helpers/marine-licence/water-framework-directive/water-framework-review-data.js'
 import { getWaterFrameworkDirectiveChangeLink } from '#src/server/marine-licence/check-your-answers/utils.js'
@@ -21,24 +24,34 @@ export const CHECK_YOUR_ANSWERS_VIEW_ROUTE =
 export const checkYourAnswersController = {
   async handler(request, h) {
     const cachedMarineLicence = getMarineLicenceCache(request)
-    request.yar.flash(
-      RETURN_TO_CACHE_KEY,
-      marineLicenceRoutes.MARINE_LICENCE_CHECK_YOUR_ANSWERS,
-      true
+    await setReturnToCache(
+      request,
+      h,
+      marineLicenceRoutes.MARINE_LICENCE_CHECK_YOUR_ANSWERS
     )
 
     let siteData = { coordinatesType: null, summaryData: [] }
+    let waterFrameworkDirective = cachedMarineLicence.waterFrameworkDirective
+
     if (cachedMarineLicence.id) {
       const marineLicenceService = getMarineLicenceService(request)
       const completeMarineLicence =
         await marineLicenceService.getMarineLicenceById(cachedMarineLicence.id)
       siteData = buildSiteData(completeMarineLicence)
+
+      // A user may have cancelled out of the WFD flow part way and returned to this page
+      // So it is necessary to reset the cache of this property to the server value
+      waterFrameworkDirective = completeMarineLicence.waterFrameworkDirective
+      await setMarineLicenceCache(request, h, {
+        ...cachedMarineLicence,
+        waterFrameworkDirective
+      })
     }
 
     const formattedMarineLicence = buildSummaryData(cachedMarineLicence)
 
     const waterFrameworkDirectiveData = waterFrameworkReviewData(
-      cachedMarineLicence.waterFrameworkDirective
+      waterFrameworkDirective
     )
 
     return h.view(CHECK_YOUR_ANSWERS_VIEW_ROUTE, {
@@ -52,7 +65,7 @@ export const checkYourAnswersController = {
       publicRegisterRoute: marineLicenceRoutes.MARINE_LICENCE_PUBLIC_REGISTER,
       waterFrameworkDirectiveData,
       waterFrameworkDirectiveChangeLink: getWaterFrameworkDirectiveChangeLink(
-        cachedMarineLicence.waterFrameworkDirective
+        waterFrameworkDirective
       )
     })
   }

--- a/src/server/marine-licence/check-your-answers/controller.js
+++ b/src/server/marine-licence/check-your-answers/controller.js
@@ -7,6 +7,8 @@ import { buildSiteData } from '#src/server/common/helpers/marine-licence/site-da
 import { buildSummaryData } from '#src/server/common/helpers/marine-licence/summary-data.js'
 import { RETURN_TO_CACHE_KEY } from '#src/server/common/constants/cache.js'
 import { getMarineLicenceService } from '#src/services/marine-licence-service/index.js'
+import { waterFrameworkReviewData } from '#src/server/common/helpers/marine-licence/water-framework-directive/water-framework-review-data.js'
+import { getChangeLink } from '#src/server/marine-licence/check-your-answers/utils.js'
 
 const checkYourAnswersViewContent = {
   pageTitle: 'Check your answers before sending your information',
@@ -35,6 +37,10 @@ export const checkYourAnswersController = {
 
     const formattedMarineLicence = buildSummaryData(cachedMarineLicence)
 
+    const waterFrameworkDirectiveData = waterFrameworkReviewData(
+      cachedMarineLicence.waterFrameworkDirective
+    )
+
     return h.view(CHECK_YOUR_ANSWERS_VIEW_ROUTE, {
       ...checkYourAnswersViewContent,
       ...cachedMarineLicence,
@@ -43,7 +49,9 @@ export const checkYourAnswersController = {
       reviewSiteDetailsRoute:
         marineLicenceRoutes.MARINE_LICENCE_REVIEW_SITE_DETAILS,
       ...formattedMarineLicence,
-      publicRegisterRoute: marineLicenceRoutes.MARINE_LICENCE_PUBLIC_REGISTER
+      publicRegisterRoute: marineLicenceRoutes.MARINE_LICENCE_PUBLIC_REGISTER,
+      waterFrameworkDirectiveData,
+      changeLink: getChangeLink(cachedMarineLicence.waterFrameworkDirective)
     })
   }
 }

--- a/src/server/marine-licence/check-your-answers/controller.js
+++ b/src/server/marine-licence/check-your-answers/controller.js
@@ -8,7 +8,7 @@ import { buildSummaryData } from '#src/server/common/helpers/marine-licence/summ
 import { RETURN_TO_CACHE_KEY } from '#src/server/common/constants/cache.js'
 import { getMarineLicenceService } from '#src/services/marine-licence-service/index.js'
 import { waterFrameworkReviewData } from '#src/server/common/helpers/marine-licence/water-framework-directive/water-framework-review-data.js'
-import { getChangeLink } from '#src/server/marine-licence/check-your-answers/utils.js'
+import { getWaterFrameworkDirectiveChangeLink } from '#src/server/marine-licence/check-your-answers/utils.js'
 
 const checkYourAnswersViewContent = {
   pageTitle: 'Check your answers before sending your information',
@@ -51,7 +51,9 @@ export const checkYourAnswersController = {
       ...formattedMarineLicence,
       publicRegisterRoute: marineLicenceRoutes.MARINE_LICENCE_PUBLIC_REGISTER,
       waterFrameworkDirectiveData,
-      changeLink: getChangeLink(cachedMarineLicence.waterFrameworkDirective)
+      waterFrameworkDirectiveChangeLink: getWaterFrameworkDirectiveChangeLink(
+        cachedMarineLicence.waterFrameworkDirective
+      )
     })
   }
 }

--- a/src/server/marine-licence/check-your-answers/controller.test.js
+++ b/src/server/marine-licence/check-your-answers/controller.test.js
@@ -19,6 +19,49 @@ vi.mock('#src/services/marine-licence-service/index.js')
 vi.mock('#src/server/common/helpers/marine-licence/site-data.js')
 vi.mock('#src/server/common/helpers/marine-licence/summary-data.js')
 
+const expectedWaterFrameworkDirectiveData = {
+  assessmentChanged: {
+    key: {
+      text: 'Changes since the previous Water Framework Directive assessment'
+    },
+    value: {
+      text: 'No'
+    }
+  },
+  excludedActivities: {
+    key: {
+      text: 'Project limited to one of the excluded activities'
+    },
+    value: {
+      text: 'No'
+    }
+  },
+  nauticalMile: {
+    key: {
+      text: 'Project located within one nautical mile (1.85km) of the coast'
+    },
+    value: {
+      text: 'Yes'
+    }
+  },
+  previousAssessment: {
+    key: {
+      text: 'Previous 2015 to 2022 Water Framework Directive assessment'
+    },
+    value: {
+      text: 'Yes'
+    }
+  },
+  uploadedFile: {
+    key: {
+      text: 'Water Framework Directive assessment upload'
+    },
+    value: {
+      text: 'test-upload-id'
+    }
+  }
+}
+
 describe('#checkYourAnswersController', () => {
   let mockRequest
   let mockH
@@ -88,7 +131,10 @@ describe('#checkYourAnswersController', () => {
       summaryData: mockSummaryData,
       reviewSiteDetailsRoute:
         marineLicenceRoutes.MARINE_LICENCE_REVIEW_SITE_DETAILS,
-      publicRegisterRoute: marineLicenceRoutes.MARINE_LICENCE_PUBLIC_REGISTER
+      publicRegisterRoute: marineLicenceRoutes.MARINE_LICENCE_PUBLIC_REGISTER,
+      waterFrameworkDirectiveData: expectedWaterFrameworkDirectiveData,
+      changeLink:
+        marineLicenceRoutes.MARINE_LICENCE_WATER_FRAMEWORK_DIRECTIVE_REVIEW_YOUR_ANSWERS
     })
   })
 
@@ -114,6 +160,7 @@ describe('#checkYourAnswersController', () => {
       preferredDates: null,
       coordinatesType: null,
       summaryData: [],
+      waterFrameworkDirectiveData: [],
       reviewSiteDetailsRoute:
         marineLicenceRoutes.MARINE_LICENCE_REVIEW_SITE_DETAILS,
       publicRegisterRoute: marineLicenceRoutes.MARINE_LICENCE_PUBLIC_REGISTER

--- a/src/server/marine-licence/check-your-answers/controller.test.js
+++ b/src/server/marine-licence/check-your-answers/controller.test.js
@@ -133,7 +133,7 @@ describe('#checkYourAnswersController', () => {
         marineLicenceRoutes.MARINE_LICENCE_REVIEW_SITE_DETAILS,
       publicRegisterRoute: marineLicenceRoutes.MARINE_LICENCE_PUBLIC_REGISTER,
       waterFrameworkDirectiveData: expectedWaterFrameworkDirectiveData,
-      changeLink:
+      waterFrameworkDirectiveChangeLink:
         marineLicenceRoutes.MARINE_LICENCE_WATER_FRAMEWORK_DIRECTIVE_REVIEW_YOUR_ANSWERS
     })
   })

--- a/src/server/marine-licence/check-your-answers/controller.test.js
+++ b/src/server/marine-licence/check-your-answers/controller.test.js
@@ -171,7 +171,7 @@ describe('#checkYourAnswersController', () => {
       preferredDates: null,
       coordinatesType: null,
       summaryData: [],
-      waterFrameworkDirectiveData: [],
+      waterFrameworkDirectiveData: {},
       reviewSiteDetailsRoute:
         marineLicenceRoutes.MARINE_LICENCE_REVIEW_SITE_DETAILS,
       publicRegisterRoute: marineLicenceRoutes.MARINE_LICENCE_PUBLIC_REGISTER

--- a/src/server/marine-licence/check-your-answers/controller.test.js
+++ b/src/server/marine-licence/check-your-answers/controller.test.js
@@ -1,5 +1,9 @@
 import { vi } from 'vitest'
-import { getMarineLicenceCache } from '#src/server/common/helpers/marine-licence/session-cache/utils.js'
+import {
+  getMarineLicenceCache,
+  setMarineLicenceCache
+} from '#src/server/common/helpers/marine-licence/session-cache/utils.js'
+import { setReturnToCache } from '#src/server/common/helpers/marine-licence/session-cache/return-to-cache.js'
 import { getMarineLicenceService } from '#src/services/marine-licence-service/index.js'
 import { buildSiteData } from '#src/server/common/helpers/marine-licence/site-data.js'
 import { buildSummaryData } from '#src/server/common/helpers/marine-licence/summary-data.js'
@@ -15,6 +19,9 @@ import {
 import { mockMarineLicenceApplication } from '~/src/server/test-helpers/mocks/marine-licence-mocks.js'
 
 vi.mock('#src/server/common/helpers/marine-licence/session-cache/utils.js')
+vi.mock(
+  '#src/server/common/helpers/marine-licence/session-cache/return-to-cache.js'
+)
 vi.mock('#src/services/marine-licence-service/index.js')
 vi.mock('#src/server/common/helpers/marine-licence/site-data.js')
 vi.mock('#src/server/common/helpers/marine-licence/summary-data.js')
@@ -68,6 +75,8 @@ describe('#checkYourAnswersController', () => {
   let mockGetMarineLicenceById
 
   const getMarineLicenceCacheMock = vi.mocked(getMarineLicenceCache)
+  const setMarineLicenceCacheMock = vi.mocked(setMarineLicenceCache)
+  const setReturnToCacheMock = vi.mocked(setReturnToCache)
   const buildSiteDataMock = vi.mocked(buildSiteData)
   const buildSummaryDataMock = vi.mocked(buildSummaryData)
 
@@ -79,9 +88,7 @@ describe('#checkYourAnswersController', () => {
     mockH = {
       view: vi.fn()
     }
-    mockRequest = {
-      yar: { flash: vi.fn() }
-    }
+    mockRequest = {}
   })
 
   test('handler should render with correct context including site data', async () => {
@@ -109,13 +116,16 @@ describe('#checkYourAnswersController', () => {
       preferredDates: 'July 2026 to August 2027'
     })
 
+    setReturnToCacheMock.mockResolvedValue(undefined)
+    setMarineLicenceCacheMock.mockResolvedValue(undefined)
+
     await checkYourAnswersController.handler(mockRequest, mockH)
 
     expect(getMarineLicenceCacheMock).toHaveBeenCalledWith(mockRequest)
-    expect(mockRequest.yar.flash).toHaveBeenCalledWith(
-      'returnTo',
-      marineLicenceRoutes.MARINE_LICENCE_CHECK_YOUR_ANSWERS,
-      true
+    expect(setReturnToCacheMock).toHaveBeenCalledWith(
+      mockRequest,
+      mockH,
+      marineLicenceRoutes.MARINE_LICENCE_CHECK_YOUR_ANSWERS
     )
     expect(mockGetMarineLicenceById).toHaveBeenCalledWith(
       mockMarineLicenceApplication.id
@@ -148,6 +158,7 @@ describe('#checkYourAnswersController', () => {
       ...mockCachedData,
       preferredDates: null
     })
+    setReturnToCacheMock.mockResolvedValue(undefined)
 
     await checkYourAnswersController.handler(mockRequest, mockH)
 

--- a/src/server/marine-licence/check-your-answers/index.njk
+++ b/src/server/marine-licence/check-your-answers/index.njk
@@ -66,7 +66,7 @@
 
       {{ appMarineLicenceWaterFrameworkDirectiveCard({
         waterFrameworkDirectiveData: waterFrameworkDirectiveData,
-        changeLink: changeLink,
+        changeLink: waterFrameworkDirectiveChangeLink,
         isReadOnly: isReadOnly
       }) }}
 

--- a/src/server/marine-licence/check-your-answers/index.njk
+++ b/src/server/marine-licence/check-your-answers/index.njk
@@ -7,6 +7,7 @@
 {% from "marine-licence/site-details-card/macro.njk" import appMarineLicenceSiteDetailsCard %}
 {% from "marine-licence/activity-details-card/macro.njk" import appMarineLicenceActivityDetailsCard %}
 {% from "marine-licence/other-permissions-card/macro.njk" import appMarineLicenceOtherPermissionsCard %}
+{% from "marine-licence/water-framework-directive-card/macro.njk" import appMarineLicenceWaterFrameworkDirectiveCard %}
 {% from "public-register-card/macro.njk" import appPublicRegisterCard %}
 
 {% block head %}
@@ -61,6 +62,13 @@
           {% endfor %}
         {% endfor %}
       {% endif %}
+
+
+      {{ appMarineLicenceWaterFrameworkDirectiveCard({
+        waterFrameworkDirectiveData: waterFrameworkDirectiveData,
+        changeLink: changeLink,
+        isReadOnly: isReadOnly
+      }) }}
 
        {{ appMarineLicenceOtherPermissionsCard({
         specialLegalPowers: specialLegalPowers,

--- a/src/server/marine-licence/check-your-answers/utils.js
+++ b/src/server/marine-licence/check-your-answers/utils.js
@@ -1,0 +1,13 @@
+import { marineLicenceRoutes } from '#src/server/common/constants/routes.js'
+
+export const getChangeLink = (waterFrameworkDirective) => {
+  if (!waterFrameworkDirective) {
+    return undefined
+  }
+
+  if (waterFrameworkDirective.nauticalMile === 'no') {
+    return marineLicenceRoutes.MARINE_LICENCE_WATER_FRAMEWORK_DIRECTIVE_NAUTICAL_MILE
+  }
+
+  return marineLicenceRoutes.MARINE_LICENCE_WATER_FRAMEWORK_DIRECTIVE_REVIEW_YOUR_ANSWERS
+}

--- a/src/server/marine-licence/check-your-answers/utils.js
+++ b/src/server/marine-licence/check-your-answers/utils.js
@@ -1,6 +1,8 @@
 import { marineLicenceRoutes } from '#src/server/common/constants/routes.js'
 
-export const getChangeLink = (waterFrameworkDirective) => {
+export const getWaterFrameworkDirectiveChangeLink = (
+  waterFrameworkDirective
+) => {
   if (!waterFrameworkDirective) {
     return undefined
   }
@@ -9,5 +11,5 @@ export const getChangeLink = (waterFrameworkDirective) => {
     return marineLicenceRoutes.MARINE_LICENCE_WATER_FRAMEWORK_DIRECTIVE_NAUTICAL_MILE
   }
 
-  return marineLicenceRoutes.MARINE_LICENCE_WATER_FRAMEWORK_DIRECTIVE_REVIEW_YOUR_ANSWERS
+  return `${marineLicenceRoutes.MARINE_LICENCE_WATER_FRAMEWORK_DIRECTIVE_REVIEW_YOUR_ANSWERS}`
 }

--- a/src/server/marine-licence/check-your-answers/utils.js
+++ b/src/server/marine-licence/check-your-answers/utils.js
@@ -11,5 +11,5 @@ export const getWaterFrameworkDirectiveChangeLink = (
     return marineLicenceRoutes.MARINE_LICENCE_WATER_FRAMEWORK_DIRECTIVE_NAUTICAL_MILE
   }
 
-  return `${marineLicenceRoutes.MARINE_LICENCE_WATER_FRAMEWORK_DIRECTIVE_REVIEW_YOUR_ANSWERS}`
+  return marineLicenceRoutes.MARINE_LICENCE_WATER_FRAMEWORK_DIRECTIVE_REVIEW_YOUR_ANSWERS
 }

--- a/src/server/marine-licence/check-your-answers/utils.test.js
+++ b/src/server/marine-licence/check-your-answers/utils.test.js
@@ -3,7 +3,7 @@ import { waterFrameworkDirective } from '~/src/server/test-helpers/mocks/marine-
 import { getWaterFrameworkDirectiveChangeLink } from '#src/server/marine-licence/check-your-answers/utils.js'
 
 describe('getWaterFrameworkDirectiveChangeLink', () => {
-  it('should return review answers route with from param when nauticalMile is yes', () => {
+  it('should return review answers route when nauticalMile is yes', () => {
     const result = getWaterFrameworkDirectiveChangeLink(waterFrameworkDirective)
 
     expect(result).toBe(
@@ -18,11 +18,11 @@ describe('getWaterFrameworkDirectiveChangeLink', () => {
     })
 
     expect(result).toBe(
-      marineLicenceRoutes.MARINE_LICENCE_WATER_FRAMEWORK_DIRECTIVE_NAUTICAL_MILE
+      `${marineLicenceRoutes.MARINE_LICENCE_WATER_FRAMEWORK_DIRECTIVE_NAUTICAL_MILE}`
     )
   })
 
-  it('should return review answers route with from param when nauticalMile is undefined', () => {
+  it('should return review answers route when nauticalMile is undefined', () => {
     const result = getWaterFrameworkDirectiveChangeLink({
       ...waterFrameworkDirective,
       nauticalMile: undefined

--- a/src/server/marine-licence/check-your-answers/utils.test.js
+++ b/src/server/marine-licence/check-your-answers/utils.test.js
@@ -1,18 +1,18 @@
 import { marineLicenceRoutes } from '#src/server/common/constants/routes.js'
 import { waterFrameworkDirective } from '~/src/server/test-helpers/mocks/marine-licence-mocks.js'
-import { getChangeLink } from '#src/server/marine-licence/check-your-answers/utils.js'
+import { getWaterFrameworkDirectiveChangeLink } from '#src/server/marine-licence/check-your-answers/utils.js'
 
-describe('getChangeLink', () => {
-  it('should return review answers route when nauticalMile is yes', () => {
-    const result = getChangeLink(waterFrameworkDirective)
+describe('getWaterFrameworkDirectiveChangeLink', () => {
+  it('should return review answers route with from param when nauticalMile is yes', () => {
+    const result = getWaterFrameworkDirectiveChangeLink(waterFrameworkDirective)
 
     expect(result).toBe(
-      marineLicenceRoutes.MARINE_LICENCE_WATER_FRAMEWORK_DIRECTIVE_REVIEW_YOUR_ANSWERS
+      `${marineLicenceRoutes.MARINE_LICENCE_WATER_FRAMEWORK_DIRECTIVE_REVIEW_YOUR_ANSWERS}`
     )
   })
 
   it('should return nautical mile route when nauticalMile is no', () => {
-    const result = getChangeLink({
+    const result = getWaterFrameworkDirectiveChangeLink({
       ...waterFrameworkDirective,
       nauticalMile: 'no'
     })
@@ -22,19 +22,19 @@ describe('getChangeLink', () => {
     )
   })
 
-  it('should return review answers route when nauticalMile is undefined', () => {
-    const result = getChangeLink({
+  it('should return review answers route with from param when nauticalMile is undefined', () => {
+    const result = getWaterFrameworkDirectiveChangeLink({
       ...waterFrameworkDirective,
       nauticalMile: undefined
     })
 
     expect(result).toBe(
-      marineLicenceRoutes.MARINE_LICENCE_WATER_FRAMEWORK_DIRECTIVE_REVIEW_YOUR_ANSWERS
+      `${marineLicenceRoutes.MARINE_LICENCE_WATER_FRAMEWORK_DIRECTIVE_REVIEW_YOUR_ANSWERS}`
     )
   })
 
   it('should return  null route when water framework directive is undefined', () => {
-    const result = getChangeLink()
+    const result = getWaterFrameworkDirectiveChangeLink()
 
     expect(result).toBe(undefined)
   })

--- a/src/server/marine-licence/check-your-answers/utils.test.js
+++ b/src/server/marine-licence/check-your-answers/utils.test.js
@@ -1,0 +1,41 @@
+import { marineLicenceRoutes } from '#src/server/common/constants/routes.js'
+import { waterFrameworkDirective } from '~/src/server/test-helpers/mocks/marine-licence-mocks.js'
+import { getChangeLink } from '#src/server/marine-licence/check-your-answers/utils.js'
+
+describe('getChangeLink', () => {
+  it('should return review answers route when nauticalMile is yes', () => {
+    const result = getChangeLink(waterFrameworkDirective)
+
+    expect(result).toBe(
+      marineLicenceRoutes.MARINE_LICENCE_WATER_FRAMEWORK_DIRECTIVE_REVIEW_YOUR_ANSWERS
+    )
+  })
+
+  it('should return nautical mile route when nauticalMile is no', () => {
+    const result = getChangeLink({
+      ...waterFrameworkDirective,
+      nauticalMile: 'no'
+    })
+
+    expect(result).toBe(
+      marineLicenceRoutes.MARINE_LICENCE_WATER_FRAMEWORK_DIRECTIVE_NAUTICAL_MILE
+    )
+  })
+
+  it('should return review answers route when nauticalMile is undefined', () => {
+    const result = getChangeLink({
+      ...waterFrameworkDirective,
+      nauticalMile: undefined
+    })
+
+    expect(result).toBe(
+      marineLicenceRoutes.MARINE_LICENCE_WATER_FRAMEWORK_DIRECTIVE_REVIEW_YOUR_ANSWERS
+    )
+  })
+
+  it('should return  null route when water framework directive is undefined', () => {
+    const result = getChangeLink()
+
+    expect(result).toBe(undefined)
+  })
+})

--- a/src/server/marine-licence/task-list/controller.js
+++ b/src/server/marine-licence/task-list/controller.js
@@ -18,7 +18,7 @@ import { PROJECT_TYPE } from '#src/server/common/constants/projects.js'
 import { getUserSession } from '#src/server/common/plugins/auth/utils.js'
 import { USER_TYPES } from '#src/server/common/constants/user-types.js'
 import Boom from '@hapi/boom'
-import { RETURN_TO_CACHE_KEY } from '#src/server/common/constants/cache.js'
+import { clearReturnToCache } from '#src/server/common/helpers/marine-licence/session-cache/return-to-cache.js'
 
 export const TASK_LIST_VIEW_ROUTE = 'marine-licence/task-list/index'
 
@@ -74,7 +74,7 @@ async function updateLicenceSession(request, h, licenceData, hasCancel) {
 
 export const taskListController = {
   async handler(request, h) {
-    request.yar.flash(RETURN_TO_CACHE_KEY)
+    clearReturnToCache(request)
 
     const userSession = await getUserSession(
       request,

--- a/src/server/marine-licence/task-list/controller.test.js
+++ b/src/server/marine-licence/task-list/controller.test.js
@@ -5,6 +5,7 @@ import {
   setMarineLicenceCache
 } from '#src/server/common/helpers/marine-licence/session-cache/utils.js'
 import { setProjectType } from '#src/server/common/helpers/session-cache/utils.js'
+import { clearReturnToCache } from '#src/server/common/helpers/marine-licence/session-cache/return-to-cache.js'
 import { authenticatedGetRequest } from '#src/server/common/helpers/authenticated-requests.js'
 import {
   transformProjectDetailsTaskList,
@@ -24,6 +25,9 @@ import * as authUtils from '#src/server/common/plugins/auth/utils.js'
 import Boom from '@hapi/boom'
 
 vi.mock('#src/server/common/helpers/marine-licence/session-cache/utils.js')
+vi.mock(
+  '#src/server/common/helpers/marine-licence/session-cache/return-to-cache.js'
+)
 vi.mock('#src/server/common/helpers/session-cache/utils.js')
 vi.mock('#src/server/common/helpers/authenticated-requests.js')
 vi.mock('#src/server/marine-licence/task-list/utils.js')
@@ -34,6 +38,7 @@ describe('#taskListController', () => {
   let mockH
 
   const getMarineLicenceCacheMock = vi.mocked(getMarineLicenceCache)
+  const clearReturnToCacheMock = vi.mocked(clearReturnToCache)
   const setMarineLicenceCacheMock = vi.mocked(setMarineLicenceCache)
   const clearMarineLicenceCacheMock = vi.mocked(clearMarineLicenceCache)
   const authenticatedGetRequestMock = vi.mocked(authenticatedGetRequest)
@@ -59,9 +64,7 @@ describe('#taskListController', () => {
       view: vi.fn(),
       redirect: vi.fn()
     }
-    mockRequest = {
-      yar: { flash: vi.fn() }
-    }
+    mockRequest = {}
   })
 
   test('taskListController handler should render with correct context', async () => {
@@ -180,6 +183,7 @@ describe('#taskListController', () => {
     await taskListController.handler(mockRequest, mockH)
 
     expect(getMarineLicenceCacheMock).toHaveBeenCalledWith(mockRequest)
+    expect(clearReturnToCacheMock).toHaveBeenCalledWith(mockRequest)
     expect(authenticatedGetRequestMock).toHaveBeenCalledWith(
       mockRequest,
       '/marine-licence/123'

--- a/src/server/marine-licence/view-details/controller.js
+++ b/src/server/marine-licence/view-details/controller.js
@@ -12,6 +12,7 @@ import {
 import { MARINE_LICENCE_KEY } from '#src/server/common/constants/marine-licence.js'
 import { buildSummaryData } from '#src/server/common/helpers/marine-licence/summary-data.js'
 import { buildSiteData } from '#src/server/common/helpers/marine-licence/site-data.js'
+import { waterFrameworkReviewData } from '#src/server/common/helpers/marine-licence/water-framework-directive/water-framework-review-data.js'
 
 export const VIEW_DETAILS_VIEW_ROUTE = 'marine-licence/view-details/index'
 
@@ -56,6 +57,10 @@ export const viewDetailsController = {
         ? `${marineLicence.applicationReference} - Marine licence`
         : marineLicence.applicationReference
 
+      const waterFrameworkDirectiveData = waterFrameworkReviewData(
+        formattedMarineLicence.waterFrameworkDirective
+      )
+
       return h.view(VIEW_DETAILS_VIEW_ROUTE, {
         pageTitle: formattedMarineLicence.projectName,
         specialLegalPowers: formattedMarineLicence.specialLegalPowers,
@@ -71,7 +76,8 @@ export const viewDetailsController = {
         pageCaption,
         backLink: isApplicantView ? routes.DASHBOARD : null,
         isInternalUserView,
-        marineLicenceId
+        marineLicenceId,
+        waterFrameworkDirectiveData
       })
     } catch (error) {
       if (error.isBoom) {

--- a/src/server/marine-licence/view-details/index.njk
+++ b/src/server/marine-licence/view-details/index.njk
@@ -5,6 +5,7 @@
 {% from "marine-licence/site-location-card/macro.njk" import appMarineLicenceSiteLocationCard %}
 {% from "marine-licence/site-details-card/macro.njk" import appMarineLicenceSiteDetailsCard %}
 {% from "marine-licence/activity-details-card/macro.njk" import appMarineLicenceActivityDetailsCard %}
+{% from "marine-licence/water-framework-directive-card/macro.njk" import appMarineLicenceWaterFrameworkDirectiveCard %}
 {% from "public-register-card/macro.njk" import appPublicRegisterCard %}
 
 {% block beforeContent %}
@@ -65,6 +66,11 @@
           marineLicenceId: marineLicenceId
         }) }}
       {% endif %}
+
+      {{ appMarineLicenceWaterFrameworkDirectiveCard({
+        waterFrameworkDirectiveData: waterFrameworkDirectiveData,
+        isReadOnly: isReadOnly
+      }) }}
 
       {{ appMarineLicenceOtherPermissionsCard({
         specialLegalPowers: specialLegalPowers,

--- a/src/server/marine-licence/water-framework-directive/nautical-mile/controller.js
+++ b/src/server/marine-licence/water-framework-directive/nautical-mile/controller.js
@@ -4,9 +4,17 @@ import { createFailAction } from '#src/server/common/helpers/createFailAction.js
 import { marineLicenceRoutes } from '#src/server/common/constants/routes.js'
 import joi from 'joi'
 import { saveWaterFrameworkDirectiveToBackend } from '#src/server/common/helpers/marine-licence/water-framework-directive/save-water-framework-directive.js'
+import { RETURN_TO_CACHE_KEY } from '#src/server/common/constants/cache.js'
+import {
+  getBackLink,
+  getCancelLink
+} from '#src/server/marine-licence/water-framework-directive/nautical-mile/utils.js'
 
 export const NAUTICAL_MILE_VIEW_ROUTE =
   'marine-licence/water-framework-directive/nautical-mile/index'
+
+const NAUTICAL_MILE_HEADING =
+  'Is your project located within one nautical mile (1.85km) of the coast?'
 
 export const errorMessages = {
   NAUTICAL_MILE_REQUIRED:
@@ -14,13 +22,8 @@ export const errorMessages = {
 }
 
 const nauticalMileSettings = {
-  pageTitle:
-    'Is your project located within one nautical mile (1.85km) of the coast?',
-  heading:
-    'Is your project located within one nautical mile (1.85km) of the coast?',
-  backLink:
-    marineLicenceRoutes.MARINE_LICENCE_WATER_FRAMEWORK_DIRECTIVE_BEFORE_YOU_START,
-  cancelLink: marineLicenceRoutes.MARINE_LICENCE_TASK_LIST
+  pageTitle: NAUTICAL_MILE_HEADING,
+  heading: NAUTICAL_MILE_HEADING
 }
 
 export const nauticalMileController = {
@@ -28,8 +31,12 @@ export const nauticalMileController = {
     const marineLicence = getMarineLicenceCache(request)
     const { waterFrameworkDirective } = marineLicence
 
+    const returnTo = request.yar.get(RETURN_TO_CACHE_KEY)
+
     return h.view(NAUTICAL_MILE_VIEW_ROUTE, {
       ...nauticalMileSettings,
+      backLink: getBackLink(returnTo),
+      cancelLink: getCancelLink(returnTo),
       projectName: marineLicence.projectName,
       payload: { nauticalMile: waterFrameworkDirective?.nauticalMile }
     })
@@ -48,13 +55,17 @@ export const nauticalMileSubmitController = {
       }),
       failAction: (request, h, err) => {
         const { projectName } = getMarineLicenceCache(request)
+
+        const returnTo = request.yar.get(RETURN_TO_CACHE_KEY)
+
         return createFailAction({
           viewRoute: NAUTICAL_MILE_VIEW_ROUTE,
           settings: nauticalMileSettings,
-          backLink: nauticalMileSettings.backLink,
+          backLink: getBackLink(returnTo),
           errorMessages,
           projectName,
-          payload: request.payload
+          payload: request.payload,
+          params: { cancelLink: getCancelLink(returnTo) }
         })(request, h, err)
       }
     }
@@ -73,6 +84,10 @@ export const nauticalMileSubmitController = {
 
     if (nauticalMile === 'no') {
       await saveWaterFrameworkDirectiveToBackend(request, true)
+      const returnTo = request.yar.get(RETURN_TO_CACHE_KEY)
+      if (returnTo) {
+        return h.redirect(`${returnTo}#water-framework-directive-card`)
+      }
       return h.redirect(marineLicenceRoutes.MARINE_LICENCE_TASK_LIST)
     }
 

--- a/src/server/marine-licence/water-framework-directive/nautical-mile/controller.test.js
+++ b/src/server/marine-licence/water-framework-directive/nautical-mile/controller.test.js
@@ -7,7 +7,10 @@ import {
 } from '#src/server/marine-licence/water-framework-directive/nautical-mile/controller.js'
 import * as cacheUtils from '#src/server/common/helpers/marine-licence/session-cache/utils.js'
 import * as wfdCache from '#src/server/common/helpers/marine-licence/session-cache/water-framework-directive.js'
-import { createMockH } from '#src/server/test-helpers/mocks/helpers.js'
+import {
+  createMockH,
+  createMockRequest
+} from '#src/server/test-helpers/mocks/helpers.js'
 import { saveWaterFrameworkDirectiveToBackend } from '#src/server/common/helpers/marine-licence/water-framework-directive/save-water-framework-directive.js'
 
 vi.mock('~/src/server/common/helpers/marine-licence/session-cache/utils.js')
@@ -42,7 +45,7 @@ describe('#nauticalMile', () => {
         mockWithouWfd
       )
 
-      await nauticalMileController.handler({ query: {} }, h)
+      await nauticalMileController.handler(createMockRequest(), h)
 
       expect(h.view).toHaveBeenCalledWith(NAUTICAL_MILE_VIEW_ROUTE, {
         backLink:
@@ -56,12 +59,28 @@ describe('#nauticalMile', () => {
         payload: { nauticalMile: undefined }
       })
     })
+
+    test('Should use check-your-answers back link with anchor when returnTo is set', async () => {
+      const request = createMockRequest()
+      request.yar.get.mockReturnValue(
+        marineLicenceRoutes.MARINE_LICENCE_CHECK_YOUR_ANSWERS
+      )
+
+      await nauticalMileController.handler(request, h)
+
+      expect(h.view).toHaveBeenCalledWith(
+        NAUTICAL_MILE_VIEW_ROUTE,
+        expect.objectContaining({
+          backLink: `${marineLicenceRoutes.MARINE_LICENCE_CHECK_YOUR_ANSWERS}#water-framework-directive-card`
+        })
+      )
+    })
   })
 
   describe('#nauticalMileSubmitController', () => {
-    test('Should correctly redirect to nautical mile page on success', async () => {
+    test('Should correctly redirect to excluded activities on success', async () => {
       await nauticalMileSubmitController.handler(
-        { payload: { nauticalMile: 'yes' }, query: {} },
+        createMockRequest({ payload: { nauticalMile: 'yes' } }),
         h
       )
 
@@ -76,9 +95,9 @@ describe('#nauticalMile', () => {
       )
     })
 
-    test('Should correctly redirect when answer is no', async () => {
+    test('Should correctly redirect to task list when answer is no and no returnTo is set', async () => {
       await nauticalMileSubmitController.handler(
-        { payload: { nauticalMile: 'no' }, query: {} },
+        createMockRequest({ payload: { nauticalMile: 'no' } }),
         h
       )
 
@@ -88,6 +107,23 @@ describe('#nauticalMile', () => {
       )
       expect(h.redirect).toHaveBeenCalledWith(
         marineLicenceRoutes.MARINE_LICENCE_TASK_LIST
+      )
+    })
+
+    test('Should redirect to check-your-answers with anchor when answer is no and returnTo is set', async () => {
+      const request = createMockRequest({ payload: { nauticalMile: 'no' } })
+      request.yar.get.mockReturnValue(
+        marineLicenceRoutes.MARINE_LICENCE_CHECK_YOUR_ANSWERS
+      )
+
+      await nauticalMileSubmitController.handler(request, h)
+
+      expect(saveWaterFrameworkDirectiveToBackend).toHaveBeenCalledWith(
+        expect.any(Object),
+        true
+      )
+      expect(h.redirect).toHaveBeenCalledWith(
+        `${marineLicenceRoutes.MARINE_LICENCE_CHECK_YOUR_ANSWERS}#water-framework-directive-card`
       )
     })
 
@@ -113,7 +149,7 @@ describe('#nauticalMile', () => {
     ])(
       'Should correctly handle failAction with $name',
       ({ payload, err, expectedExtra }) => {
-        const request = { payload }
+        const request = createMockRequest({ payload })
         nauticalMileSubmitController.options.validate.failAction(
           request,
           h,
@@ -134,5 +170,19 @@ describe('#nauticalMile', () => {
         expect(h.view().takeover).toHaveBeenCalled()
       }
     )
+
+    test('Should use check-your-answers back link with anchor in failAction when returnTo is set', () => {
+      const request = createMockRequest({ payload: { nauticalMile: '' } })
+      request.yar.get.mockReturnValue(
+        marineLicenceRoutes.MARINE_LICENCE_CHECK_YOUR_ANSWERS
+      )
+      nauticalMileSubmitController.options.validate.failAction(request, h, {})
+      expect(h.view).toHaveBeenCalledWith(
+        NAUTICAL_MILE_VIEW_ROUTE,
+        expect.objectContaining({
+          backLink: `${marineLicenceRoutes.MARINE_LICENCE_CHECK_YOUR_ANSWERS}#water-framework-directive-card`
+        })
+      )
+    })
   })
 })

--- a/src/server/marine-licence/water-framework-directive/nautical-mile/utils.js
+++ b/src/server/marine-licence/water-framework-directive/nautical-mile/utils.js
@@ -1,0 +1,11 @@
+import { marineLicenceRoutes } from '#src/server/common/constants/routes.js'
+
+export const getBackLink = (returnTo) =>
+  returnTo
+    ? `${marineLicenceRoutes.MARINE_LICENCE_CHECK_YOUR_ANSWERS}#water-framework-directive-card`
+    : marineLicenceRoutes.MARINE_LICENCE_WATER_FRAMEWORK_DIRECTIVE_BEFORE_YOU_START
+
+export const getCancelLink = (returnTo) =>
+  returnTo
+    ? `${marineLicenceRoutes.MARINE_LICENCE_CHECK_YOUR_ANSWERS}#water-framework-directive-card`
+    : marineLicenceRoutes.MARINE_LICENCE_TASK_LIST

--- a/src/server/marine-licence/water-framework-directive/nautical-mile/utils.test.js
+++ b/src/server/marine-licence/water-framework-directive/nautical-mile/utils.test.js
@@ -1,0 +1,49 @@
+import {
+  getBackLink,
+  getCancelLink
+} from '#src/server/marine-licence/water-framework-directive/nautical-mile/utils.js'
+import { marineLicenceRoutes } from '#src/server/common/constants/routes.js'
+
+describe('getBackLink', () => {
+  test('returns check-your-answers link with anchor when returnTo is set', () => {
+    expect(
+      getBackLink(marineLicenceRoutes.MARINE_LICENCE_CHECK_YOUR_ANSWERS)
+    ).toBe(
+      `${marineLicenceRoutes.MARINE_LICENCE_CHECK_YOUR_ANSWERS}#water-framework-directive-card`
+    )
+  })
+
+  test('returns before-you-start link when returnTo is null', () => {
+    expect(getBackLink(null)).toBe(
+      marineLicenceRoutes.MARINE_LICENCE_WATER_FRAMEWORK_DIRECTIVE_BEFORE_YOU_START
+    )
+  })
+
+  test('returns before-you-start link when returnTo is undefined', () => {
+    expect(getBackLink(undefined)).toBe(
+      marineLicenceRoutes.MARINE_LICENCE_WATER_FRAMEWORK_DIRECTIVE_BEFORE_YOU_START
+    )
+  })
+})
+
+describe('getCancelLink', () => {
+  test('returns check-your-answers link with anchor when returnTo is set', () => {
+    expect(
+      getCancelLink(marineLicenceRoutes.MARINE_LICENCE_CHECK_YOUR_ANSWERS)
+    ).toBe(
+      `${marineLicenceRoutes.MARINE_LICENCE_CHECK_YOUR_ANSWERS}#water-framework-directive-card`
+    )
+  })
+
+  test('returns before-you-start link when returnTo is null', () => {
+    expect(getCancelLink(null)).toBe(
+      marineLicenceRoutes.MARINE_LICENCE_TASK_LIST
+    )
+  })
+
+  test('returns before-you-start link when returnTo is undefined', () => {
+    expect(getCancelLink(undefined)).toBe(
+      marineLicenceRoutes.MARINE_LICENCE_TASK_LIST
+    )
+  })
+})

--- a/src/server/marine-licence/water-framework-directive/review-your-answers/controller.js
+++ b/src/server/marine-licence/water-framework-directive/review-your-answers/controller.js
@@ -40,8 +40,7 @@ export const waterFrameworkReviewYourAnswersController = {
 
 export const reviewYourAnswersSubmitController = {
   async handler(request, h) {
-    const returnTo = request.yar.flash(RETURN_TO_CACHE_KEY)
-    const redirectPath = Array.isArray(returnTo) ? returnTo[0] : returnTo
+    const redirectPath = request.yar.get(RETURN_TO_CACHE_KEY)
     if (redirectPath) {
       return h.redirect(`${redirectPath}#water-framework-directive-card`)
     }

--- a/src/server/marine-licence/water-framework-directive/review-your-answers/controller.js
+++ b/src/server/marine-licence/water-framework-directive/review-your-answers/controller.js
@@ -2,6 +2,7 @@ import { marineLicenceRoutes } from '#src/server/common/constants/routes.js'
 import { getMarineLicenceCache } from '#src/server/common/helpers/marine-licence/session-cache/utils.js'
 import { waterFrameworkReviewData } from '#src/server/common/helpers/marine-licence/water-framework-directive/water-framework-review-data.js'
 import { getBackLink } from '#src/server/marine-licence/water-framework-directive/review-your-answers/utils.js'
+import { RETURN_TO_CACHE_KEY } from '#src/server/common/constants/cache.js'
 
 export const REVIEW_YOUR_ANSWERS_VIEW_ROUTE =
   'marine-licence/water-framework-directive/review-your-answers/index'
@@ -38,7 +39,12 @@ export const waterFrameworkReviewYourAnswersController = {
 }
 
 export const reviewYourAnswersSubmitController = {
-  async handler(_request, h) {
+  async handler(request, h) {
+    const returnTo = request.yar.flash(RETURN_TO_CACHE_KEY)
+    const redirectPath = Array.isArray(returnTo) ? returnTo[0] : returnTo
+    if (redirectPath) {
+      return h.redirect(`${redirectPath}#water-framework-directive-card`)
+    }
     return h.redirect(marineLicenceRoutes.MARINE_LICENCE_TASK_LIST)
   }
 }

--- a/src/server/marine-licence/water-framework-directive/review-your-answers/controller.test.js
+++ b/src/server/marine-licence/water-framework-directive/review-your-answers/controller.test.js
@@ -82,10 +82,10 @@ describe('#reviewYourAnswers', () => {
   })
 
   describe('reviewYourAnswersSubmitController', () => {
-    test('redirects to task list on submit when no return flash is set', async () => {
+    test('redirects to task list on submit when no returnTo session value is set', async () => {
       const h = createMockHandler('redirect')
       const request = createMockRequest({ payload: {} })
-      request.yar.flash.mockReturnValue(null)
+      request.yar.get.mockReturnValue(null)
 
       await reviewYourAnswersSubmitController.handler(request, h)
 
@@ -94,12 +94,12 @@ describe('#reviewYourAnswers', () => {
       )
     })
 
-    test('redirects to check-your-answers on submit when return flash is set', async () => {
+    test('redirects to check-your-answers with anchor on submit when returnTo session value is set', async () => {
       const h = createMockHandler('redirect')
       const request = createMockRequest({ payload: {} })
-      request.yar.flash.mockReturnValue([
+      request.yar.get.mockReturnValue(
         marineLicenceRoutes.MARINE_LICENCE_CHECK_YOUR_ANSWERS
-      ])
+      )
 
       await reviewYourAnswersSubmitController.handler(request, h)
 

--- a/src/server/marine-licence/water-framework-directive/review-your-answers/controller.test.js
+++ b/src/server/marine-licence/water-framework-directive/review-your-answers/controller.test.js
@@ -82,14 +82,30 @@ describe('#reviewYourAnswers', () => {
   })
 
   describe('reviewYourAnswersSubmitController', () => {
-    test('redirects to task list on submit', async () => {
+    test('redirects to task list on submit when no return flash is set', async () => {
       const h = createMockHandler('redirect')
       const request = createMockRequest({ payload: {} })
+      request.yar.flash.mockReturnValue(null)
 
       await reviewYourAnswersSubmitController.handler(request, h)
 
       expect(h.redirect).toHaveBeenCalledWith(
         marineLicenceRoutes.MARINE_LICENCE_TASK_LIST
+      )
+    })
+
+    test('redirects to check-your-answers on submit when return flash is set', async () => {
+      const h = createMockHandler('redirect')
+      const request = createMockRequest({ payload: {} })
+      request.yar.flash.mockReturnValue([
+        marineLicenceRoutes.MARINE_LICENCE_CHECK_YOUR_ANSWERS
+      ])
+
+      await reviewYourAnswersSubmitController.handler(request, h)
+
+      expect(h.redirect).toHaveBeenCalledWith(
+        marineLicenceRoutes.MARINE_LICENCE_CHECK_YOUR_ANSWERS +
+          '#water-framework-directive-card'
       )
     })
   })

--- a/src/server/marine-licence/water-framework-directive/review-your-answers/utils.js
+++ b/src/server/marine-licence/water-framework-directive/review-your-answers/utils.js
@@ -1,7 +1,8 @@
 import { marineLicenceRoutes } from '#src/server/common/constants/routes.js'
+import { RETURN_TO_CACHE_KEY } from '#src/server/common/constants/cache.js'
 
 export const getBackLink = (request, waterFrameworkDirective = {}) => {
-  if (request.query?.from === 'check-your-answers') {
+  if (request.yar.get(RETURN_TO_CACHE_KEY)) {
     return `${marineLicenceRoutes.MARINE_LICENCE_CHECK_YOUR_ANSWERS}#water-framework-directive-card`
   }
 

--- a/src/server/marine-licence/water-framework-directive/review-your-answers/utils.js
+++ b/src/server/marine-licence/water-framework-directive/review-your-answers/utils.js
@@ -1,6 +1,10 @@
 import { marineLicenceRoutes } from '#src/server/common/constants/routes.js'
 
 export const getBackLink = (request, waterFrameworkDirective = {}) => {
+  if (request.query?.from === 'check-your-answers') {
+    return `${marineLicenceRoutes.MARINE_LICENCE_CHECK_YOUR_ANSWERS}#water-framework-directive-card`
+  }
+
   const previousPage = request.headers?.referer
 
   if (previousPage && URL.canParse(previousPage)) {

--- a/src/server/marine-licence/water-framework-directive/review-your-answers/utils.test.js
+++ b/src/server/marine-licence/water-framework-directive/review-your-answers/utils.test.js
@@ -6,10 +6,11 @@ import { waterFrameworkDirective } from '#src/server/test-helpers/mocks/marine-l
 describe('getBackLink', () => {
   const mockRequest = createMockRequest()
 
-  test('returns check-your-answers link when query.from is check-your-answers', () => {
-    const mockRequestFromCYA = createMockRequest({
-      query: { from: 'check-your-answers' }
-    })
+  test('returns check-your-answers link when returnTo session value is set', () => {
+    const mockRequestFromCYA = createMockRequest()
+    mockRequestFromCYA.yar.get.mockReturnValue(
+      marineLicenceRoutes.MARINE_LICENCE_CHECK_YOUR_ANSWERS
+    )
 
     expect(getBackLink(mockRequestFromCYA, waterFrameworkDirective)).toBe(
       `${marineLicenceRoutes.MARINE_LICENCE_CHECK_YOUR_ANSWERS}#water-framework-directive-card`

--- a/src/server/marine-licence/water-framework-directive/review-your-answers/utils.test.js
+++ b/src/server/marine-licence/water-framework-directive/review-your-answers/utils.test.js
@@ -6,6 +6,16 @@ import { waterFrameworkDirective } from '#src/server/test-helpers/mocks/marine-l
 describe('getBackLink', () => {
   const mockRequest = createMockRequest()
 
+  test('returns check-your-answers link when query.from is check-your-answers', () => {
+    const mockRequestFromCYA = createMockRequest({
+      query: { from: 'check-your-answers' }
+    })
+
+    expect(getBackLink(mockRequestFromCYA, waterFrameworkDirective)).toBe(
+      `${marineLicenceRoutes.MARINE_LICENCE_CHECK_YOUR_ANSWERS}#water-framework-directive-card`
+    )
+  })
+
   test('returns excluded-activities link when excludedActivities is yes', () => {
     expect(
       getBackLink(mockRequest, {

--- a/tests/integration/marine-licence/check-your-answers.test.js
+++ b/tests/integration/marine-licence/check-your-answers.test.js
@@ -12,8 +12,26 @@ import {
   mockPolygonMarineLicence
 } from '~/src/server/test-helpers/mocks/marine-licence-mocks.js'
 import * as marineLicenceService from '~/src/services/marine-licence-service/index.js'
+import { validateWaterFrameworkDirective } from '~/tests/integration/shared/summary-card-validators.js'
+import {
+  NAUTICAL_MILE_HEADING,
+  EXCLUDED_ACTIVITIES_HEADING,
+  PREVIOUS_ASSESSMENT_HEADING,
+  ASSESSMENT_CHANGED_HEADING,
+  FILE_UPLOAD_HEADING
+} from '~/src/server/common/helpers/marine-licence/water-framework-directive/water-framework-review-data.js'
 
 vi.mock('~/src/services/marine-licence-service/index.js')
+
+const expectedWfdContent = {
+  waterFrameworkDirective: {
+    [NAUTICAL_MILE_HEADING]: 'Yes',
+    [EXCLUDED_ACTIVITIES_HEADING]: 'No',
+    [PREVIOUS_ASSESSMENT_HEADING]: 'Yes',
+    [ASSESSMENT_CHANGED_HEADING]: 'No',
+    [FILE_UPLOAD_HEADING]: 'test-upload-id'
+  }
+}
 
 describe('Marine Licence Check Your Answers - site and activity cards', () => {
   const getServer = setupTestServer()
@@ -76,6 +94,18 @@ describe('Marine Licence Check Your Answers - site and activity cards', () => {
       )
     })
 
+    test('renders the water framework directive card with a Change link', () => {
+      const wfdCard = document.querySelector('#water-framework-directive-card')
+      expect(wfdCard).toBeTruthy()
+
+      const changeLink = wfdCard.querySelector('.govuk-summary-card__actions a')
+      expect(changeLink).toBeTruthy()
+      expect(changeLink.textContent).toContain('Change')
+      expect(changeLink.getAttribute('href')).toBe(
+        `${marineLicenceRoutes.MARINE_LICENCE_WATER_FRAMEWORK_DIRECTIVE_REVIEW_YOUR_ANSWERS}?from=check-your-answers`
+      )
+    })
+
     test('renders activity card with card-level Change link and no row-level actions', () => {
       const activityCards = document.querySelectorAll(
         '[id^="activity-details-site-1-activity-"]'
@@ -91,6 +121,7 @@ describe('Marine Licence Check Your Answers - site and activity cards', () => {
       expect(
         activityCard.querySelectorAll('.govuk-summary-list__actions')
       ).toHaveLength(0)
+      validateWaterFrameworkDirective(document, expectedWfdContent)
     })
   })
 
@@ -113,6 +144,7 @@ describe('Marine Licence Check Your Answers - site and activity cards', () => {
       expect(
         getByRole(document, 'heading', { level: 2, name: 'Site 1' })
       ).toBeInTheDocument()
+      validateWaterFrameworkDirective(document, expectedWfdContent)
     })
   })
 
@@ -134,6 +166,7 @@ describe('Marine Licence Check Your Answers - site and activity cards', () => {
         'Single or multiple sets of coordinates'
       )
       expect(siteCard.textContent).toContain('100 metres')
+      validateWaterFrameworkDirective(document, expectedWfdContent)
     })
   })
 
@@ -155,6 +188,7 @@ describe('Marine Licence Check Your Answers - site and activity cards', () => {
         'Single or multiple sets of coordinates'
       )
       expect(siteCard.textContent).toContain('55.123456, 55.123456')
+      validateWaterFrameworkDirective(document, expectedWfdContent)
     })
   })
 
@@ -179,6 +213,7 @@ describe('Marine Licence Check Your Answers - site and activity cards', () => {
       expect(
         getByRole(document, 'heading', { level: 2, name: 'Project details' })
       ).toBeInTheDocument()
+      validateWaterFrameworkDirective(document, expectedWfdContent)
     })
   })
 })

--- a/tests/integration/marine-licence/view-details/fixtures.js
+++ b/tests/integration/marine-licence/view-details/fixtures.js
@@ -1,4 +1,11 @@
 import { mockSubmittedMarineLicenceApplication } from '~/src/server/test-helpers/mocks/marine-licence-mocks.js'
+import {
+  NAUTICAL_MILE_HEADING,
+  EXCLUDED_ACTIVITIES_HEADING,
+  PREVIOUS_ASSESSMENT_HEADING,
+  ASSESSMENT_CHANGED_HEADING,
+  FILE_UPLOAD_HEADING
+} from '~/src/server/common/helpers/marine-licence/water-framework-directive/water-framework-review-data.js'
 
 export const expectedProjectDetailsCard = {
   cardTitle: 'Project details',
@@ -26,4 +33,14 @@ export const expectedSiteDetailsCard = {
       value: 'Download coordinates as a csv file'
     }
   ]
+}
+
+export const expectedWaterFrameworkDirectiveCard = {
+  waterFrameworkDirective: {
+    [NAUTICAL_MILE_HEADING]: 'Yes',
+    [EXCLUDED_ACTIVITIES_HEADING]: 'No',
+    [PREVIOUS_ASSESSMENT_HEADING]: 'Yes',
+    [ASSESSMENT_CHANGED_HEADING]: 'No',
+    [FILE_UPLOAD_HEADING]: 'test-upload-id'
+  }
 }

--- a/tests/integration/marine-licence/view-details/view-details-internal-user.test.js
+++ b/tests/integration/marine-licence/view-details/view-details-internal-user.test.js
@@ -6,10 +6,14 @@ import {
 } from '~/tests/integration/shared/test-setup-helpers.js'
 import { loadPage } from '~/tests/integration/shared/app-server.js'
 import { mockSubmittedMarineLicenceApplication } from '~/src/server/test-helpers/mocks/marine-licence-mocks.js'
-import { expectedSiteDetailsCard } from './fixtures.js'
+import {
+  expectedSiteDetailsCard,
+  expectedWaterFrameworkDirectiveCard
+} from './fixtures.js'
 import { getCardRow } from './utils.js'
 import { getAuthProvider } from '~/src/server/common/helpers/authenticated-requests.js'
 import { AUTH_STRATEGIES } from '~/src/server/common/constants/auth.js'
+import { validateWaterFrameworkDirective } from '#tests/integration/shared/summary-card-validators.js'
 
 vi.mock('~/src/server/common/helpers/authenticated-requests.js')
 
@@ -54,5 +58,27 @@ describe('Marine Licence View Details', () => {
         ).toBe(value)
       }
     )
+  })
+
+  describe('water framework directive card', () => {
+    let document
+
+    beforeEach(async () => {
+      document = await loadViewDetailsPage(getServer())
+    })
+
+    test('renders the water framework directive card', () => {
+      validateWaterFrameworkDirective(
+        document,
+        expectedWaterFrameworkDirectiveCard
+      )
+    })
+
+    test('does not render a Change link', () => {
+      const card = document.querySelector('#water-framework-directive-card')
+      const changeLink = card.querySelector('.govuk-summary-card__actions a')
+
+      expect(changeLink).toBeNull()
+    })
   })
 })

--- a/tests/integration/marine-licence/view-details/view-details.test.js
+++ b/tests/integration/marine-licence/view-details/view-details.test.js
@@ -6,8 +6,12 @@ import {
 } from '~/tests/integration/shared/test-setup-helpers.js'
 import { loadPage } from '~/tests/integration/shared/app-server.js'
 import { mockSubmittedMarineLicenceApplication } from '~/src/server/test-helpers/mocks/marine-licence-mocks.js'
-import { expectedProjectDetailsCard } from './fixtures.js'
+import {
+  expectedProjectDetailsCard,
+  expectedWaterFrameworkDirectiveCard
+} from './fixtures.js'
 import { getCardRow } from './utils.js'
+import { validateWaterFrameworkDirective } from '#tests/integration/shared/summary-card-validators.js'
 
 describe('Marine Licence View Details', () => {
   const getServer = setupTestServer()
@@ -79,6 +83,28 @@ describe('Marine Licence View Details', () => {
 
     test('does not render the internal-user-only site-details-card', () => {
       expect(document.querySelector('#site-details-card')).toBeNull()
+    })
+  })
+
+  describe('water framework directive card', () => {
+    let document
+
+    beforeEach(async () => {
+      document = await loadViewDetailsPage(getServer())
+    })
+
+    test('renders the water framework directive card', () => {
+      validateWaterFrameworkDirective(
+        document,
+        expectedWaterFrameworkDirectiveCard
+      )
+    })
+
+    test('does not render a Change link', () => {
+      const card = document.querySelector('#water-framework-directive-card')
+      const changeLink = card.querySelector('.govuk-summary-card__actions a')
+
+      expect(changeLink).toBeNull()
     })
   })
 })

--- a/tests/integration/shared/summary-card-validators.js
+++ b/tests/integration/shared/summary-card-validators.js
@@ -171,10 +171,20 @@ export const validatePublicRegister = (document, expected) => {
 }
 
 /**
- * Validates site details summary card with support for extended content
+ * Validates water framework directive summary card with support for extended content
  * @param {Document} document - JSDOM document
  * @param {object} expectedPageContent - Expected page content
  */
+export const validateWaterFrameworkDirective = (document, expected) => {
+  if (expected.waterFrameworkDirective) {
+    validateSummaryCardContent(
+      document,
+      '#water-framework-directive-card',
+      expected.waterFrameworkDirective
+    )
+  }
+}
+
 export const validateSiteDetails = (document, expectedPageContent) => {
   const siteDetailsData = expectedPageContent.siteDetails
   const multipleSiteDetails =


### PR DESCRIPTION
## Description

Water Framework Directive: Show the card on View Details and Check Your Answers

 ## Changes

- New card showing data, using same util as Review Your Answers for data formatting
- 'Change ' link shows on CYA only
- Change link must work and allow the user to change Nautical Mile from No to Yes and proceed through flow of pages.

 ## Logic for 'Change'

- new helper `return-to-cache.js` is needed here. We can't just flash the RETURN_TO value now as we could potentially have a situation where a user goes from Nautical Mile through the flow part way, and then goes back. We need to remember that the user goes back to Check Your Answers here, which is why get/set is introduced. Flash remains there for the site-details scenario's.

- The other scenarios are Change going to Review Details or Nautical Mile with 'no' staying as the choice, both of these work in the same way as Site Details 

<img width="1006" height="556" alt="Screenshot 2026-06-18 at 13 39 51" src="https://github.com/user-attachments/assets/5c5add4a-6739-4e25-8994-7ea402e6938d" />
