### PR TITLE
ML-1456: lcml redirect to mcms applicant view

### DIFF
--- a/src/server/common/components/marine-licence/application-details-card/macro.njk
+++ b/src/server/common/components/marine-licence/application-details-card/macro.njk
@@ -1,0 +1,4 @@
+{% macro appMarineLicenceApplicationDetailsCard(params) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}
+

--- a/src/server/common/components/marine-licence/application-details-card/template.njk
+++ b/src/server/common/components/marine-licence/application-details-card/template.njk
@@ -21,7 +21,7 @@
     text: "Reference number"
   },
   value: {
-    html: params.applicationReference
+    text: params.applicationReference
   }
 }, {
   key: {
@@ -43,7 +43,7 @@
 {{ govukSummaryList({
   card: {
     title: {
-      text: "Application Details"
+      text: "Application details"
     },
     attributes: {
       id: "application-details-card"

--- a/src/server/common/components/marine-licence/application-details-card/template.njk
+++ b/src/server/common/components/marine-licence/application-details-card/template.njk
@@ -1,0 +1,53 @@
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+
+{% set rows = [] %}
+
+{% set rows = (rows.push({
+  key: {
+    text: "Application type"
+  },
+  value: {
+    text: 'Marine licence application'
+  }
+},{
+  key: {
+    text: "Status"
+  },
+  value: {
+    html: params.statusTag
+  }
+},{
+  key: {
+    text: "Reference number"
+  },
+  value: {
+    html: params.applicationReference
+  }
+}, {
+  key: {
+    text: "Date submitted"
+  },
+  value: {
+    text: params.submittedAt
+  }
+},{
+  key: {
+    text: "Date of transfer"
+  },
+  value: {
+    text: params.transferredDate
+  }
+}), rows) %}
+
+
+{{ govukSummaryList({
+  card: {
+    title: {
+      text: "Application Details"
+    },
+    attributes: {
+      id: "application-details-card"
+    }
+  },
+  rows: rows
+}) }}

--- a/src/server/common/components/marine-licence/application-details-card/template.test.js
+++ b/src/server/common/components/marine-licence/application-details-card/template.test.js
@@ -1,0 +1,40 @@
+import { renderComponent } from '#src/server/test-helpers/component-helpers.js'
+
+describe('Marine Licence Application Details Card Component', () => {
+  let $component
+
+  beforeEach(() => {
+    $component = renderComponent('marine-licence/application-details-card', {
+      statusTag: '<a>Test</a>',
+      applicationReference: 'TEST-REF',
+      submittedAt: '01 01 2026',
+      transferredDate: '02 01 2026'
+    })
+  })
+
+  test('Should render Application Details card component', () => {
+    expect($component('#application-details-card')).toHaveLength(1)
+  })
+
+  test('Should have correct card title', () => {
+    expect($component('.govuk-summary-card__title').text().trim()).toBe(
+      'Application Details'
+    )
+
+    const htmlContent = $component.html()
+    expect(htmlContent).toContain('Application type')
+    expect(htmlContent).toContain('Marine licence application')
+
+    expect(htmlContent).toContain('Status')
+    expect(htmlContent).toContain('<a>Test</a>')
+
+    expect(htmlContent).toContain('Reference number')
+    expect(htmlContent).toContain('TEST-REF')
+
+    expect(htmlContent).toContain('Date submitted')
+    expect(htmlContent).toContain('01 01 2026')
+
+    expect(htmlContent).toContain('Date of transfer')
+    expect(htmlContent).toContain('02 01 2026')
+  })
+})

--- a/src/server/common/components/marine-licence/application-details-card/template.test.js
+++ b/src/server/common/components/marine-licence/application-details-card/template.test.js
@@ -12,13 +12,13 @@ describe('Marine Licence Application Details Card Component', () => {
     })
   })
 
-  test('Should render Application Details card component', () => {
+  test('Should render Application details card component', () => {
     expect($component('#application-details-card')).toHaveLength(1)
   })
 
   test('Should have correct card title', () => {
     expect($component('.govuk-summary-card__title').text().trim()).toBe(
-      'Application Details'
+      'Application details'
     )
 
     const htmlContent = $component.html()

--- a/src/server/common/constants/mcms.js
+++ b/src/server/common/constants/mcms.js
@@ -1,2 +1,8 @@
-export const MCMS_LOGIN_URL =
-  'https://marinelicensing.marinemanagement.org.uk/mmofox5/fox/live/MMO_LOGIN/login'
+import { config } from '#src/config/config.js'
+
+const MCMS_LOGIN_PATH = 'mmofox5/fox/live/MMO_LOGIN/login'
+
+export const MCMS_LOGIN_URL = new URL(
+  MCMS_LOGIN_PATH,
+  config.get('mcms.url')
+).toString()

--- a/src/server/common/constants/mcms.js
+++ b/src/server/common/constants/mcms.js
@@ -1,0 +1,2 @@
+export const MCMS_LOGIN_URL =
+  'https://marinelicensing.marinemanagement.org.uk/mmofox5/fox/live/MMO_LOGIN/login'

--- a/src/server/common/constants/projects.js
+++ b/src/server/common/constants/projects.js
@@ -2,6 +2,7 @@ export const PROJECT_STATUS = {
   DRAFT: 'Draft',
   ACTIVE: 'Active',
   SUBMITTED: 'Submitted',
+  TRANSFERRED: 'Transferred',
   WITHDRAWN: 'Withdrawn'
 }
 

--- a/src/server/common/constants/routes.js
+++ b/src/server/common/constants/routes.js
@@ -60,6 +60,8 @@ export const marineLicenceRoutes = {
   MARINE_LICENCE_COMPLETION_DATE: '/marine-licence/completion-date',
   MARINE_LICENCE_CHECK_YOUR_ANSWERS: '/marine-licence/check-your-answers',
   MARINE_LICENCE_CONFIRMATION: '/marine-licence/confirmation',
+  MARINE_LICENCE_APPLICATION_TRANSFERRED:
+    '/marine-licence/application-transferred',
   MARINE_LICENCE_PROJECT_NAME: '/marine-licence/project-name',
   MARINE_LICENCE_TASK_LIST: '/marine-licence/task-list',
   MARINE_LICENCE_DELETE: '/marine-licence/delete',

--- a/src/server/common/helpers/ui/get-tag-style.js
+++ b/src/server/common/helpers/ui/get-tag-style.js
@@ -6,6 +6,8 @@ export const getTagStyle = (status) => {
       return 'govuk-tag--blue'
     case PROJECT_STATUS.WITHDRAWN:
       return 'govuk-tag--grey'
+    case PROJECT_STATUS.TRANSFERRED:
+      return 'govuk-tag--magenta'
     default:
       return 'govuk-tag--green'
   }

--- a/src/server/common/helpers/ui/get-tag-style.test.js
+++ b/src/server/common/helpers/ui/get-tag-style.test.js
@@ -13,6 +13,10 @@ describe('getTagStyle', () => {
     expect(getTagStyle('Active')).toBe('govuk-tag--green')
   })
 
+  it('should return magenta for Withdrawn', () => {
+    expect(getTagStyle('Transferred')).toBe('govuk-tag--magenta')
+  })
+
   it('should return green for unknown status', () => {
     expect(getTagStyle('SomeOtherStatus')).toBe('govuk-tag--green')
   })

--- a/src/server/common/helpers/ui/get-tag-style.test.js
+++ b/src/server/common/helpers/ui/get-tag-style.test.js
@@ -13,7 +13,7 @@ describe('getTagStyle', () => {
     expect(getTagStyle('Active')).toBe('govuk-tag--green')
   })
 
-  it('should return magenta for Withdrawn', () => {
+  it('should return magenta for Transferred', () => {
     expect(getTagStyle('Transferred')).toBe('govuk-tag--magenta')
   })
 

--- a/src/server/dashboard/utils.js
+++ b/src/server/dashboard/utils.js
@@ -26,15 +26,23 @@ const getDraftActions = (id, escapedProjectName, projectType) => {
   return `<a href="${taskListRoute}/${id}" class="govuk-link govuk-!-margin-right-4 govuk-link--no-visited-state" aria-label="Continue to task list">Continue</a><a href="${deleteRoute}/${id}" class="govuk-link govuk-link--no-visited-state" aria-label="Delete ${escapedProjectName}">Delete</a>`
 }
 
-const getActiveActions = (id, escapedProjectName, projectType, canWithdraw) => {
+const getViewDetailsRoute = (projectType, status) => {
+  if (
+    projectType === MARINE_LICENCE_KEY &&
+    status === PROJECT_STATUS.TRANSFERRED
+  ) {
+    return marineLicenceRoutes.MARINE_LICENCE_APPLICATION_TRANSFERRED
+  }
+
+  return projectType === MARINE_LICENCE_KEY
+    ? marineLicenceRoutes.MARINE_LICENCE_VIEW_DETAILS
+    : routes.VIEW_DETAILS
+}
+
+const getActiveActions = (id, escapedProjectName, viewRoute, canWithdraw) => {
   const marginClass = canWithdraw
     ? 'govuk-link govuk-!-margin-right-4 '
     : 'govuk-link '
-
-  const viewRoute =
-    projectType === MARINE_LICENCE_KEY
-      ? marineLicenceRoutes.MARINE_LICENCE_VIEW_DETAILS
-      : routes.VIEW_DETAILS
 
   let buttons = `<a href="${viewRoute}/${id}" class="${marginClass}govuk-link--no-visited-state" aria-label="View details of ${escapedProjectName}">View details</a>`
 
@@ -58,11 +66,12 @@ export const getActionButtons = (project) => {
   const { status, id, projectName, projectType } = project
 
   const escapedProjectName = escapeHtml(projectName)
+  const viewRoute = getViewDetailsRoute(projectType, status)
 
   if (projectType === MARINE_LICENCE_KEY) {
     return status === PROJECT_STATUS.DRAFT && isOwnProject
       ? getDraftActions(id, escapedProjectName, projectType)
-      : getActiveActions(id, escapedProjectName, projectType)
+      : getActiveActions(id, escapedProjectName, viewRoute)
   }
 
   const canWithdraw = status === PROJECT_STATUS.ACTIVE && !!isOwnProject
@@ -70,12 +79,12 @@ export const getActionButtons = (project) => {
   if (isOwnProject) {
     return status === PROJECT_STATUS.DRAFT
       ? getDraftActions(id, escapedProjectName, projectType)
-      : getActiveActions(id, escapedProjectName, projectType, canWithdraw)
+      : getActiveActions(id, escapedProjectName, viewRoute, canWithdraw)
   }
 
   return project.status === PROJECT_STATUS.DRAFT
     ? ''
-    : `<a href="${routes.VIEW_DETAILS}/${project.id}" class="govuk-link govuk-link--no-visited-state" aria-label="View details of ${escapedProjectName}">View details</a>`
+    : `<a href="${viewRoute}/${project.id}" class="govuk-link govuk-link--no-visited-state" aria-label="View details of ${escapedProjectName}">View details</a>`
 }
 
 export const formatProjectsForDisplay = (projects, isEmployee = false) =>

--- a/src/server/dashboard/utils.test.js
+++ b/src/server/dashboard/utils.test.js
@@ -344,7 +344,7 @@ describe('getActionButtons', () => {
     )
   })
 
-  it('returns empty string for marine licence project when not draft or not own project', () => {
+  it('returns View details link for marine licence project when not draft or not own project', () => {
     const marineLicenceActive = {
       id: 'ml123',
       projectName: 'Marine Licence Project',
@@ -355,6 +355,20 @@ describe('getActionButtons', () => {
     const result = getActionButtons(marineLicenceActive)
     expect(result).toBe(
       '<a href="/marine-licence/view-details/ml123" class="govuk-link govuk-link--no-visited-state" aria-label="View details of Marine Licence Project">View details</a>'
+    )
+  })
+
+  it('returns transferred page link for transferred marine licence', () => {
+    const transferred = {
+      id: 'ml123',
+      projectName: 'Marine Licence Project',
+      projectType: 'MARINE_LICENCE',
+      status: 'Transferred',
+      isOwnProject: true
+    }
+    const result = getActionButtons(transferred)
+    expect(result).toBe(
+      `<a href="${marineLicenceRoutes.MARINE_LICENCE_APPLICATION_TRANSFERRED}/ml123" class="govuk-link govuk-link--no-visited-state" aria-label="View details of Marine Licence Project">View details</a>`
     )
   })
 })

--- a/src/server/marine-licence/application-transferred/controller.js
+++ b/src/server/marine-licence/application-transferred/controller.js
@@ -21,7 +21,8 @@ const applicationTransferredSettings = {
   heading: pageTitle,
   mcmsLoginUrl: MCMS_LOGIN_URL,
   contactEmail: CONTACT_EMAIL,
-  contactPhone: CONTACT_PHONE
+  contactPhone: CONTACT_PHONE,
+  backLink: routes.DASHBOARD
 }
 
 export const applicationTransferredController = {

--- a/src/server/marine-licence/application-transferred/controller.js
+++ b/src/server/marine-licence/application-transferred/controller.js
@@ -1,0 +1,49 @@
+import Boom from '@hapi/boom'
+import { marineLicenceRoutes } from '#src/server/common/constants/routes.js'
+import { MCMS_LOGIN_URL } from '#src/server/common/constants/mcms.js'
+import { getMarineLicenceService } from '#src/services/marine-licence-service/index.js'
+
+export const APPLICATION_TRANSFERRED_VIEW_ROUTE =
+  'marine-licence/application-transferred/index'
+
+export const CONTACT_EMAIL = 'marine.consents@marinemanagement.org.uk'
+
+export const CONTACT_PHONE = '0191 376 2791'
+
+const pageTitle = 'Your application has been transferred'
+
+const applicationTransferredSettings = {
+  pageTitle,
+  heading: pageTitle,
+  mcmsLoginUrl: MCMS_LOGIN_URL,
+  contactEmail: CONTACT_EMAIL,
+  contactPhone: CONTACT_PHONE
+}
+
+export const applicationTransferredController = {
+  async handler(request, h) {
+    const { marineLicenceId } = request.params
+
+    try {
+      const service = getMarineLicenceService(request)
+      const marineLicence = await service.getMarineLicenceById(marineLicenceId)
+
+      return h.view(APPLICATION_TRANSFERRED_VIEW_ROUTE, {
+        ...applicationTransferredSettings,
+        projectName: marineLicence.projectName,
+        applicationReference: marineLicence.applicationReference,
+        viewDetailsUrl: `${marineLicenceRoutes.MARINE_LICENCE_VIEW_DETAILS}/${marineLicenceId}`
+      })
+    } catch (error) {
+      if (error.isBoom) {
+        throw error
+      }
+
+      request.logger.error(
+        error,
+        'Error displaying application transferred page'
+      )
+      throw Boom.internal('Error displaying application transferred page')
+    }
+  }
+}

--- a/src/server/marine-licence/application-transferred/controller.js
+++ b/src/server/marine-licence/application-transferred/controller.js
@@ -1,7 +1,11 @@
 import Boom from '@hapi/boom'
-import { marineLicenceRoutes } from '#src/server/common/constants/routes.js'
+import {
+  marineLicenceRoutes,
+  routes
+} from '#src/server/common/constants/routes.js'
 import { MCMS_LOGIN_URL } from '#src/server/common/constants/mcms.js'
 import { getMarineLicenceService } from '#src/services/marine-licence-service/index.js'
+import { PROJECT_STATUS } from '#src/server/common/constants/projects.js'
 
 export const APPLICATION_TRANSFERRED_VIEW_ROUTE =
   'marine-licence/application-transferred/index'
@@ -27,6 +31,10 @@ export const applicationTransferredController = {
     try {
       const service = getMarineLicenceService(request)
       const marineLicence = await service.getMarineLicenceById(marineLicenceId)
+
+      if (marineLicence.status !== PROJECT_STATUS.TRANSFERRED) {
+        return h.redirect(routes.DASHBOARD)
+      }
 
       return h.view(APPLICATION_TRANSFERRED_VIEW_ROUTE, {
         ...applicationTransferredSettings,

--- a/src/server/marine-licence/application-transferred/controller.test.js
+++ b/src/server/marine-licence/application-transferred/controller.test.js
@@ -1,6 +1,9 @@
 import { vi } from 'vitest'
 import Boom from '@hapi/boom'
-import { marineLicenceRoutes } from '#src/server/common/constants/routes.js'
+import {
+  marineLicenceRoutes,
+  routes
+} from '#src/server/common/constants/routes.js'
 import {
   applicationTransferredController,
   APPLICATION_TRANSFERRED_VIEW_ROUTE,
@@ -51,7 +54,8 @@ describe('#applicationTransferred', () => {
         viewDetailsUrl: `${marineLicenceRoutes.MARINE_LICENCE_VIEW_DETAILS}/${mockLicence.id}`,
         mcmsLoginUrl: MCMS_LOGIN_URL,
         contactEmail: CONTACT_EMAIL,
-        contactPhone: CONTACT_PHONE
+        contactPhone: CONTACT_PHONE,
+        backLink: routes.DASHBOARD
       })
     })
 

--- a/src/server/marine-licence/application-transferred/controller.test.js
+++ b/src/server/marine-licence/application-transferred/controller.test.js
@@ -1,0 +1,95 @@
+import { vi } from 'vitest'
+import Boom from '@hapi/boom'
+import { marineLicenceRoutes } from '#src/server/common/constants/routes.js'
+import {
+  applicationTransferredController,
+  APPLICATION_TRANSFERRED_VIEW_ROUTE,
+  CONTACT_EMAIL,
+  CONTACT_PHONE
+} from '#src/server/marine-licence/application-transferred/controller.js'
+import { MCMS_LOGIN_URL } from '#src/server/common/constants/mcms.js'
+import { getMarineLicenceService } from '#src/services/marine-licence-service/index.js'
+import { mockSubmittedMarineLicenceApplication } from '#src/server/test-helpers/mocks/marine-licence-mocks.js'
+
+vi.mock('#src/services/marine-licence-service/index.js')
+
+describe('#applicationTransferred', () => {
+  const mockLicence = mockSubmittedMarineLicenceApplication
+
+  let mockMarineLicenceService
+
+  beforeEach(() => {
+    mockMarineLicenceService = {
+      getMarineLicenceById: vi.fn().mockResolvedValue(mockLicence)
+    }
+    vi.mocked(getMarineLicenceService).mockReturnValue(mockMarineLicenceService)
+  })
+
+  describe('#applicationTransferredController', () => {
+    test('should render view with data from the service', async () => {
+      const request = {
+        params: { marineLicenceId: mockLicence.id },
+        logger: { error: vi.fn() }
+      }
+      const h = { view: vi.fn() }
+
+      await applicationTransferredController.handler(request, h)
+
+      expect(getMarineLicenceService).toHaveBeenCalledWith(request)
+      expect(
+        mockMarineLicenceService.getMarineLicenceById
+      ).toHaveBeenCalledWith(mockLicence.id)
+      expect(h.view).toHaveBeenCalledWith(APPLICATION_TRANSFERRED_VIEW_ROUTE, {
+        pageTitle: 'Your application has been transferred',
+        heading: 'Your application has been transferred',
+        projectName: mockLicence.projectName,
+        applicationReference: mockLicence.applicationReference,
+        viewDetailsUrl: `${marineLicenceRoutes.MARINE_LICENCE_VIEW_DETAILS}/${mockLicence.id}`,
+        mcmsLoginUrl: MCMS_LOGIN_URL,
+        contactEmail: CONTACT_EMAIL,
+        contactPhone: CONTACT_PHONE
+      })
+    })
+
+    test('should propagate Boom errors from the service', async () => {
+      mockMarineLicenceService.getMarineLicenceById.mockRejectedValue(
+        Boom.notFound('Not found')
+      )
+
+      const request = {
+        params: { marineLicenceId: mockLicence.id },
+        logger: { error: vi.fn() }
+      }
+      const h = { view: vi.fn() }
+
+      await expect(
+        applicationTransferredController.handler(request, h)
+      ).rejects.toMatchObject({
+        isBoom: true,
+        output: { statusCode: 404 }
+      })
+    })
+
+    test('should throw internal error for unexpected failures', async () => {
+      const error = new Error('Unexpected failure')
+      mockMarineLicenceService.getMarineLicenceById.mockRejectedValue(error)
+
+      const request = {
+        params: { marineLicenceId: mockLicence.id },
+        logger: { error: vi.fn() }
+      }
+      const h = { view: vi.fn() }
+
+      await expect(
+        applicationTransferredController.handler(request, h)
+      ).rejects.toMatchObject({
+        isBoom: true,
+        output: { statusCode: 500 }
+      })
+      expect(request.logger.error).toHaveBeenCalledWith(
+        error,
+        'Error displaying application transferred page'
+      )
+    })
+  })
+})

--- a/src/server/marine-licence/application-transferred/controller.test.js
+++ b/src/server/marine-licence/application-transferred/controller.test.js
@@ -10,11 +10,15 @@ import {
 import { MCMS_LOGIN_URL } from '#src/server/common/constants/mcms.js'
 import { getMarineLicenceService } from '#src/services/marine-licence-service/index.js'
 import { mockSubmittedMarineLicenceApplication } from '#src/server/test-helpers/mocks/marine-licence-mocks.js'
+import { PROJECT_STATUS } from '#src/server/common/constants/projects.js'
 
 vi.mock('#src/services/marine-licence-service/index.js')
 
 describe('#applicationTransferred', () => {
-  const mockLicence = mockSubmittedMarineLicenceApplication
+  const mockLicence = {
+    ...mockSubmittedMarineLicenceApplication,
+    status: PROJECT_STATUS.TRANSFERRED
+  }
 
   let mockMarineLicenceService
 

--- a/src/server/marine-licence/application-transferred/index.js
+++ b/src/server/marine-licence/application-transferred/index.js
@@ -1,0 +1,10 @@
+import { applicationTransferredController } from '#src/server/marine-licence/application-transferred/controller.js'
+import { marineLicenceRoutes } from '#src/server/common/constants/routes.js'
+
+export const applicationTransferredRoutes = [
+  {
+    method: 'GET',
+    path: `${marineLicenceRoutes.MARINE_LICENCE_APPLICATION_TRANSFERRED}/{marineLicenceId}`,
+    ...applicationTransferredController
+  }
+]

--- a/src/server/marine-licence/application-transferred/index.njk
+++ b/src/server/marine-licence/application-transferred/index.njk
@@ -1,0 +1,32 @@
+{% extends 'layouts/page.njk' %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <span class="govuk-caption-l">{{ projectName }}</span>
+      <h1 class="govuk-heading-l">{{ heading }}</h1>
+
+      <p class="govuk-body">Your application ({{ applicationReference }}) has been transferred from Get permission for marine work to our Marine Case Management System (MCMS).</p>
+
+      <p class="govuk-body">Get permission for marine work currently processes certain types of marine licence application. MCMS processes all types, so we have transferred your application there.</p>
+
+      <p class="govuk-body">Your application will continue to be managed as normal and you do not need to do anything.</p>
+
+      <h2 class="govuk-heading-m">What happens next</h2>
+
+      <p class="govuk-body">Your fee estimate may change but we will confirm that when we contact you.</p>
+
+      <p class="govuk-body">If you have an MCMS account you can <a class="govuk-link" href="{{ mcmsLoginUrl }}">track the progress of your application</a>.</p>
+
+      <p class="govuk-body">If you have not heard from us or do not have access to MCMS, contact us:</p>
+
+      <p class="govuk-body">Email: <a class="govuk-link" href="mailto:{{ contactEmail }}">{{ contactEmail }}</a></p>
+
+      <p class="govuk-body">Phone: {{ contactPhone }}</p>
+
+      <p class="govuk-body"><a class="govuk-link" href="{{ viewDetailsUrl }}">View your submitted application in this service</a></p>
+
+    </div>
+  </div>
+{% endblock %}

--- a/src/server/marine-licence/application-transferred/index.njk
+++ b/src/server/marine-licence/application-transferred/index.njk
@@ -1,4 +1,15 @@
 {% extends 'layouts/page.njk' %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+
+{% block beforeContent %}
+{{ super() }}
+<nav>
+  {{ govukBackLink({
+    text: "Back",
+    href: backLink
+  }) }}
+</nav>
+{% endblock %}
 
 {% block content %}
   <div class="govuk-grid-row">

--- a/src/server/marine-licence/index.js
+++ b/src/server/marine-licence/index.js
@@ -21,6 +21,7 @@ import { marinePlanPolicyGuidanceRoutes } from '#src/server/marine-licence/marin
 import { marinePlanPoliciesRoutes } from '#src/server/marine-licence/marine-plan-policies/index.js'
 import { feeEstimateRoutes } from '#src/server/marine-licence/fee-estimate/index.js'
 import { feeEstimateAreYouSureRoutes } from '#src/server/marine-licence/fee-estimate-are-you-sure/index.js'
+import { applicationTransferredRoutes } from '#src/server/marine-licence/application-transferred/index.js'
 
 export const marineLicence = {
   plugin: {
@@ -49,7 +50,8 @@ export const marineLicence = {
         ...marinePlanPolicyGuidanceRoutes,
         ...marinePlanPoliciesRoutes,
         ...feeEstimateRoutes,
-        ...feeEstimateAreYouSureRoutes
+        ...feeEstimateAreYouSureRoutes,
+        ...applicationTransferredRoutes
       ])
     }
   }

--- a/src/server/marine-licence/view-details/controller.js
+++ b/src/server/marine-licence/view-details/controller.js
@@ -14,8 +14,18 @@ import { buildSummaryData } from '#src/server/common/helpers/marine-licence/summ
 import { buildSiteData } from '#src/server/common/helpers/marine-licence/site-data.js'
 import { waterFrameworkReviewData } from '#src/server/common/helpers/marine-licence/water-framework-directive/water-framework-review-data.js'
 import { buildMarinePlanPoliciesData } from '#src/server/common/helpers/marine-licence/marine-plan-policies-data.js'
+import { PROJECT_STATUS } from '#src/server/common/constants/projects.js'
+import { buildApplicationDetailsCardData } from '#src/server/marine-licence/view-details/utils.js'
 
 export const VIEW_DETAILS_VIEW_ROUTE = 'marine-licence/view-details/index'
+
+const getApplicantBackLink = (status, marineLicenceId) => {
+  if (status === PROJECT_STATUS.TRANSFERRED) {
+    return `${marineLicenceRoutes.MARINE_LICENCE_APPLICATION_TRANSFERRED}/${marineLicenceId}`
+  }
+
+  return routes.DASHBOARD
+}
 
 export const viewDetailsController = {
   async handler(request, h) {
@@ -64,6 +74,9 @@ export const viewDetailsController = {
 
       const marinePlanPolicies = buildMarinePlanPoliciesData(marineLicence)
 
+      const applicationDetailsCardData =
+        buildApplicationDetailsCardData(marineLicence)
+
       return h.view(VIEW_DETAILS_VIEW_ROUTE, {
         pageTitle: formattedMarineLicence.projectName,
         specialLegalPowers: formattedMarineLicence.specialLegalPowers,
@@ -78,14 +91,17 @@ export const viewDetailsController = {
         summaryData,
         isReadOnly: true,
         pageCaption,
-        backLink: isApplicantView ? routes.DASHBOARD : null,
+        backLink: isApplicantView
+          ? getApplicantBackLink(marineLicence.status, marineLicenceId)
+          : null,
         isInternalUserView,
         marineLicenceId,
         waterFrameworkDirectiveData,
         invoicingData: formattedMarineLicence.invoicing,
         invoicingChangeLink:
           marineLicenceRoutes.MARINE_LICENCE_CHECK_INVOICING_DETAILS,
-        marinePlanPolicies
+        marinePlanPolicies,
+        ...applicationDetailsCardData
       })
     } catch (error) {
       if (error.isBoom) {

--- a/src/server/marine-licence/view-details/index.njk
+++ b/src/server/marine-licence/view-details/index.njk
@@ -32,14 +32,12 @@
       {% endif %}
       <h1 class="govuk-heading-l" id="view-details-heading">{{ pageTitle }}</h1>
 
-      {% if status === 'Transferred' %}
+      {% if isTransferred %}
         {{ appMarineLicenceApplicationDetailsCard({
           statusTag: statusTag,
           applicationReference: applicationReference,
           transferredDate: transferredDate,
-          submittedAt: submittedAt,
-          isReadOnly: isReadOnly,
-          preferredDates: preferredDates
+          submittedAt: submittedAt
         }) }}
       {% endif %}
 

--- a/src/server/marine-licence/view-details/index.njk
+++ b/src/server/marine-licence/view-details/index.njk
@@ -1,6 +1,7 @@
 {% extends 'layouts/page.njk' %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "marine-licence/other-permissions-card/macro.njk" import appMarineLicenceOtherPermissionsCard %}
+{% from "marine-licence/application-details-card/macro.njk" import appMarineLicenceApplicationDetailsCard %}
 {% from "marine-licence/project-details-card/macro.njk" import appMarineLicenceProjectDetailsCard %}
 {% from "marine-licence/site-location-card/macro.njk" import appMarineLicenceSiteLocationCard %}
 {% from "marine-licence/site-details-card/macro.njk" import appMarineLicenceSiteDetailsCard %}
@@ -30,6 +31,17 @@
         <span class="govuk-caption-l">{{ pageCaption }}</span>
       {% endif %}
       <h1 class="govuk-heading-l" id="view-details-heading">{{ pageTitle }}</h1>
+
+      {% if status === 'Transferred' %}
+        {{ appMarineLicenceApplicationDetailsCard({
+          statusTag: statusTag,
+          applicationReference: applicationReference,
+          transferredDate: transferredDate,
+          submittedAt: submittedAt,
+          isReadOnly: isReadOnly,
+          preferredDates: preferredDates
+        }) }}
+      {% endif %}
 
       {{ appMarineLicenceProjectDetailsCard({
         projectName: projectName,

--- a/src/server/marine-licence/view-details/utils.js
+++ b/src/server/marine-licence/view-details/utils.js
@@ -1,5 +1,6 @@
 import { formatDate } from '#src/config/nunjucks/filters/format-date.js'
 import { getTagStyle } from '#src/server/common/helpers/ui/get-tag-style.js'
+import { PROJECT_STATUS } from '#src/server/common/constants/projects.js'
 import escapeHtml from 'lodash/escape.js'
 
 export const buildApplicationDetailsCardData = (marineLicence) => {
@@ -10,7 +11,7 @@ export const buildApplicationDetailsCardData = (marineLicence) => {
     applicationReference,
     submittedAt: formatDate(submittedAt, 'd MMM yyyy'),
     transferredDate: formatDate(transferredDate, 'd MMM yyyy'),
-    status,
+    isTransferred: status === PROJECT_STATUS.TRANSFERRED,
     statusTag: `<strong class="govuk-tag ${getTagStyle(status)}">${escapeHtml(status)}</strong>`
   }
 }

--- a/src/server/marine-licence/view-details/utils.js
+++ b/src/server/marine-licence/view-details/utils.js
@@ -1,0 +1,16 @@
+import { formatDate } from '#src/config/nunjucks/filters/format-date.js'
+import { getTagStyle } from '#src/server/common/helpers/ui/get-tag-style.js'
+import escapeHtml from 'lodash/escape.js'
+
+export const buildApplicationDetailsCardData = (marineLicence) => {
+  const { applicationReference, status, submittedAt, transferredDate } =
+    marineLicence
+
+  return {
+    applicationReference,
+    submittedAt: formatDate(submittedAt, 'd MMM yyyy'),
+    transferredDate: formatDate(transferredDate, 'd MMM yyyy'),
+    status,
+    statusTag: `<strong class="govuk-tag ${getTagStyle(status)}">${escapeHtml(status)}</strong>`
+  }
+}

--- a/src/server/marine-licence/view-details/utils.test.js
+++ b/src/server/marine-licence/view-details/utils.test.js
@@ -1,0 +1,30 @@
+import { buildApplicationDetailsCardData } from '#src/server/marine-licence/view-details/utils.js'
+import { PROJECT_STATUS } from '#src/server/common/constants/projects.js'
+
+describe('#buildApplicationDetailsCardData', () => {
+  test('returns the application details fields and a rendered status tag', () => {
+    const marineLicence = {
+      applicationReference: 'ML-2026-001',
+      status: PROJECT_STATUS.TRANSFERRED,
+      submittedAt: '2026-01-15',
+      transferredDate: '2026-02-20'
+    }
+
+    const result = buildApplicationDetailsCardData(marineLicence)
+
+    expect(result.applicationReference).toBe('ML-2026-001')
+    expect(result.status).toBe(PROJECT_STATUS.TRANSFERRED)
+    expect(result.submittedAt).toBe('15 Jan 2026')
+    expect(result.transferredDate).toBe('20 Feb 2026')
+    expect(result.statusTag).toContain('govuk-tag--magenta')
+    expect(result.statusTag).toContain(PROJECT_STATUS.TRANSFERRED)
+  })
+
+  test('escapes html in the status', () => {
+    const marineLicence = { status: '<script>alert(1)</script>' }
+
+    const result = buildApplicationDetailsCardData(marineLicence)
+
+    expect(result.statusTag).not.toContain('<script>')
+  })
+})

--- a/src/server/marine-licence/view-details/utils.test.js
+++ b/src/server/marine-licence/view-details/utils.test.js
@@ -13,11 +13,19 @@ describe('#buildApplicationDetailsCardData', () => {
     const result = buildApplicationDetailsCardData(marineLicence)
 
     expect(result.applicationReference).toBe('ML-2026-001')
-    expect(result.status).toBe(PROJECT_STATUS.TRANSFERRED)
+    expect(result.isTransferred).toBe(true)
     expect(result.submittedAt).toBe('15 Jan 2026')
     expect(result.transferredDate).toBe('20 Feb 2026')
     expect(result.statusTag).toContain('govuk-tag--magenta')
     expect(result.statusTag).toContain(PROJECT_STATUS.TRANSFERRED)
+  })
+
+  test('sets isTransferred to false when status is not transferred', () => {
+    const result = buildApplicationDetailsCardData({
+      status: PROJECT_STATUS.SUBMITTED
+    })
+
+    expect(result.isTransferred).toBe(false)
   })
 
   test('escapes html in the status', () => {

--- a/src/server/service-home/controller.js
+++ b/src/server/service-home/controller.js
@@ -2,6 +2,7 @@ import {
   marineLicenceRoutes,
   routes
 } from '#src/server/common/constants/routes.js'
+import { MCMS_LOGIN_URL } from '#src/server/common/constants/mcms.js'
 import { config } from '#src/config/config.js'
 import { clearMarineLicenceCache } from '#src/server/common/helpers/marine-licence/session-cache/utils.js'
 
@@ -26,7 +27,7 @@ const cards = [
   },
   {
     title: 'Sign in to the Marine Case Management System',
-    link: 'https://marinelicensing.marinemanagement.org.uk/mmofox5/fox/live/MMO_LOGIN/login',
+    link: MCMS_LOGIN_URL,
     description: 'View or manage projects not available in this account.'
   }
 ]

--- a/src/server/service-home/controller.test.js
+++ b/src/server/service-home/controller.test.js
@@ -1,6 +1,7 @@
 import { vi } from 'vitest'
 import { statusCodes } from '#src/server/common/constants/status-codes.js'
 import { routes } from '#src/server/common/constants/routes.js'
+import { MCMS_LOGIN_URL } from '#src/server/common/constants/mcms.js'
 import { setupTestServer } from '#tests/integration/shared/test-setup-helpers.js'
 import { makeGetRequest } from '#src/server/test-helpers/server-requests.js'
 import { serviceHomeController, SERVICE_HOME_VIEW_ROUTE } from './controller.js'
@@ -55,7 +56,7 @@ describe('#serviceHome', () => {
           {
             description:
               'View or manage projects not available in this account.',
-            link: 'https://marinelicensing.marinemanagement.org.uk/mmofox5/fox/live/MMO_LOGIN/login',
+            link: MCMS_LOGIN_URL,
             title: 'Sign in to the Marine Case Management System'
           }
         ]

--- a/src/server/test-helpers/mocks/marine-licence-mocks.js
+++ b/src/server/test-helpers/mocks/marine-licence-mocks.js
@@ -168,9 +168,11 @@ export const mockSubmittedMarineLicenceApplication = {
 }
 
 export const mockTransferredMarineLicenceApplication = {
-  ...mockMarineLicenceApplication,
+  ...mockSubmittedMarineLicenceApplication,
   status: PROJECT_STATUS.TRANSFERRED,
-  applicationReference: 'MLA/2026/10264'
+  applicationReference: 'MLA/2026/10264',
+  submittedAt: '2026-05-26T10:00:00Z',
+  transferredDate: '2026-06-26T10:00:00Z'
 }
 
 export const mockMarineLicenceWithMarinePlanPolicies = {

--- a/src/server/test-helpers/mocks/marine-licence-mocks.js
+++ b/src/server/test-helpers/mocks/marine-licence-mocks.js
@@ -1,5 +1,6 @@
 import { MARINE_LICENCE_KEY } from '#src/server/common/constants/marine-licence.js'
 import { faker } from '@faker-js/faker'
+import { PROJECT_STATUS } from '#src/server/common/constants/projects.js'
 
 export const mockMarineLicenceTaskList = {
   projectName: 'COMPLETED',
@@ -163,6 +164,12 @@ export const mockMarineLicenceApplication = {
 export const mockSubmittedMarineLicenceApplication = {
   ...mockMarineLicenceApplication,
   status: 'Submitted',
+  applicationReference: 'MLA/2026/10264'
+}
+
+export const mockTransferredMarineLicenceApplication = {
+  ...mockMarineLicenceApplication,
+  status: PROJECT_STATUS.TRANSFERRED,
   applicationReference: 'MLA/2026/10264'
 }
 

--- a/tests/integration/accessibility/marine-licence-page-accessibility.test.js
+++ b/tests/integration/accessibility/marine-licence-page-accessibility.test.js
@@ -242,6 +242,11 @@ const marineLicencePages = [
   {
     url: `${marineLicenceRoutes.MARINE_LICENCE_CONFIRMATION}?applicationReference=123`,
     title: 'Application sent'
+  },
+  {
+    url: `${marineLicenceRoutes.MARINE_LICENCE_APPLICATION_TRANSFERRED}/${mockSubmittedMarineLicenceApplication.id}`,
+    title: 'Your application has been transferred',
+    marineLicence: mockSubmittedMarineLicenceApplication
   }
   // TODO: Uncomment when meta refresh a11y issue is resolved (same issue as upload-and-wait)
   // {

--- a/tests/integration/accessibility/marine-licence-page-accessibility.test.js
+++ b/tests/integration/accessibility/marine-licence-page-accessibility.test.js
@@ -15,6 +15,7 @@ import { agentSession } from '../shared/session-fixtures.js'
 import { selectActivityVariants } from '~/src/server/common/constants/activity-variants.js'
 import { getMarinePlanPolicyLink } from '~/src/server/common/helpers/marine-licence/marine-plan-policy-link.js'
 import { runPageAccessibilityTests } from './page-accessibility-tests.js'
+import { mockTransferredMarineLicenceApplication } from '#src/server/test-helpers/mocks/marine-licence-mocks.js'
 
 vi.mock('~/src/server/common/helpers/authenticated-requests.js')
 vi.mock('~/src/server/common/helpers/defraid-login/session-cache.js')
@@ -246,7 +247,7 @@ const marineLicencePages = [
   {
     url: `${marineLicenceRoutes.MARINE_LICENCE_APPLICATION_TRANSFERRED}/${mockSubmittedMarineLicenceApplication.id}`,
     title: 'Your application has been transferred',
-    marineLicence: mockSubmittedMarineLicenceApplication
+    marineLicence: mockTransferredMarineLicenceApplication
   }
   // TODO: Uncomment when meta refresh a11y issue is resolved (same issue as upload-and-wait)
   // {

--- a/tests/integration/marine-licence/application-transferred.test.js
+++ b/tests/integration/marine-licence/application-transferred.test.js
@@ -33,6 +33,10 @@ describe('Application transferred', () => {
     })
 
     expect(getByText(document, marineLicence.projectName)).toBeInTheDocument()
+    expect(getByRole(document, 'link', { name: 'Back' })).toHaveAttribute(
+      'href',
+      routes.DASHBOARD
+    )
     expect(getByRole(document, 'heading', { level: 1 })).toHaveTextContent(
       'Your application has been transferred'
     )

--- a/tests/integration/marine-licence/application-transferred.test.js
+++ b/tests/integration/marine-licence/application-transferred.test.js
@@ -1,0 +1,62 @@
+import { getByRole, getByText } from '@testing-library/dom'
+import { marineLicenceRoutes } from '~/src/server/common/constants/routes.js'
+import {
+  mockMarineLicence,
+  setupTestServer
+} from '~/tests/integration/shared/test-setup-helpers.js'
+import { loadPage } from '~/tests/integration/shared/app-server.js'
+import { mockSubmittedMarineLicenceApplication } from '~/src/server/test-helpers/mocks/marine-licence-mocks.js'
+import {
+  CONTACT_EMAIL,
+  CONTACT_PHONE
+} from '~/src/server/marine-licence/application-transferred/controller.js'
+import { MCMS_LOGIN_URL } from '~/src/server/common/constants/mcms.js'
+
+describe('Application transferred', () => {
+  const getServer = setupTestServer()
+  const marineLicence = mockSubmittedMarineLicenceApplication
+
+  test('page elements', async () => {
+    mockMarineLicence(marineLicence)
+
+    const document = await loadPage({
+      requestUrl: `${marineLicenceRoutes.MARINE_LICENCE_APPLICATION_TRANSFERRED}/${marineLicence.id}`,
+      server: getServer()
+    })
+
+    expect(getByText(document, marineLicence.projectName)).toBeInTheDocument()
+    expect(getByRole(document, 'heading', { level: 1 })).toHaveTextContent(
+      'Your application has been transferred'
+    )
+    expect(
+      getByText(document, (content) =>
+        content.includes(
+          `Your application (${marineLicence.applicationReference}) has been transferred from Get permission for marine work to our Marine Case Management System (MCMS).`
+        )
+      )
+    ).toBeInTheDocument()
+    expect(
+      getByRole(document, 'heading', {
+        level: 2,
+        name: 'What happens next'
+      })
+    ).toBeInTheDocument()
+    expect(
+      getByRole(document, 'link', {
+        name: 'track the progress of your application'
+      })
+    ).toHaveAttribute('href', MCMS_LOGIN_URL)
+    expect(
+      getByRole(document, 'link', { name: CONTACT_EMAIL })
+    ).toHaveAttribute('href', `mailto:${CONTACT_EMAIL}`)
+    expect(getByText(document, `Phone: ${CONTACT_PHONE}`)).toBeInTheDocument()
+    expect(
+      getByRole(document, 'link', {
+        name: 'View your submitted application in this service'
+      })
+    ).toHaveAttribute(
+      'href',
+      `${marineLicenceRoutes.MARINE_LICENCE_VIEW_DETAILS}/${marineLicence.id}`
+    )
+  })
+})

--- a/tests/integration/marine-licence/application-transferred.test.js
+++ b/tests/integration/marine-licence/application-transferred.test.js
@@ -1,23 +1,31 @@
 import { getByRole, getByText } from '@testing-library/dom'
-import { marineLicenceRoutes } from '~/src/server/common/constants/routes.js'
+import {
+  marineLicenceRoutes,
+  routes
+} from '~/src/server/common/constants/routes.js'
 import {
   mockMarineLicence,
   setupTestServer
 } from '~/tests/integration/shared/test-setup-helpers.js'
 import { loadPage } from '~/tests/integration/shared/app-server.js'
-import { mockSubmittedMarineLicenceApplication } from '~/src/server/test-helpers/mocks/marine-licence-mocks.js'
 import {
   CONTACT_EMAIL,
   CONTACT_PHONE
 } from '~/src/server/marine-licence/application-transferred/controller.js'
 import { MCMS_LOGIN_URL } from '~/src/server/common/constants/mcms.js'
+import {
+  mockSubmittedMarineLicenceApplication,
+  mockTransferredMarineLicenceApplication
+} from '#src/server/test-helpers/mocks/marine-licence-mocks.js'
+import { statusCodes } from '~/src/server/common/constants/status-codes.js'
+import { makeGetRequest } from '~/src/server/test-helpers/server-requests.js'
 
 describe('Application transferred', () => {
   const getServer = setupTestServer()
-  const marineLicence = mockSubmittedMarineLicenceApplication
+  const marineLicence = mockTransferredMarineLicenceApplication
 
   test('page elements', async () => {
-    mockMarineLicence(marineLicence)
+    mockMarineLicence(mockTransferredMarineLicenceApplication)
 
     const document = await loadPage({
       requestUrl: `${marineLicenceRoutes.MARINE_LICENCE_APPLICATION_TRANSFERRED}/${marineLicence.id}`,
@@ -58,5 +66,17 @@ describe('Application transferred', () => {
       'href',
       `${marineLicenceRoutes.MARINE_LICENCE_VIEW_DETAILS}/${marineLicence.id}`
     )
+  })
+
+  test('should if marine licence is not transferred', async () => {
+    mockMarineLicence(mockSubmittedMarineLicenceApplication)
+
+    const response = await makeGetRequest({
+      url: `${marineLicenceRoutes.MARINE_LICENCE_APPLICATION_TRANSFERRED}/${marineLicence.id}`,
+      server: getServer()
+    })
+
+    expect(response.statusCode).toBe(statusCodes.redirect)
+    expect(response.headers.location).toBe(routes.DASHBOARD)
   })
 })

--- a/tests/integration/marine-licence/view-details/fixtures.js
+++ b/tests/integration/marine-licence/view-details/fixtures.js
@@ -1,4 +1,7 @@
-import { mockSubmittedMarineLicenceApplication } from '~/src/server/test-helpers/mocks/marine-licence-mocks.js'
+import {
+  mockSubmittedMarineLicenceApplication,
+  mockTransferredMarineLicenceApplication
+} from '~/src/server/test-helpers/mocks/marine-licence-mocks.js'
 import {
   NAUTICAL_MILE_HEADING,
   EXCLUDED_ACTIVITIES_HEADING,
@@ -13,6 +16,32 @@ import {
   CONTACT_PHONE_NUMBER,
   PO_HEADING
 } from '#src/server/common/helpers/marine-licence/invoicing/invoicing-review-data.js'
+
+export const expectedApplicationDetailsCard = {
+  cardTitle: 'Application details',
+  rows: [
+    {
+      key: 'Application type',
+      value: 'Marine licence application'
+    },
+    {
+      key: 'Status',
+      value: 'Transferred'
+    },
+    {
+      key: 'Reference number',
+      value: mockTransferredMarineLicenceApplication.applicationReference
+    },
+    {
+      key: 'Date submitted',
+      value: '26 May 2026'
+    },
+    {
+      key: 'Date of transfer',
+      value: '26 Jun 2026'
+    }
+  ]
+}
 
 export const expectedProjectDetailsCard = {
   cardTitle: 'Project details',

--- a/tests/integration/marine-licence/view-details/view-details.test.js
+++ b/tests/integration/marine-licence/view-details/view-details.test.js
@@ -1,17 +1,24 @@
 import { getByRole } from '@testing-library/dom'
-import { marineLicenceRoutes } from '~/src/server/common/constants/routes.js'
+import {
+  marineLicenceRoutes,
+  routes
+} from '~/src/server/common/constants/routes.js'
 import {
   mockMarineLicence,
   setupTestServer
 } from '~/tests/integration/shared/test-setup-helpers.js'
 import { loadPage } from '~/tests/integration/shared/app-server.js'
-import { mockSubmittedMarineLicenceApplication } from '~/src/server/test-helpers/mocks/marine-licence-mocks.js'
+import {
+  mockSubmittedMarineLicenceApplication,
+  mockTransferredMarineLicenceApplication
+} from '~/src/server/test-helpers/mocks/marine-licence-mocks.js'
 import {
   expectedProjectDetailsCard,
   expectedOtherPermissionsCard,
   expectedWaterFrameworkDirectiveCard,
   expectedInvocingCardIndividualUser,
-  expectedInvocingCardOrgUser
+  expectedInvocingCardOrgUser,
+  expectedApplicationDetailsCard
 } from './fixtures.js'
 import { getCardRow } from './utils.js'
 import {
@@ -23,11 +30,11 @@ describe('Marine Licence View Details', () => {
   const getServer = setupTestServer()
 
   const loadViewDetailsPage = async (server, marineLicenceMock) => {
-    mockMarineLicence(
+    const marineLicence =
       marineLicenceMock ?? mockSubmittedMarineLicenceApplication
-    )
+    mockMarineLicence(marineLicence)
     return loadPage({
-      requestUrl: `${marineLicenceRoutes.MARINE_LICENCE_VIEW_DETAILS}/${mockSubmittedMarineLicenceApplication.id}`,
+      requestUrl: `${marineLicenceRoutes.MARINE_LICENCE_VIEW_DETAILS}/${marineLicence.id}`,
       server
     })
   }
@@ -37,6 +44,63 @@ describe('Marine Licence View Details', () => {
 
     expect(getByRole(document, 'heading', { level: 1 })).toHaveTextContent(
       mockSubmittedMarineLicenceApplication.projectName
+    )
+  })
+
+  test('back link goes to dashboard for submitted applications', async () => {
+    const document = await loadViewDetailsPage(getServer())
+
+    expect(getByRole(document, 'link', { name: 'Back' })).toHaveAttribute(
+      'href',
+      routes.DASHBOARD
+    )
+  })
+
+  test('back link goes to application transferred page for transferred applications', async () => {
+    const document = await loadViewDetailsPage(
+      getServer(),
+      mockTransferredMarineLicenceApplication
+    )
+
+    expect(getByRole(document, 'link', { name: 'Back' })).toHaveAttribute(
+      'href',
+      `${marineLicenceRoutes.MARINE_LICENCE_APPLICATION_TRANSFERRED}/${mockTransferredMarineLicenceApplication.id}`
+    )
+  })
+
+  describe('application details card', () => {
+    let document
+
+    beforeEach(async () => {
+      document = await loadViewDetailsPage(
+        getServer(),
+        mockTransferredMarineLicenceApplication
+      )
+    })
+
+    test('does not render for submitted applications', async () => {
+      document = await loadViewDetailsPage(getServer())
+
+      expect(document.querySelector('#application-details-card')).toBeNull()
+    })
+
+    test('renders for transferred applications', async () => {
+      expect(
+        document.querySelector('#application-details-card')
+      ).toBeInTheDocument()
+    })
+
+    test.each(expectedApplicationDetailsCard.rows)(
+      'renders "$key" row with correct value',
+      ({ key, value }) => {
+        const card = document.querySelector('#application-details-card')
+        const row = getCardRow(card, key)
+
+        expect(row).toBeTruthy()
+        expect(
+          row.querySelector('.govuk-summary-list__value').textContent.trim()
+        ).toBe(value)
+      }
     )
   })
 

--- a/tests/integration/service-home/service-home.test.js
+++ b/tests/integration/service-home/service-home.test.js
@@ -1,5 +1,6 @@
 import { getByRole, queryByRole } from '@testing-library/dom'
 import { routes } from '~/src/server/common/constants/routes.js'
+import { MCMS_LOGIN_URL } from '~/src/server/common/constants/mcms.js'
 import { setupTestServer } from '~/tests/integration/shared/test-setup-helpers.js'
 import { loadPage } from '~/tests/integration/shared/app-server.js'
 import { config } from '~/src/config/config.js'
@@ -60,10 +61,7 @@ describe('Service Home', () => {
       const signInLink = getByRole(doc, 'link', {
         name: /Sign in to the Marine Case Management System/i
       })
-      expect(signInLink).toHaveAttribute(
-        'href',
-        'https://marinelicensing.marinemanagement.org.uk/mmofox5/fox/live/MMO_LOGIN/login'
-      )
+      expect(signInLink).toHaveAttribute('href', MCMS_LOGIN_URL)
       expect(signInLink).toHaveClass('card')
       expect(signInLink.parentElement).toHaveClass(
         'govuk-grid-column-one-third-from-desktop'


### PR DESCRIPTION
## Description
 
Transfer Application page

## Changes

- New status 'Transferred' on the Projects Dashboard.
- Links goes to new 'Your application has been transferred' page.
- New 'Application Details' card on View Details

<img width="2304" height="2640" alt="Your-application-has-been-transferred-Get-permission-for-marine-work-07-30-2026_03_15_PM" src="https://github.com/user-attachments/assets/7d22a793-7660-4efa-8f35-71601dc7d217" />
