### PR TITLE
ML-1344 - Header should not appear at the top of the 'file upload' page

### DIFF
--- a/src/config/nunjucks/context/context.js
+++ b/src/config/nunjucks/context/context.js
@@ -31,7 +31,8 @@ const hideNavigationRoutesMarineLicence = new Set([
 
 const hideNavigationRoutesMarineLicenceAlways = new Set([
   marineLicenceRoutes.MARINE_LICENCE_CALCULATE_MARINE_PLAN_POLICIES,
-  marineLicenceRoutes.MARINE_LICENCE_UPLOAD_AND_WAIT
+  marineLicenceRoutes.MARINE_LICENCE_UPLOAD_AND_WAIT,
+  marineLicenceRoutes.MARINE_LICENCE_WATER_FRAMEWORK_DIRECTIVE_UPLOAD_AND_WAIT
 ])
 
 const hideNavigationRoutesExemptionAlways = new Set([routes.UPLOAD_AND_WAIT])

--- a/src/config/nunjucks/context/context.test.js
+++ b/src/config/nunjucks/context/context.test.js
@@ -185,6 +185,16 @@ describe('#context', () => {
     expect(contextResult.navigation).toEqual([])
   })
 
+  it('When on the water framework directive file upload page, should not use navigation links', () => {
+    vi.mocked(getMarineLicenceCache).mockReturnValue({ id: 'some-id' })
+    const mockRequest = {
+      path: '/marine-licence/water-framework-directive-upload-and-wait',
+      logger: { error: vi.fn() }
+    }
+    const contextResult = context(mockRequest)
+    expect(contextResult.navigation).toEqual([])
+  })
+
   it('When session cache throws, should show navigation', () => {
     vi.mocked(getMarineLicenceCache).mockImplementation(() => {
       throw new TypeError('Cannot read properties of null')


### PR DESCRIPTION
Water framework directive upoload and wait page was missed when hiding navigation links on the page