### PR TITLE
ML-1260 - MPP - Handling errors/timeouts in MPP API calls

### DIFF
--- a/src/server/common/helpers/marine-licence/marine-plan-policy-query.js
+++ b/src/server/common/helpers/marine-licence/marine-plan-policy-query.js
@@ -1,0 +1,21 @@
+import { apiRoutes } from '#src/server/common/constants/routes.js'
+import { authenticatedPostRequest } from '#src/server/common/helpers/authenticated-requests.js'
+
+const QUERY_STARTED_AT_KEY = 'marinePlanPolicyQueryStartedAt'
+
+export function storeMarinePlanPolicyQueryStartTime(request) {
+  request.yar.set(QUERY_STARTED_AT_KEY, Date.now())
+}
+
+export function getMarinePlanPolicyQueryStartTime(request) {
+  return request.yar.get(QUERY_STARTED_AT_KEY)
+}
+
+export async function triggerMarinePlanPolicyQuery(request, marineLicenceId) {
+  await authenticatedPostRequest(
+    request,
+    apiRoutes.CALCULATE_MARINE_PLAN_POLICIES,
+    JSON.stringify({ id: marineLicenceId })
+  )
+  storeMarinePlanPolicyQueryStartTime(request)
+}

--- a/src/server/common/helpers/marine-licence/marine-plan-policy-query.test.js
+++ b/src/server/common/helpers/marine-licence/marine-plan-policy-query.test.js
@@ -1,8 +1,13 @@
 import { vi } from 'vitest'
 import {
   storeMarinePlanPolicyQueryStartTime,
-  getMarinePlanPolicyQueryStartTime
-} from './marine-plan-policy-wait.js'
+  getMarinePlanPolicyQueryStartTime,
+  triggerMarinePlanPolicyQuery
+} from './marine-plan-policy-query.js'
+import { authenticatedPostRequest } from '#src/server/common/helpers/authenticated-requests.js'
+import { apiRoutes } from '#src/server/common/constants/routes.js'
+
+vi.mock('~/src/server/common/helpers/authenticated-requests.js')
 
 const createMockRequest = () => ({
   yar: {
@@ -11,7 +16,7 @@ const createMockRequest = () => ({
   }
 })
 
-describe('marine-plan-policy-wait', () => {
+describe('marine-plan-policy-query', () => {
   let mockRequest
 
   beforeEach(() => {
@@ -46,6 +51,26 @@ describe('marine-plan-policy-wait', () => {
       mockRequest.yar.get.mockReturnValue(undefined)
 
       expect(getMarinePlanPolicyQueryStartTime(mockRequest)).toBeUndefined()
+    })
+  })
+
+  describe('triggerMarinePlanPolicyQuery', () => {
+    it('posts the calculate request and stores the start time', async () => {
+      const now = 1700000000000
+      vi.spyOn(Date, 'now').mockReturnValue(now)
+      vi.mocked(authenticatedPostRequest).mockResolvedValue({})
+
+      await triggerMarinePlanPolicyQuery(mockRequest, 'test-id')
+
+      expect(authenticatedPostRequest).toHaveBeenCalledWith(
+        mockRequest,
+        apiRoutes.CALCULATE_MARINE_PLAN_POLICIES,
+        JSON.stringify({ id: 'test-id' })
+      )
+      expect(mockRequest.yar.set).toHaveBeenCalledWith(
+        'marinePlanPolicyQueryStartedAt',
+        now
+      )
     })
   })
 })

--- a/src/server/common/helpers/marine-licence/marine-plan-policy-wait.js
+++ b/src/server/common/helpers/marine-licence/marine-plan-policy-wait.js
@@ -1,9 +1,0 @@
-const QUERY_STARTED_AT_KEY = 'marinePlanPolicyQueryStartedAt'
-
-export function storeMarinePlanPolicyQueryStartTime(request) {
-  request.yar.set(QUERY_STARTED_AT_KEY, Date.now())
-}
-
-export function getMarinePlanPolicyQueryStartTime(request) {
-  return request.yar.get(QUERY_STARTED_AT_KEY)
-}

--- a/src/server/marine-licence/marine-plan-policies/calculate-marine-plan-policies-and-wait/controller.js
+++ b/src/server/marine-licence/marine-plan-policies/calculate-marine-plan-policies-and-wait/controller.js
@@ -11,11 +11,11 @@ export const CALCULATE_MARINE_PLAN_POLICIES_AND_WAIT_VIEW_ROUTE =
 
 const WAIT_TIMEOUT_MS = 50_000
 
-const waitPageView = () => ({
+const WAIT_PAGE_VIEW = {
   pageTitle: 'Loading your Marine plan policies',
   heading: 'Loading your Marine plan policies',
   pageRefreshTimeInMs: 2000
-})
+}
 
 async function handleFailedJob(request, h, marineLicenceId, taskList) {
   if (taskList?.siteDetails !== 'COMPLETED') {
@@ -25,7 +25,7 @@ async function handleFailedJob(request, h, marineLicenceId, taskList) {
   await triggerMarinePlanPolicyQuery(request, marineLicenceId)
   return h.view(
     CALCULATE_MARINE_PLAN_POLICIES_AND_WAIT_VIEW_ROUTE,
-    waitPageView()
+    WAIT_PAGE_VIEW
   )
 }
 
@@ -54,7 +54,7 @@ export const calculateMarinePlanPoliciesAndWaitController = {
 
     return h.view(
       CALCULATE_MARINE_PLAN_POLICIES_AND_WAIT_VIEW_ROUTE,
-      waitPageView()
+      WAIT_PAGE_VIEW
     )
   }
 }

--- a/src/server/marine-licence/marine-plan-policies/calculate-marine-plan-policies-and-wait/controller.js
+++ b/src/server/marine-licence/marine-plan-policies/calculate-marine-plan-policies-and-wait/controller.js
@@ -1,12 +1,33 @@
 import { marineLicenceRoutes } from '#src/server/common/constants/routes.js'
 import { getMarineLicenceCache } from '#src/server/common/helpers/marine-licence/session-cache/utils.js'
 import { getMarineLicenceService } from '#src/services/marine-licence-service/index.js'
-import { getMarinePlanPolicyQueryStartTime } from '#src/server/common/helpers/marine-licence/marine-plan-policy-wait.js'
+import {
+  getMarinePlanPolicyQueryStartTime,
+  triggerMarinePlanPolicyQuery
+} from '#src/server/common/helpers/marine-licence/marine-plan-policy-query.js'
 
 export const CALCULATE_MARINE_PLAN_POLICIES_AND_WAIT_VIEW_ROUTE =
   'marine-licence/marine-plan-policies/calculate-marine-plan-policies-and-wait/index'
 
 const WAIT_TIMEOUT_MS = 50_000
+
+const waitPageView = () => ({
+  pageTitle: 'Loading your Marine plan policies',
+  heading: 'Loading your Marine plan policies',
+  pageRefreshTimeInMs: 2000
+})
+
+async function handleFailedJob(request, h, marineLicenceId, taskList) {
+  if (taskList?.siteDetails !== 'COMPLETED') {
+    return h.redirect(marineLicenceRoutes.MARINE_LICENCE_TASK_LIST)
+  }
+
+  await triggerMarinePlanPolicyQuery(request, marineLicenceId)
+  return h.view(
+    CALCULATE_MARINE_PLAN_POLICIES_AND_WAIT_VIEW_ROUTE,
+    waitPageView()
+  )
+}
 
 export const calculateMarinePlanPoliciesAndWaitController = {
   async handler(request, h) {
@@ -17,24 +38,23 @@ export const calculateMarinePlanPoliciesAndWaitController = {
     }
 
     const marineLicenceService = getMarineLicenceService(request)
-    const { marinePlanPolicyJob } =
+    const { marinePlanPolicyJob, taskList } =
       await marineLicenceService.getMarineLicenceById(marineLicence.id)
 
+    if (marinePlanPolicyJob === 'failed') {
+      return handleFailedJob(request, h, marineLicence.id, taskList)
+    }
+
     const startedAt = getMarinePlanPolicyQueryStartTime(request)
-
-    const isJobComplete =
-      marinePlanPolicyJob === 'ready' || marinePlanPolicyJob === 'failed'
-
     const hasTimedOut = startedAt && Date.now() - startedAt >= WAIT_TIMEOUT_MS
 
-    if (isJobComplete || hasTimedOut) {
+    if (marinePlanPolicyJob === 'ready' || hasTimedOut) {
       return h.redirect(marineLicenceRoutes.MARINE_LICENCE_TASK_LIST)
     }
 
-    return h.view(CALCULATE_MARINE_PLAN_POLICIES_AND_WAIT_VIEW_ROUTE, {
-      pageTitle: 'Loading your Marine plan policies',
-      heading: 'Loading your Marine plan policies',
-      pageRefreshTimeInMs: 2000
-    })
+    return h.view(
+      CALCULATE_MARINE_PLAN_POLICIES_AND_WAIT_VIEW_ROUTE,
+      waitPageView()
+    )
   }
 }

--- a/src/server/marine-licence/marine-plan-policies/calculate-marine-plan-policies-and-wait/controller.js
+++ b/src/server/marine-licence/marine-plan-policies/calculate-marine-plan-policies-and-wait/controller.js
@@ -31,6 +31,11 @@ export const calculateMarinePlanPoliciesAndWaitController = {
       return h.redirect(marineLicenceRoutes.MARINE_LICENCE_TASK_LIST)
     }
 
+    const startedAt = getMarinePlanPolicyQueryStartTime(request)
+    if (startedAt && Date.now() - startedAt >= WAIT_TIMEOUT_MS) {
+      return h.redirect(marineLicenceRoutes.MARINE_LICENCE_TASK_LIST)
+    }
+
     return h.view(CALCULATE_MARINE_PLAN_POLICIES_AND_WAIT_VIEW_ROUTE, {
       pageTitle: 'Loading your Marine plan policies',
       heading: 'Loading your Marine plan policies',

--- a/src/server/marine-licence/marine-plan-policies/calculate-marine-plan-policies-and-wait/controller.js
+++ b/src/server/marine-licence/marine-plan-policies/calculate-marine-plan-policies-and-wait/controller.js
@@ -31,11 +31,6 @@ export const calculateMarinePlanPoliciesAndWaitController = {
       return h.redirect(marineLicenceRoutes.MARINE_LICENCE_TASK_LIST)
     }
 
-    const startedAt = getMarinePlanPolicyQueryStartTime(request)
-    if (startedAt && Date.now() - startedAt >= WAIT_TIMEOUT_MS) {
-      return h.redirect(marineLicenceRoutes.MARINE_LICENCE_TASK_LIST)
-    }
-
     return h.view(CALCULATE_MARINE_PLAN_POLICIES_AND_WAIT_VIEW_ROUTE, {
       pageTitle: 'Loading your Marine plan policies',
       heading: 'Loading your Marine plan policies',

--- a/src/server/marine-licence/marine-plan-policies/calculate-marine-plan-policies-and-wait/controller.test.js
+++ b/src/server/marine-licence/marine-plan-policies/calculate-marine-plan-policies-and-wait/controller.test.js
@@ -1,7 +1,7 @@
 import { vi } from 'vitest'
 import * as cacheUtils from '#src/server/common/helpers/marine-licence/session-cache/utils.js'
 import * as marineLicenceService from '#src/services/marine-licence-service/index.js'
-import * as marinePlanPolicyWait from '#src/server/common/helpers/marine-licence/marine-plan-policy-wait.js'
+import * as marinePlanPolicyQuery from '#src/server/common/helpers/marine-licence/marine-plan-policy-query.js'
 import {
   CALCULATE_MARINE_PLAN_POLICIES_AND_WAIT_VIEW_ROUTE,
   calculateMarinePlanPoliciesAndWaitController
@@ -11,7 +11,9 @@ import { createMockRequest } from '#src/server/test-helpers/mocks/helpers.js'
 
 vi.mock('~/src/server/common/helpers/marine-licence/session-cache/utils.js')
 vi.mock('~/src/services/marine-licence-service/index.js')
-vi.mock('~/src/server/common/helpers/marine-licence/marine-plan-policy-wait.js')
+vi.mock(
+  '~/src/server/common/helpers/marine-licence/marine-plan-policy-query.js'
+)
 
 describe('#calculateMarinePlanPoliciesAndWaitController', () => {
   const mockRequest = createMockRequest()
@@ -26,8 +28,11 @@ describe('#calculateMarinePlanPoliciesAndWaitController', () => {
         .mockResolvedValue({ marinePlanPolicyJob: 'pending' })
     })
     vi.mocked(
-      marinePlanPolicyWait.getMarinePlanPolicyQueryStartTime
+      marinePlanPolicyQuery.getMarinePlanPolicyQueryStartTime
     ).mockReturnValue(undefined)
+    vi.mocked(
+      marinePlanPolicyQuery.triggerMarinePlanPolicyQuery
+    ).mockResolvedValue(undefined)
   })
 
   test('should redirect to task list when no marine licence id in cache', async () => {
@@ -58,9 +63,62 @@ describe('#calculateMarinePlanPoliciesAndWaitController', () => {
     expect(h.redirect).toHaveBeenCalledWith(
       marineLicenceRoutes.MARINE_LICENCE_TASK_LIST
     )
+    expect(
+      marinePlanPolicyQuery.triggerMarinePlanPolicyQuery
+    ).not.toHaveBeenCalled()
   })
 
-  test('should redirect to task list when marinePlanPolicyJob is failed', async () => {
+  test('should re-trigger the query and render the spinner when marinePlanPolicyJob is failed and site details are completed', async () => {
+    vi.mocked(marineLicenceService.getMarineLicenceService).mockReturnValueOnce(
+      {
+        getMarineLicenceById: vi.fn().mockResolvedValue({
+          marinePlanPolicyJob: 'failed',
+          taskList: { siteDetails: 'COMPLETED' }
+        })
+      }
+    )
+
+    const h = { redirect: vi.fn(), view: vi.fn() }
+
+    await calculateMarinePlanPoliciesAndWaitController.handler(mockRequest, h)
+
+    expect(
+      marinePlanPolicyQuery.triggerMarinePlanPolicyQuery
+    ).toHaveBeenCalledWith(mockRequest, 'test-id')
+    expect(h.view).toHaveBeenCalledWith(
+      CALCULATE_MARINE_PLAN_POLICIES_AND_WAIT_VIEW_ROUTE,
+      {
+        pageTitle: 'Loading your Marine plan policies',
+        heading: 'Loading your Marine plan policies',
+        pageRefreshTimeInMs: 2000
+      }
+    )
+    expect(h.redirect).not.toHaveBeenCalled()
+  })
+
+  test('should redirect to task list when marinePlanPolicyJob is failed and site details are not completed', async () => {
+    vi.mocked(marineLicenceService.getMarineLicenceService).mockReturnValueOnce(
+      {
+        getMarineLicenceById: vi.fn().mockResolvedValue({
+          marinePlanPolicyJob: 'failed',
+          taskList: { siteDetails: 'IN_PROGRESS' }
+        })
+      }
+    )
+
+    const h = { redirect: vi.fn(), view: vi.fn() }
+
+    await calculateMarinePlanPoliciesAndWaitController.handler(mockRequest, h)
+
+    expect(h.redirect).toHaveBeenCalledWith(
+      marineLicenceRoutes.MARINE_LICENCE_TASK_LIST
+    )
+    expect(
+      marinePlanPolicyQuery.triggerMarinePlanPolicyQuery
+    ).not.toHaveBeenCalled()
+  })
+
+  test('should redirect to task list when marinePlanPolicyJob is failed and taskList is missing', async () => {
     vi.mocked(marineLicenceService.getMarineLicenceService).mockReturnValueOnce(
       {
         getMarineLicenceById: vi
@@ -69,13 +127,16 @@ describe('#calculateMarinePlanPoliciesAndWaitController', () => {
       }
     )
 
-    const h = { redirect: vi.fn() }
+    const h = { redirect: vi.fn(), view: vi.fn() }
 
     await calculateMarinePlanPoliciesAndWaitController.handler(mockRequest, h)
 
     expect(h.redirect).toHaveBeenCalledWith(
       marineLicenceRoutes.MARINE_LICENCE_TASK_LIST
     )
+    expect(
+      marinePlanPolicyQuery.triggerMarinePlanPolicyQuery
+    ).not.toHaveBeenCalled()
   })
 
   test('should render spinner view when job is not ready', async () => {
@@ -91,6 +152,9 @@ describe('#calculateMarinePlanPoliciesAndWaitController', () => {
         pageRefreshTimeInMs: 2000
       }
     )
+    expect(
+      marinePlanPolicyQuery.triggerMarinePlanPolicyQuery
+    ).not.toHaveBeenCalled()
   })
 
   test('should render spinner view when job is computing', async () => {
@@ -114,13 +178,16 @@ describe('#calculateMarinePlanPoliciesAndWaitController', () => {
         pageRefreshTimeInMs: 2000
       }
     )
+    expect(
+      marinePlanPolicyQuery.triggerMarinePlanPolicyQuery
+    ).not.toHaveBeenCalled()
   })
 
   test('should render spinner view when under the 50 second wait limit', async () => {
     const now = 1_700_000_000_000
     vi.spyOn(Date, 'now').mockReturnValue(now)
     vi.mocked(
-      marinePlanPolicyWait.getMarinePlanPolicyQueryStartTime
+      marinePlanPolicyQuery.getMarinePlanPolicyQueryStartTime
     ).mockReturnValue(now - 49_000)
 
     const h = { view: vi.fn() }
@@ -137,7 +204,7 @@ describe('#calculateMarinePlanPoliciesAndWaitController', () => {
     const now = 1_700_000_000_000
     vi.spyOn(Date, 'now').mockReturnValue(now)
     vi.mocked(
-      marinePlanPolicyWait.getMarinePlanPolicyQueryStartTime
+      marinePlanPolicyQuery.getMarinePlanPolicyQueryStartTime
     ).mockReturnValue(now - 50_000)
 
     const h = { redirect: vi.fn() }
@@ -160,7 +227,7 @@ describe('#calculateMarinePlanPoliciesAndWaitController', () => {
     const now = 1_700_000_000_000
     vi.spyOn(Date, 'now').mockReturnValue(now)
     vi.mocked(
-      marinePlanPolicyWait.getMarinePlanPolicyQueryStartTime
+      marinePlanPolicyQuery.getMarinePlanPolicyQueryStartTime
     ).mockReturnValue(now - 60_000)
 
     const h = { redirect: vi.fn() }

--- a/src/server/marine-licence/marine-plan-policies/marine-plan-policies-holding/controller.test.js
+++ b/src/server/marine-licence/marine-plan-policies/marine-plan-policies-holding/controller.test.js
@@ -75,7 +75,6 @@ describe('#marinePlanPoliciesHoldingController', () => {
   })
 
   test.each(['pending', 'computing'])(
-
     'should render the holding view when marinePlanPolicyJob is %s',
     async (marinePlanPolicyJob) => {
       vi.mocked(

--- a/src/server/marine-licence/marine-plan-policies/marine-plan-policies-holding/controller.test.js
+++ b/src/server/marine-licence/marine-plan-policies/marine-plan-policies-holding/controller.test.js
@@ -75,6 +75,7 @@ describe('#marinePlanPoliciesHoldingController', () => {
   })
 
   test.each(['pending', 'computing'])(
+
     'should render the holding view when marinePlanPolicyJob is %s',
     async (marinePlanPolicyJob) => {
       vi.mocked(

--- a/src/server/marine-licence/site-details/review-site-details/controller.js
+++ b/src/server/marine-licence/site-details/review-site-details/controller.js
@@ -13,12 +13,9 @@ import {
   setMarineLicenceCache,
   updateMarineLicenceSiteDetails
 } from '#src/server/common/helpers/marine-licence/session-cache/utils.js'
-import { storeMarinePlanPolicyQueryStartTime } from '#src/server/common/helpers/marine-licence/marine-plan-policy-wait.js'
+import { triggerMarinePlanPolicyQuery } from '#src/server/common/helpers/marine-licence/marine-plan-policy-query.js'
 import { getMarineLicenceService } from '#src/services/marine-licence-service/index.js'
-import {
-  authenticatedPatchRequest,
-  authenticatedPostRequest
-} from '#src/server/common/helpers/authenticated-requests.js'
+import { authenticatedPatchRequest } from '#src/server/common/helpers/authenticated-requests.js'
 import { finishedSiteDetailsSchema } from '#src/server/common/validation/finished-site-details/schema.js'
 import { finishedSiteDetailsErrorMessages } from '#src/server/common/validation/finished-site-details/constants.js'
 import {
@@ -195,12 +192,7 @@ async function confirmSiteDetails(
     return h.redirect(returnToCheckYourAnswers)
   }
 
-  await authenticatedPostRequest(
-    request,
-    apiRoutes.CALCULATE_MARINE_PLAN_POLICIES,
-    JSON.stringify({ id: marineLicence.id })
-  )
-  storeMarinePlanPolicyQueryStartTime(request)
+  await triggerMarinePlanPolicyQuery(request, marineLicence.id)
   return h.redirect(
     marineLicenceRoutes.MARINE_LICENCE_CALCULATE_MARINE_PLAN_POLICIES
   )

--- a/src/server/marine-licence/site-details/review-site-details/controller.test.js
+++ b/src/server/marine-licence/site-details/review-site-details/controller.test.js
@@ -2,6 +2,7 @@ import { beforeAll, vi } from 'vitest'
 import * as cacheUtils from '#src/server/common/helpers/marine-licence/session-cache/utils.js'
 import * as marineLicenceService from '#src/services/marine-licence-service/index.js'
 import * as authenticatedRequests from '#src/server/common/helpers/authenticated-requests.js'
+import * as marinePlanPolicyQuery from '#src/server/common/helpers/marine-licence/marine-plan-policy-query.js'
 import {
   FILE_UPLOAD_REVIEW_VIEW_ROUTE,
   reviewSiteDetailsController,
@@ -23,6 +24,9 @@ import { RETURN_TO_CACHE_KEY } from '#src/server/common/constants/cache.js'
 vi.mock('~/src/server/common/helpers/marine-licence/session-cache/utils.js')
 vi.mock('~/src/services/marine-licence-service/index.js')
 vi.mock('~/src/server/common/helpers/authenticated-requests.js')
+vi.mock(
+  '~/src/server/common/helpers/marine-licence/marine-plan-policy-query.js'
+)
 
 function createMockHandler(type = 'view') {
   if (type === 'redirect') {
@@ -279,8 +283,8 @@ describe('#reviewSiteDetails', () => {
         }
       )
       vi.mocked(
-        authenticatedRequests.authenticatedPostRequest
-      ).mockResolvedValue({})
+        marinePlanPolicyQuery.triggerMarinePlanPolicyQuery
+      ).mockResolvedValue(undefined)
       vi.mocked(
         authenticatedRequests.authenticatedPatchRequest
       ).mockResolvedValue({})
@@ -299,16 +303,8 @@ describe('#reviewSiteDetails', () => {
         confirmed: true
       })
       expect(
-        vi.mocked(authenticatedRequests.authenticatedPostRequest)
-      ).toHaveBeenCalledWith(
-        request,
-        apiRoutes.CALCULATE_MARINE_PLAN_POLICIES,
-        JSON.stringify({ id: 'test-id' })
-      )
-      expect(request.yar.set).toHaveBeenCalledWith(
-        'marinePlanPolicyQueryStartedAt',
-        expect.any(Number)
-      )
+        vi.mocked(marinePlanPolicyQuery.triggerMarinePlanPolicyQuery)
+      ).toHaveBeenCalledWith(request, 'test-id')
       expect(h.redirect).toHaveBeenCalledWith(
         marineLicenceRoutes.MARINE_LICENCE_CALCULATE_MARINE_PLAN_POLICIES
       )
@@ -347,7 +343,7 @@ describe('#reviewSiteDetails', () => {
         confirmed: true
       })
       expect(
-        vi.mocked(authenticatedRequests.authenticatedPostRequest)
+        vi.mocked(marinePlanPolicyQuery.triggerMarinePlanPolicyQuery)
       ).not.toHaveBeenCalled()
       expect(h.redirect).toHaveBeenCalledWith(
         marineLicenceRoutes.MARINE_LICENCE_CHECK_YOUR_ANSWERS
@@ -369,8 +365,8 @@ describe('#reviewSiteDetails', () => {
         }
       )
       vi.mocked(
-        authenticatedRequests.authenticatedPostRequest
-      ).mockResolvedValue({})
+        marinePlanPolicyQuery.triggerMarinePlanPolicyQuery
+      ).mockResolvedValue(undefined)
       vi.mocked(
         authenticatedRequests.authenticatedPatchRequest
       ).mockResolvedValue({})
@@ -384,16 +380,8 @@ describe('#reviewSiteDetails', () => {
       await reviewSiteDetailsSubmitController.handler(request, h)
 
       expect(
-        vi.mocked(authenticatedRequests.authenticatedPostRequest)
-      ).toHaveBeenCalledWith(
-        request,
-        apiRoutes.CALCULATE_MARINE_PLAN_POLICIES,
-        JSON.stringify({ id: 'test-id' })
-      )
-      expect(request.yar.set).toHaveBeenCalledWith(
-        'marinePlanPolicyQueryStartedAt',
-        expect.any(Number)
-      )
+        vi.mocked(marinePlanPolicyQuery.triggerMarinePlanPolicyQuery)
+      ).toHaveBeenCalledWith(request, 'test-id')
       expect(h.redirect).toHaveBeenCalledWith(
         marineLicenceRoutes.MARINE_LICENCE_CALCULATE_MARINE_PLAN_POLICIES
       )
@@ -414,8 +402,8 @@ describe('#reviewSiteDetails', () => {
         }
       )
       vi.mocked(
-        authenticatedRequests.authenticatedPostRequest
-      ).mockResolvedValue({})
+        marinePlanPolicyQuery.triggerMarinePlanPolicyQuery
+      ).mockResolvedValue(undefined)
       vi.mocked(
         authenticatedRequests.authenticatedPatchRequest
       ).mockResolvedValue({})
@@ -428,16 +416,8 @@ describe('#reviewSiteDetails', () => {
       await reviewSiteDetailsSubmitController.handler(request, h)
 
       expect(
-        vi.mocked(authenticatedRequests.authenticatedPostRequest)
-      ).toHaveBeenCalledWith(
-        request,
-        apiRoutes.CALCULATE_MARINE_PLAN_POLICIES,
-        JSON.stringify({ id: 'test-id' })
-      )
-      expect(request.yar.set).toHaveBeenCalledWith(
-        'marinePlanPolicyQueryStartedAt',
-        expect.any(Number)
-      )
+        vi.mocked(marinePlanPolicyQuery.triggerMarinePlanPolicyQuery)
+      ).toHaveBeenCalledWith(request, 'test-id')
       expect(h.redirect).toHaveBeenCalledWith(
         marineLicenceRoutes.MARINE_LICENCE_CALCULATE_MARINE_PLAN_POLICIES
       )
@@ -474,7 +454,7 @@ describe('#reviewSiteDetails', () => {
         confirmed: false
       })
       expect(
-        vi.mocked(authenticatedRequests.authenticatedPostRequest)
+        vi.mocked(marinePlanPolicyQuery.triggerMarinePlanPolicyQuery)
       ).not.toHaveBeenCalled()
       expect(h.redirect).toHaveBeenCalledWith(
         marineLicenceRoutes.MARINE_LICENCE_TASK_LIST
@@ -504,7 +484,7 @@ describe('#reviewSiteDetails', () => {
         vi.mocked(authenticatedRequests.authenticatedPatchRequest)
       ).not.toHaveBeenCalled()
       expect(
-        vi.mocked(authenticatedRequests.authenticatedPostRequest)
+        vi.mocked(marinePlanPolicyQuery.triggerMarinePlanPolicyQuery)
       ).not.toHaveBeenCalled()
       expect(h.view).toHaveBeenCalledWith(
         FILE_UPLOAD_REVIEW_VIEW_ROUTE,

--- a/src/server/marine-licence/task-list/utils.js
+++ b/src/server/marine-licence/task-list/utils.js
@@ -131,6 +131,17 @@ const NOT_STARTED_STATUS = {
   }
 }
 
+const buildNotStartedTask = (href) => [
+  {
+    title: {
+      text: marinePlanPoliciesConsiderationText,
+      classes: taskClasses
+    },
+    href,
+    status: NOT_STARTED_STATUS
+  }
+]
+
 const getMarinePlanPoliciesStatus = (total, completed) => {
   if (typeof total !== 'number') {
     return {
@@ -187,29 +198,15 @@ export const transformMarinePlanPoliciesTaskList = (
   }
 
   if (marinePlanPolicyJob === 'failed') {
-    return [
-      {
-        title: {
-          text: marinePlanPoliciesConsiderationText,
-          classes: taskClasses
-        },
-        href: marineLicenceRoutes.MARINE_LICENCE_CALCULATE_MARINE_PLAN_POLICIES,
-        status: NOT_STARTED_STATUS
-      }
-    ]
+    return buildNotStartedTask(
+      marineLicenceRoutes.MARINE_LICENCE_CALCULATE_MARINE_PLAN_POLICIES
+    )
   }
 
   if (marinePlanPolicyJob !== 'ready') {
-    return [
-      {
-        title: {
-          text: marinePlanPoliciesConsiderationText,
-          classes: taskClasses
-        },
-        href: marineLicenceRoutes.MARINE_LICENCE_MARINE_PLAN_POLICIES_HOLDING,
-        status: NOT_STARTED_STATUS
-      }
-    ]
+    return buildNotStartedTask(
+      marineLicenceRoutes.MARINE_LICENCE_MARINE_PLAN_POLICIES_HOLDING
+    )
   }
 
   const { status, suffix } = getMarinePlanPoliciesStatus(

--- a/src/server/marine-licence/task-list/utils.js
+++ b/src/server/marine-licence/task-list/utils.js
@@ -181,11 +181,21 @@ export const transformMarinePlanPoliciesTaskList = (
     }
   ]
 
-  if (
-    taskList.siteDetails !== 'COMPLETED' ||
-    marinePlanPolicyJob === 'failed'
-  ) {
+  if (taskList.siteDetails !== 'COMPLETED') {
     return cannotStartYet
+  }
+
+  if (marinePlanPolicyJob === 'failed') {
+    return [
+      {
+        title: {
+          text: 'Marine plan policy considerations',
+          classes: taskClasses
+        },
+        href: marineLicenceRoutes.MARINE_LICENCE_CALCULATE_MARINE_PLAN_POLICIES,
+        status: NOT_STARTED_STATUS
+      }
+    ]
   }
 
   if (marinePlanPolicyJob !== 'ready') {

--- a/src/server/marine-licence/task-list/utils.js
+++ b/src/server/marine-licence/task-list/utils.js
@@ -1,6 +1,7 @@
 import { marineLicenceRoutes } from '#src/server/common/constants/routes.js'
 
 const taskClasses = 'govuk-link--no-visited-state'
+const marinePlanPoliciesConsiderationText = 'Marine plan policy considerations'
 
 const setStatus = (task) => {
   if (!task || task === 'INCOMPLETE') {
@@ -173,7 +174,7 @@ export const transformMarinePlanPoliciesTaskList = (
 ) => {
   const cannotStartYet = [
     {
-      title: { text: 'Marine plan policy considerations' },
+      title: { text: marinePlanPoliciesConsiderationText },
       status: {
         text: 'Cannot start yet',
         classes: 'govuk-task-list__status--cannot-start-yet'
@@ -189,7 +190,7 @@ export const transformMarinePlanPoliciesTaskList = (
     return [
       {
         title: {
-          text: 'Marine plan policy considerations',
+          text: marinePlanPoliciesConsiderationText,
           classes: taskClasses
         },
         href: marineLicenceRoutes.MARINE_LICENCE_CALCULATE_MARINE_PLAN_POLICIES,
@@ -202,7 +203,7 @@ export const transformMarinePlanPoliciesTaskList = (
     return [
       {
         title: {
-          text: 'Marine plan policy considerations',
+          text: marinePlanPoliciesConsiderationText,
           classes: taskClasses
         },
         href: marineLicenceRoutes.MARINE_LICENCE_MARINE_PLAN_POLICIES_HOLDING,
@@ -219,7 +220,7 @@ export const transformMarinePlanPoliciesTaskList = (
   return [
     {
       title: {
-        text: `Marine plan policy considerations${suffix}`,
+        text: `${marinePlanPoliciesConsiderationText}}${suffix}`,
         classes: taskClasses
       },
       href: marineLicenceRoutes.MARINE_LICENCE_MARINE_PLAN_POLICIES,

--- a/src/server/marine-licence/task-list/utils.js
+++ b/src/server/marine-licence/task-list/utils.js
@@ -220,7 +220,7 @@ export const transformMarinePlanPoliciesTaskList = (
   return [
     {
       title: {
-        text: `${marinePlanPoliciesConsiderationText}}${suffix}`,
+        text: `${marinePlanPoliciesConsiderationText}${suffix}`,
         classes: taskClasses
       },
       href: marineLicenceRoutes.MARINE_LICENCE_MARINE_PLAN_POLICIES,

--- a/src/server/marine-licence/task-list/utils.test.js
+++ b/src/server/marine-licence/task-list/utils.test.js
@@ -641,7 +641,7 @@ describe('taskList utils', () => {
       ['INCOMPLETE', 'ready'],
       ['IN_PROGRESS', 'ready'],
       ['INCOMPLETE', 'pending'],
-      ['COMPLETED', 'failed'],
+      ['IN_PROGRESS', 'failed'],
       [undefined, undefined]
     ])(
       'returns "Cannot start yet" (no link) when siteDetails=%s and job=%s',
@@ -685,6 +685,26 @@ describe('taskList utils', () => {
         ])
       }
     )
+
+    test('returns "Not yet started" linked to the MPP spinner page (re-trigger) when siteDetails=COMPLETED and job=failed', () => {
+      expect(
+        transformMarinePlanPoliciesTaskList(
+          { siteDetails: 'COMPLETED' },
+          { marinePlanPolicyJob: 'failed', marinePlanPoliciesCount: 44 }
+        )
+      ).toEqual([
+        {
+          title: {
+            text: 'Marine plan policy considerations',
+            classes: 'govuk-link--no-visited-state'
+          },
+          href: marineLicenceRoutes.MARINE_LICENCE_CALCULATE_MARINE_PLAN_POLICIES,
+          status: {
+            tag: { text: 'Not yet started', classes: 'govuk-tag--blue' }
+          }
+        }
+      ])
+    })
   })
 
   describe('transformWaterFrameworkDirectiveTaskList', () => {

--- a/tests/integration/marine-licence/calculate-marine-plan-policies-and-wait.test.js
+++ b/tests/integration/marine-licence/calculate-marine-plan-policies-and-wait.test.js
@@ -61,12 +61,37 @@ describe('Marine Plan Policy Query Spinner', () => {
     )
   })
 
-  test('should redirect to task list when marinePlanPolicyJob is failed', async () => {
+  test('should re-trigger the query and render the spinner when marinePlanPolicyJob is failed and site details are completed', async () => {
     vi.mocked(marineLicenceService.getMarineLicenceService).mockReturnValueOnce(
       {
         getMarineLicenceById: vi.fn().mockResolvedValue({
           ...mockMarineLicenceApplication,
           marinePlanPolicyJob: 'failed'
+        })
+      }
+    )
+
+    const document = await loadPage({
+      requestUrl:
+        marineLicenceRoutes.MARINE_LICENCE_CALCULATE_MARINE_PLAN_POLICIES,
+      server: getServer()
+    })
+
+    expect(getByRole(document, 'heading', { level: 1 })).toHaveTextContent(
+      'Loading your Marine plan policies'
+    )
+  })
+
+  test('should redirect to task list when marinePlanPolicyJob is failed and site details are not completed', async () => {
+    vi.mocked(marineLicenceService.getMarineLicenceService).mockReturnValueOnce(
+      {
+        getMarineLicenceById: vi.fn().mockResolvedValue({
+          ...mockMarineLicenceApplication,
+          marinePlanPolicyJob: 'failed',
+          taskList: {
+            ...mockMarineLicenceApplication.taskList,
+            siteDetails: 'IN_PROGRESS'
+          }
         })
       }
     )

--- a/tests/integration/marine-licence/task-list.test.js
+++ b/tests/integration/marine-licence/task-list.test.js
@@ -126,10 +126,34 @@ describe('Task List', () => {
     )
   })
 
-  test('should render "Marine plan policy considerations" as unlinked "Cannot start yet" when marinePlanPolicyJob is failed', async () => {
+  test('should link "Marine plan policy considerations" to the spinner page (re-trigger) when marinePlanPolicyJob is failed and site details are completed', async () => {
     mockMarineLicence({
       ...mockMarineLicenceApplication,
       marinePlanPolicyJob: 'failed'
+    })
+    const failedDocument = await loadPage({
+      requestUrl: marineLicenceRoutes.MARINE_LICENCE_TASK_LIST,
+      server: getServer()
+    })
+
+    expect(
+      getByRole(failedDocument, 'link', {
+        name: 'Marine plan policy considerations'
+      })
+    ).toHaveAttribute(
+      'href',
+      marineLicenceRoutes.MARINE_LICENCE_CALCULATE_MARINE_PLAN_POLICIES
+    )
+  })
+
+  test('should render "Marine plan policy considerations" as unlinked "Cannot start yet" when marinePlanPolicyJob is failed but site details are not completed', async () => {
+    mockMarineLicence({
+      ...mockMarineLicenceApplication,
+      marinePlanPolicyJob: 'failed',
+      taskList: {
+        ...mockMarineLicenceApplication.taskList,
+        siteDetails: 'IN_PROGRESS'
+      }
     })
     const failedDocument = await loadPage({
       requestUrl: marineLicenceRoutes.MARINE_LICENCE_TASK_LIST,


### PR DESCRIPTION
## ML-1260: Retrigger marine plan policy query on terminal failure

### What
Previously, if the marine plan policy calculation job failed, the user was redirected straight to the task list with no way to retry — the task list showed "Cannot start yet" indefinitely.

This PR makes a `failed` job retry automatically: the wait page re-triggers the calculation and shows the spinner again, and the task list now shows "Not yet started" (linking back to kick off the calculation) instead of a dead-end "Cannot start yet".

### Changes
- Extracted `triggerMarinePlanPolicyQuery` (trigger + start-time bookkeeping) into `marine-plan-policy-query.js` (renamed from `marine-plan-policy-wait.js`), shared by `review-site-details` and the new retrigger path.
- `calculate-marine-plan-policies-and-wait` controller: on `failed`, re-triggers the query and re-renders the wait page instead of redirecting to the task list.
- `task-list/utils.js`: `failed` now renders as "Not yet started" (linked) rather than "Cannot start yet"; extracted `buildNotStartedTask` helper to remove duplication between the `failed` and pending branches.
- Minor cleanup: de-duplicated the `"Marine plan policy considerations"` string into a constant; replaced a static zero-arg view-object function with a plain constant.
