### PR TITLE
ML-1431: MCMS handover

### DIFF
--- a/src/server/journey/self-service/services/application-handoff.js
+++ b/src/server/journey/self-service/services/application-handoff.js
@@ -73,6 +73,13 @@ export function buildMcmsRedirectUrl(baseUrl, path, queryString) {
   return `${url.toString()}${separator}${queryString}`
 }
 
+function joinAnswerIds(entry) {
+  return (entry?.answers ?? [])
+    .map((a) => a?.id)
+    .filter(Boolean)
+    .join(',')
+}
+
 export function buildMcmsHandoffQueryString({
   questionLog,
   focusedOption,
@@ -86,9 +93,9 @@ export function buildMcmsHandoffQueryString({
   }
   for (const entry of questionLog ?? []) {
     const mapping = entry?.mcmsAppFormMapping
-    const answerId = entry?.answers?.[0]?.id
-    if (mapping && answerId) {
-      params.append(mapping, answerId)
+    const answerIds = joinAnswerIds(entry)
+    if (mapping && answerIds) {
+      params.append(mapping, answerIds)
     }
   }
   for (const param of focusedOption?.params ?? []) {

--- a/src/server/journey/self-service/services/application-handoff.test.js
+++ b/src/server/journey/self-service/services/application-handoff.test.js
@@ -177,7 +177,7 @@ describe('buildMcmsHandoffQueryString', () => {
     )
   })
 
-  it('joins all selected answers of a multi-select question as a comma-separated value (ML-1431)', () => {
+  it('joins all selected answers of a multi-select question as a comma-separated value', () => {
     const qs = buildMcmsHandoffQueryString({
       questionLog: [
         {
@@ -205,7 +205,7 @@ describe('buildMcmsHandoffQueryString', () => {
     )
   })
 
-  it('joins three or more selected answers (not hard-coded to two)', () => {
+  it('joins three or more selected answers', () => {
     const qs = buildMcmsHandoffQueryString({
       questionLog: [
         {

--- a/src/server/journey/self-service/services/application-handoff.test.js
+++ b/src/server/journey/self-service/services/application-handoff.test.js
@@ -177,6 +177,66 @@ describe('buildMcmsHandoffQueryString', () => {
     )
   })
 
+  it('joins all selected answers of a multi-select question as a comma-separated value (ML-1431)', () => {
+    const qs = buildMcmsHandoffQueryString({
+      questionLog: [
+        {
+          questionRoute: '/construction/maintenance-existing-works',
+          answers: [
+            {
+              id: 'SCAFFOLDING_ACCESS_TOWERS',
+              text: 'Scaffolding or access towers'
+            },
+            {
+              id: 'REPAINTING_STRUCTURES',
+              text: 'Re-painting of existing structures or assets'
+            }
+          ],
+          mcmsAppFormMapping: 'MAINTENANCE_EXISTING_WORKS_ACTIVITIES'
+        }
+      ],
+      focusedOption: { params: null },
+      journeyId: 'CTX',
+      viewAnswersUrl: null
+    })
+    expect(qs).toBe(
+      'journeyId=CTX' +
+        '&MAINTENANCE_EXISTING_WORKS_ACTIVITIES=SCAFFOLDING_ACCESS_TOWERS%2CREPAINTING_STRUCTURES'
+    )
+  })
+
+  it('joins three or more selected answers (not hard-coded to two)', () => {
+    const qs = buildMcmsHandoffQueryString({
+      questionLog: [
+        {
+          questionRoute: '/removal/activities',
+          answers: [{ id: 'A' }, { id: 'B' }, { id: 'C' }],
+          mcmsAppFormMapping: 'MINOR_REMOVALS_ACTIVITIES'
+        }
+      ],
+      focusedOption: { params: null },
+      journeyId: 'CTX',
+      viewAnswersUrl: null
+    })
+    expect(qs).toBe('journeyId=CTX&MINOR_REMOVALS_ACTIVITIES=A%2CB%2CC')
+  })
+
+  it('emits a single-select answer with no comma', () => {
+    const qs = buildMcmsHandoffQueryString({
+      questionLog: [
+        {
+          questionRoute: '/activity-type',
+          answers: [{ id: 'DEPOSIT', text: 'Deposit' }],
+          mcmsAppFormMapping: 'ACTIVITY_TYPE'
+        }
+      ],
+      focusedOption: { params: null },
+      journeyId: 'CTX',
+      viewAnswersUrl: null
+    })
+    expect(qs).toBe('journeyId=CTX&ACTIVITY_TYPE=DEPOSIT')
+  })
+
   it('always emits journeyId and skips entries with no mapping or no answer', () => {
     const qs = buildMcmsHandoffQueryString({
       questionLog: [

--- a/src/server/journey/self-service/services/application-handoff.test.js
+++ b/src/server/journey/self-service/services/application-handoff.test.js
@@ -237,6 +237,35 @@ describe('buildMcmsHandoffQueryString', () => {
     expect(qs).toBe('journeyId=CTX&ACTIVITY_TYPE=DEPOSIT')
   })
 
+  it('drops answers with no id and joins only the truthy ids', () => {
+    const qs = buildMcmsHandoffQueryString({
+      questionLog: [
+        {
+          questionRoute: '/removal/activities',
+          answers: [{ id: null }, { id: 'B' }, null, { id: 'C' }],
+          mcmsAppFormMapping: 'MINOR_REMOVALS_ACTIVITIES'
+        }
+      ],
+      focusedOption: { params: null },
+      journeyId: 'CTX',
+      viewAnswersUrl: null
+    })
+    expect(qs).toBe('journeyId=CTX&MINOR_REMOVALS_ACTIVITIES=B%2CC')
+  })
+
+  it('skips a null entry and a mapped entry that has no answers array', () => {
+    const qs = buildMcmsHandoffQueryString({
+      questionLog: [
+        null,
+        { questionRoute: '/x', mcmsAppFormMapping: 'ACTIVITY_TYPE' }
+      ],
+      focusedOption: { params: null },
+      journeyId: 'CTX',
+      viewAnswersUrl: null
+    })
+    expect(qs).toBe('journeyId=CTX')
+  })
+
   it('always emits journeyId and skips entries with no mapping or no answer', () => {
     const qs = buildMcmsHandoffQueryString({
       questionLog: [


### PR DESCRIPTION
## Issue 

When sending multiple checkbox values over to MCMS for ML it is currently only sending the first checkbox.  This bugfix sends across all all selected values joined by a comma.  The comma is urlencoded to %2C in the QS and will be correctly decoded to a comma, which the remote system can use to split on.

