### PR TITLE
ML-1475 - LCML - Step 2 Upload technical drawing for construction

### DIFF
--- a/src/config/nunjucks/globals/set-site-details-action.js
+++ b/src/config/nunjucks/globals/set-site-details-action.js
@@ -1,10 +1,19 @@
-const buildQueryString = (siteNumber, activityNumber, skipAction, action) => {
+const buildQueryString = (
+  siteNumber,
+  activityNumber,
+  drawingNumber,
+  skipAction,
+  action
+) => {
   const queryParams = []
   if (siteNumber) {
     queryParams.push(`site=${siteNumber}`)
   }
   if (activityNumber) {
     queryParams.push(`activity=${activityNumber}`)
+  }
+  if (drawingNumber) {
+    queryParams.push(`drawing=${drawingNumber}`)
   }
   if (!skipAction) {
     queryParams.push(`action=${action}`)
@@ -21,11 +30,12 @@ export function setSiteDetailsAction(
 ) {
   const hasValue = value && value !== ''
   const action = hasValue ? 'change' : 'add'
-  const { skipAction, activityNumber, hideLinkText } = options
+  const { skipAction, activityNumber, drawingNumber, hideLinkText } = options
 
   const queryString = buildQueryString(
     siteNumber,
     activityNumber,
+    drawingNumber,
     skipAction,
     action
   )

--- a/src/config/nunjucks/globals/set-site-details-action.test.js
+++ b/src/config/nunjucks/globals/set-site-details-action.test.js
@@ -183,6 +183,23 @@ describe('setSiteDetailsAction', () => {
     })
   })
 
+  test('should include drawing query param when provided', () => {
+    const result = setSiteDetailsAction('Value', '/page', 1, '', {
+      skipAction: true,
+      drawingNumber: 2
+    })
+
+    expect(result).toEqual({
+      items: [
+        {
+          classes: 'govuk-link--no-visited-state',
+          href: '/page?site=1&drawing=2',
+          text: 'Change'
+        }
+      ]
+    })
+  })
+
   test('should include activity with action when no site is provided', () => {
     const result = setSiteDetailsAction('Value', '/page', null, '', {
       activityNumber: 3

--- a/src/server/common/components/marine-licence/construction-drawing-card/template.njk
+++ b/src/server/common/components/marine-licence/construction-drawing-card/template.njk
@@ -2,46 +2,66 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "incomplete-field/macro.njk" import appIncompleteField %}
 
-{% set siteHasConstructionDrawing = false %}
-{% set firstDrawingActivityNumber = 1 %}
+{% set siteRequiresConstructionDrawing = false %}
 
 {% for activityDetails in params.activityDetails %}
   {% if activityDetails.requiresConstructionDrawing %}
-    {% if not siteHasConstructionDrawing %}
-      {% set siteHasConstructionDrawing = true %}
-      {% set firstDrawingActivityNumber = loop.index %}
-    {% endif %}
+    {% set siteRequiresConstructionDrawing = true %}
+  {% endif %}
+{% endfor %}
+
+{% if siteRequiresConstructionDrawing %}
+  {% set constructionDrawings = params.constructionDrawings or [] %}
+  {% set drawingCount = constructionDrawings.length if constructionDrawings.length > 1 else 1 %}
+
+  {% for drawingIndex in range(0, drawingCount) %}
+    {% set drawing = constructionDrawings[drawingIndex] or {} %}
+    {% set drawingNumber = drawingIndex + 1 %}
 
     {% set drawingRows = [{
       key: { text: "File upload" },
-      value: { html: appIncompleteField({ text: "" }) },
-      actions: setSiteDetailsAction(false, 'upload-construction-drawing', params.siteNumber, "", { activityNumber: loop.index })
+      value: { html: appIncompleteField({ text: drawing.filename }) },
+      actions: setSiteDetailsAction(drawing.filename, 'upload-construction-drawing', params.siteNumber, "", { drawingNumber: drawingNumber })
     }] %}
+
+    {% set deleteActionItems = [{
+      href: "delete-construction-drawing?site=" + params.siteNumber + "&drawing=" + drawingNumber,
+      text: "Delete file upload",
+      classes: "govuk-link--no-visited-state"
+    }] if drawingIndex > 0 else [] %}
 
     {{ govukSummaryList({
       card: {
         attributes: {
-          id: "construction-drawing-site-" + params.siteNumber + "-activity-" + loop.index
+          id: "construction-drawing-site-" + params.siteNumber + "-" + drawingNumber
         },
         title: {
-          text: "Site " + params.siteNumber + " - Construction drawing " + loop.index
+          text: "Site " + params.siteNumber + " - Construction drawing " + drawingNumber
+        },
+        actions: {
+          items: deleteActionItems
         }
       },
       classes: "govuk-summary-list--full-width",
       rows: drawingRows
     }) }}
-  {% endif %}
-{% endfor %}
+  {% endfor %}
 
-{% if siteHasConstructionDrawing %}
-  <div class="govuk-!-margin-bottom-6">
-    {{ govukButton({
-      text: "Add another construction drawing for site " + params.siteNumber,
-      classes: "govuk-button--secondary",
-      href: "upload-construction-drawing?site=" + params.siteNumber + "&activity=" + firstDrawingActivityNumber,
-      attributes: {
-        id: 'add-another-construction-drawing-site-' + params.siteNumber
-      }
-    }) }}
-  </div>
+  <form method="POST">
+    <input type="hidden" name="csrfToken" value="{{ params.csrfToken }}">
+    <input type="hidden" name="siteNumber" value="{{ params.siteNumber }}">
+
+    <div class="govuk-!-margin-bottom-6">
+      {{ govukButton({
+        text: "Add another construction drawing for site " + params.siteNumber,
+        classes: "govuk-button--secondary",
+        attributes: {
+          id: 'add-another-construction-drawing-site-' + params.siteNumber,
+          name: "addConstructionDrawing",
+          value: "addConstructionDrawing",
+          type: "submit"
+        }
+      }) }}
+    </div>
+  </form>
 {% endif %}

--- a/src/server/common/components/marine-licence/construction-drawing-card/template.test.js
+++ b/src/server/common/components/marine-licence/construction-drawing-card/template.test.js
@@ -1,15 +1,14 @@
 import { renderComponent } from '#src/server/test-helpers/component-helpers.js'
 
 describe('Marine Licence Construction Drawing Card', () => {
-  test('renders a drawing card per qualifying activity, in order', () => {
+  test('renders a single drawing card when no drawings have been added yet', () => {
     const $component = renderComponent(
       'marine-licence/construction-drawing-card',
       {
         siteNumber: 1,
         activityDetails: [
           { requiresConstructionDrawing: true },
-          { requiresConstructionDrawing: false },
-          { requiresConstructionDrawing: true }
+          { requiresConstructionDrawing: false }
         ]
       }
     )
@@ -18,21 +17,16 @@ describe('Marine Licence Construction Drawing Card', () => {
       .toArray()
       .map((el) => $component(el).attr('id'))
 
-    expect(cardIds).toEqual([
-      'construction-drawing-site-1-activity-1',
-      'construction-drawing-site-1-activity-3'
-    ])
+    expect(cardIds).toEqual(['construction-drawing-site-1-1'])
 
     expect(
-      $component(
-        '#construction-drawing-site-1-activity-1 .govuk-summary-card__title'
-      )
+      $component('#construction-drawing-site-1-1 .govuk-summary-card__title')
         .text()
         .trim()
     ).toBe('Site 1 - Construction drawing 1')
   })
 
-  test('renders the "Add" link for each drawing card pointing at the upload-construction-drawing route', () => {
+  test('renders the "Add" link pointing at the upload-construction-drawing route', () => {
     const $component = renderComponent(
       'marine-licence/construction-drawing-card',
       {
@@ -42,30 +36,100 @@ describe('Marine Licence Construction Drawing Card', () => {
     )
 
     const link = $component(
-      '#construction-drawing-site-2-activity-1 .govuk-summary-list__actions a'
+      '#construction-drawing-site-2-1 .govuk-summary-list__actions a'
     )
+    expect(link.text()).toContain('Add')
     expect(link.attr('href')).toBe(
-      'upload-construction-drawing?site=2&activity=1&action=add'
+      'upload-construction-drawing?site=2&drawing=1&action=add'
     )
   })
 
-  test('renders "Add another construction drawing" button linking to the first qualifying activity', () => {
+  test('renders the "Change" link and filename for an uploaded drawing', () => {
     const $component = renderComponent(
       'marine-licence/construction-drawing-card',
       {
         siteNumber: 1,
-        activityDetails: [
-          { requiresConstructionDrawing: false },
-          { requiresConstructionDrawing: true }
+        activityDetails: [{ requiresConstructionDrawing: true }],
+        constructionDrawings: [{ filename: 'tech-drawing.pdf' }]
+      }
+    )
+
+    const row = $component('#construction-drawing-site-1-1')
+    expect(row.text()).toContain('tech-drawing.pdf')
+
+    const link = row.find('.govuk-summary-list__actions a')
+    expect(link.text()).toContain('Change')
+    expect(link.attr('href')).toBe(
+      'upload-construction-drawing?site=1&drawing=1&action=change'
+    )
+  })
+
+  test('renders a card per drawing, numbered sequentially, with a delete link from the second drawing onwards', () => {
+    const $component = renderComponent(
+      'marine-licence/construction-drawing-card',
+      {
+        siteNumber: 1,
+        activityDetails: [{ requiresConstructionDrawing: true }],
+        constructionDrawings: [
+          { filename: 'drawing-one.pdf' },
+          { filename: 'drawing-two.pdf' },
+          {}
         ]
       }
     )
 
-    const button = $component('#add-another-construction-drawing-site-1')
-    expect(button).toHaveLength(1)
-    expect(button.attr('href')).toBe(
-      'upload-construction-drawing?site=1&activity=2'
+    const cardIds = $component('.govuk-summary-card')
+      .toArray()
+      .map((el) => $component(el).attr('id'))
+
+    expect(cardIds).toEqual([
+      'construction-drawing-site-1-1',
+      'construction-drawing-site-1-2',
+      'construction-drawing-site-1-3'
+    ])
+
+    expect(
+      $component('#construction-drawing-site-1-1 .govuk-summary-card__actions')
+        .length
+    ).toBe(0)
+
+    const secondCardDeleteLink = $component(
+      '#construction-drawing-site-1-2 .govuk-summary-card__actions a'
     )
+    expect(secondCardDeleteLink.text()).toContain('Delete file upload')
+    expect(secondCardDeleteLink.attr('href')).toBe(
+      'delete-construction-drawing?site=1&drawing=2'
+    )
+
+    const thirdCardDeleteLink = $component(
+      '#construction-drawing-site-1-3 .govuk-summary-card__actions a'
+    )
+    expect(thirdCardDeleteLink.attr('href')).toBe(
+      'delete-construction-drawing?site=1&drawing=3'
+    )
+  })
+
+  test('renders "Add another construction drawing" as a POST submit button, not a link', () => {
+    const $component = renderComponent(
+      'marine-licence/construction-drawing-card',
+      {
+        siteNumber: 1,
+        activityDetails: [{ requiresConstructionDrawing: true }],
+        csrfToken: 'test-csrf-token'
+      }
+    )
+
+    const button = $component('#add-another-construction-drawing-site-1')
+    const form = button.closest('form')
+
+    expect(button.attr('href')).toBeUndefined()
+    expect(button.attr('type')).toBe('submit')
+    expect(button.attr('name')).toBe('addConstructionDrawing')
+    expect(form.attr('method')).toBe('POST')
+    expect(form.find('input[name="csrfToken"]').attr('value')).toBe(
+      'test-csrf-token'
+    )
+    expect(form.find('input[name="siteNumber"]').attr('value')).toBe('1')
   })
 
   test('renders nothing when no activity requires a drawing', () => {

--- a/src/server/common/constants/routes.js
+++ b/src/server/common/constants/routes.js
@@ -99,6 +99,10 @@ export const marineLicenceRoutes = {
   MARINE_LICENCE_DELETE_ACTIVITY: '/marine-licence/delete-activity',
   MARINE_LICENCE_UPLOAD_CONSTRUCTION_DRAWING:
     '/marine-licence/upload-construction-drawing',
+  MARINE_LICENCE_UPLOAD_CONSTRUCTION_DRAWING_WAIT:
+    '/marine-licence/upload-construction-drawing-wait',
+  MARINE_LICENCE_DELETE_CONSTRUCTION_DRAWING:
+    '/marine-licence/delete-construction-drawing',
   MARINE_LICENCE_CONFIRM_CHANGE_ACTIVITY_TYPE:
     '/marine-licence/confirm-change-activity-type',
   MARINE_LICENCE_DELETE_SITE: '/marine-licence/delete-site',
@@ -205,6 +209,9 @@ export const apiRoutes = {
   UPDATE_MARINE_LICENCE_SITE_DETAILS: '/marine-licence/site-details',
   MARINE_LICENCE_PROJECT_BACKGROUND: '/marine-licence/project-background',
   DELETE_ACTIVITY_FROM_SITE: '/marine-licence/delete-activity-details',
+  ADD_CONSTRUCTION_DRAWING: '/marine-licence/add-construction-drawing',
+  UPDATE_CONSTRUCTION_DRAWING: '/marine-licence/update-construction-drawing',
+  DELETE_CONSTRUCTION_DRAWING: '/marine-licence/delete-construction-drawing',
   GENERATE_COORDINATES_CSV:
     '/marine-licence/{marineLicenceId}/generate-coordinates-csv',
   UPDATE_FEE_ESTIMATE: '/marine-licence/fee-estimate',

--- a/src/server/common/constants/routes.js
+++ b/src/server/common/constants/routes.js
@@ -212,6 +212,7 @@ export const apiRoutes = {
   ADD_CONSTRUCTION_DRAWING: '/marine-licence/add-construction-drawing',
   UPDATE_CONSTRUCTION_DRAWING: '/marine-licence/update-construction-drawing',
   DELETE_CONSTRUCTION_DRAWING: '/marine-licence/delete-construction-drawing',
+  DELETE_CONSTRUCTION_DRAWINGS: '/marine-licence/delete-construction-drawings',
   GENERATE_COORDINATES_CSV:
     '/marine-licence/{marineLicenceId}/generate-coordinates-csv',
   UPDATE_FEE_ESTIMATE: '/marine-licence/fee-estimate',

--- a/src/server/common/helpers/file-upload/error-messages.js
+++ b/src/server/common/helpers/file-upload/error-messages.js
@@ -37,7 +37,13 @@ export const CDP_ERROR_MESSAGES = {
 
 export const FILE_TYPE_ERROR_MESSAGES = {
   kml: 'The selected file must be a KML file',
-  shapefile: 'The selected file must be a Shapefile'
+  shapefile: 'The selected file must be a Shapefile',
+  'construction-drawing':
+    'The selected file must be a PDF or image (.bmp, .gif, .jpg, .jpeg, .png, .tif) file'
+}
+
+export const FILE_SIZE_ERROR_MESSAGES = {
+  'construction-drawing': 'The selected file must be smaller than 10 MB'
 }
 
 export const WFD_FILE_TYPE_ERROR_MESSAGE =

--- a/src/server/common/helpers/file-upload/file-upload.js
+++ b/src/server/common/helpers/file-upload/file-upload.js
@@ -27,11 +27,6 @@ export const getFileTypeContent = (fileUploadType) => {
       heading: 'Upload a shapefile',
       acceptAttribute: '.zip'
     }
-  } else if (fileUploadType === 'construction-drawing') {
-    return {
-      heading: UPLOAD_A_FILE,
-      acceptAttribute: CONSTRUCTION_DRAWING_ACCEPT_ATTRIBUTE
-    }
   } else {
     return {
       heading: UPLOAD_A_FILE,

--- a/src/server/common/helpers/file-upload/file-upload.js
+++ b/src/server/common/helpers/file-upload/file-upload.js
@@ -8,9 +8,13 @@ import {
   GEO_PARSER_ERROR_MESSAGES,
   CDP_ERROR_MESSAGES,
   FILE_TYPE_ERROR_MESSAGES,
+  FILE_SIZE_ERROR_MESSAGES,
   DEFAULT_ERROR_MESSAGE,
   DEFAULT_GEO_PARSER_ERROR_MESSAGE
 } from '#src/server/common/helpers/file-upload/error-messages.js'
+
+export const CONSTRUCTION_DRAWING_ACCEPT_ATTRIBUTE =
+  '.pdf,.bmp,.gif,.jpg,.jpeg,.png,.tif'
 
 export const getFileTypeContent = (fileUploadType) => {
   if (fileUploadType === 'kml') {
@@ -22,6 +26,11 @@ export const getFileTypeContent = (fileUploadType) => {
     return {
       heading: 'Upload a shapefile',
       acceptAttribute: '.zip'
+    }
+  } else if (fileUploadType === 'construction-drawing') {
+    return {
+      heading: UPLOAD_A_FILE,
+      acceptAttribute: CONSTRUCTION_DRAWING_ACCEPT_ATTRIBUTE
     }
   } else {
     return {
@@ -37,6 +46,8 @@ export const getAllowedExtensions = (fileType) => {
       return ['kml']
     case 'shapefile':
       return ['zip']
+    case 'construction-drawing':
+      return ['pdf', 'bmp', 'gif', 'jpg', 'jpeg', 'png', 'tif']
     default:
       return []
   }
@@ -81,6 +92,10 @@ export const getGeoParserErrorMessage = (errorCode) => {
 export const getCdpErrorMessageFromCode = (errorCode, fileType) => {
   if (errorCode === 'INVALID_FILE_TYPE') {
     return FILE_TYPE_ERROR_MESSAGES[fileType] || CDP_ERROR_MESSAGES[errorCode]
+  }
+
+  if (errorCode === 'FILE_TOO_LARGE') {
+    return FILE_SIZE_ERROR_MESSAGES[fileType] || CDP_ERROR_MESSAGES[errorCode]
   }
 
   return CDP_ERROR_MESSAGES[errorCode] || DEFAULT_ERROR_MESSAGE

--- a/src/server/common/helpers/file-upload/file-upload.test.js
+++ b/src/server/common/helpers/file-upload/file-upload.test.js
@@ -1,11 +1,14 @@
 import {
   getAllowedExtensions,
   getCdpErrorMessageFromCode,
-  getGeoParserErrorMessage
+  getFileTypeContent,
+  getGeoParserErrorMessage,
+  CONSTRUCTION_DRAWING_ACCEPT_ATTRIBUTE
 } from '#src/server/common/helpers/file-upload/file-upload.js'
 import {
   CDP_ERROR_MESSAGES,
   FILE_TYPE_ERROR_MESSAGES,
+  FILE_SIZE_ERROR_MESSAGES,
   DEFAULT_ERROR_MESSAGE,
   DEFAULT_GEO_PARSER_ERROR_MESSAGE,
   GEO_PARSER_ERROR_MESSAGES
@@ -15,6 +18,10 @@ describe('#getAllowedExtensions', () => {
   test.each([
     ['kml', ['kml']],
     ['shapefile', ['zip']],
+    [
+      'construction-drawing',
+      ['pdf', 'bmp', 'gif', 'jpg', 'jpeg', 'png', 'tif']
+    ],
     ['unknown', []],
     [undefined, []]
   ])(
@@ -25,15 +32,34 @@ describe('#getAllowedExtensions', () => {
   )
 })
 
+describe('#getFileTypeContent', () => {
+  test('returns the construction drawing accept attribute', () => {
+    expect(getFileTypeContent('construction-drawing')).toEqual({
+      heading: 'Upload a file',
+      acceptAttribute: CONSTRUCTION_DRAWING_ACCEPT_ATTRIBUTE
+    })
+  })
+})
+
 describe('#getCdpErrorMessageFromCode', () => {
   test.each([
     ['VIRUS_DETECTED', 'kml', CDP_ERROR_MESSAGES.VIRUS_DETECTED],
     ['FILE_EMPTY', 'kml', CDP_ERROR_MESSAGES.FILE_EMPTY],
     ['FILE_TOO_LARGE', 'kml', CDP_ERROR_MESSAGES.FILE_TOO_LARGE],
+    [
+      'FILE_TOO_LARGE',
+      'construction-drawing',
+      FILE_SIZE_ERROR_MESSAGES['construction-drawing']
+    ],
     ['NO_FILE_SELECTED', 'kml', CDP_ERROR_MESSAGES.NO_FILE_SELECTED],
     ['UPLOAD_ERROR', 'kml', CDP_ERROR_MESSAGES.UPLOAD_ERROR],
     ['INVALID_FILE_TYPE', 'kml', FILE_TYPE_ERROR_MESSAGES.kml],
     ['INVALID_FILE_TYPE', 'shapefile', FILE_TYPE_ERROR_MESSAGES.shapefile],
+    [
+      'INVALID_FILE_TYPE',
+      'construction-drawing',
+      FILE_TYPE_ERROR_MESSAGES['construction-drawing']
+    ],
     ['INVALID_FILE_TYPE', 'foo', CDP_ERROR_MESSAGES.INVALID_FILE_TYPE],
     [null, 'kml', DEFAULT_ERROR_MESSAGE],
     ['UNKNOWN_CODE', 'kml', DEFAULT_ERROR_MESSAGE]

--- a/src/server/common/helpers/file-upload/file-upload.test.js
+++ b/src/server/common/helpers/file-upload/file-upload.test.js
@@ -1,9 +1,7 @@
 import {
   getAllowedExtensions,
   getCdpErrorMessageFromCode,
-  getFileTypeContent,
-  getGeoParserErrorMessage,
-  CONSTRUCTION_DRAWING_ACCEPT_ATTRIBUTE
+  getGeoParserErrorMessage
 } from '#src/server/common/helpers/file-upload/file-upload.js'
 import {
   CDP_ERROR_MESSAGES,
@@ -30,15 +28,6 @@ describe('#getAllowedExtensions', () => {
       expect(getAllowedExtensions(fileType)).toEqual(expected)
     }
   )
-})
-
-describe('#getFileTypeContent', () => {
-  test('returns the construction drawing accept attribute', () => {
-    expect(getFileTypeContent('construction-drawing')).toEqual({
-      heading: 'Upload a file',
-      acceptAttribute: CONSTRUCTION_DRAWING_ACCEPT_ATTRIBUTE
-    })
-  })
 })
 
 describe('#getCdpErrorMessageFromCode', () => {

--- a/src/server/common/helpers/marine-licence/construction-drawings-request.js
+++ b/src/server/common/helpers/marine-licence/construction-drawings-request.js
@@ -1,0 +1,24 @@
+import Boom from '@hapi/boom'
+import { authenticatedPatchRequest } from '#src/server/common/helpers/authenticated-requests.js'
+
+export const deleteConstructionDrawingsRequest = async (
+  request,
+  { route, payload, logAction, reason, errorMessage }
+) => {
+  try {
+    await authenticatedPatchRequest(request, route, payload)
+  } catch (error) {
+    request.logger.error(
+      {
+        err: error,
+        event: {
+          action: logAction,
+          reference: payload.id,
+          reason
+        }
+      },
+      errorMessage
+    )
+    throw Boom.internal(errorMessage)
+  }
+}

--- a/src/server/common/helpers/marine-licence/construction-drawings-request.test.js
+++ b/src/server/common/helpers/marine-licence/construction-drawings-request.test.js
@@ -1,0 +1,53 @@
+import { vi } from 'vitest'
+import { deleteConstructionDrawingsRequest } from '#src/server/common/helpers/marine-licence/construction-drawings-request.js'
+import * as authenticatedRequests from '#src/server/common/helpers/authenticated-requests.js'
+import { createMockRequest } from '#src/server/test-helpers/mocks/helpers.js'
+
+vi.mock('~/src/server/common/helpers/authenticated-requests.js')
+
+describe('deleteConstructionDrawingsRequest', () => {
+  const options = {
+    route: '/marine-licence/delete-construction-drawing',
+    payload: { id: 'test-id', siteIndex: 0, drawingIndex: 1 },
+    logAction: 'marine-licence:delete-construction-drawing-failed',
+    reason: 'siteIndex=0 drawingIndex=1',
+    errorMessage: 'Error deleting construction drawing'
+  }
+
+  it('calls authenticatedPatchRequest with the given route and payload', async () => {
+    vi.mocked(
+      authenticatedRequests.authenticatedPatchRequest
+    ).mockResolvedValue({})
+    const request = createMockRequest()
+
+    await deleteConstructionDrawingsRequest(request, options)
+
+    expect(
+      authenticatedRequests.authenticatedPatchRequest
+    ).toHaveBeenCalledWith(request, options.route, options.payload)
+  })
+
+  it('logs and throws a Boom error when the request fails', async () => {
+    const apiError = new Error('API error')
+    vi.mocked(
+      authenticatedRequests.authenticatedPatchRequest
+    ).mockRejectedValueOnce(apiError)
+    const request = createMockRequest()
+
+    await expect(
+      deleteConstructionDrawingsRequest(request, options)
+    ).rejects.toThrow('Error deleting construction drawing')
+
+    expect(request.logger.error).toHaveBeenCalledWith(
+      {
+        err: apiError,
+        event: {
+          action: options.logAction,
+          reference: options.payload.id,
+          reason: options.reason
+        }
+      },
+      options.errorMessage
+    )
+  })
+})

--- a/src/server/common/helpers/marine-licence/save-site-details.js
+++ b/src/server/common/helpers/marine-licence/save-site-details.js
@@ -29,7 +29,8 @@ export const prepareFileUploadDataForSave = (siteDetails, request) => {
         checksumSha256: site.s3Location.checksumSha256
       },
       siteName: site.siteName,
-      activityDetails: site.activityDetails
+      activityDetails: site.activityDetails,
+      constructionDrawings: site.constructionDrawings
     }
 
     request.logger.info(
@@ -57,7 +58,8 @@ export const prepareManualCoordinateDataForSave = (siteDetails) => {
       coordinateSystem: site.coordinateSystem,
       coordinates: site.coordinates,
       siteName: site.siteName,
-      activityDetails: site.activityDetails
+      activityDetails: site.activityDetails,
+      constructionDrawings: site.constructionDrawings
     }
 
     if (site.coordinatesEntry === 'single') {

--- a/src/server/common/helpers/marine-licence/save-site-details.test.js
+++ b/src/server/common/helpers/marine-licence/save-site-details.test.js
@@ -51,7 +51,8 @@ describe('save-site-details', () => {
           s3Bucket: 'test-bucket',
           s3Key: 'test-key',
           checksumSha256: 'test-checksum'
-        }
+        },
+        constructionDrawings: undefined
       })
 
       expect(mockRequest.logger.info).toHaveBeenCalledWith(
@@ -135,7 +136,8 @@ describe('save-site-details', () => {
           s3Bucket: 'test-bucket',
           s3Key: 'test-key',
           checksumSha256: 'test-checksum'
-        }
+        },
+        constructionDrawings: undefined
       })
 
       expect(result[1]).toEqual({
@@ -151,7 +153,8 @@ describe('save-site-details', () => {
           s3Bucket: 'test-bucket',
           s3Key: 'test-key-2',
           checksumSha256: 'test-checksum-2'
-        }
+        },
+        constructionDrawings: undefined
       })
     })
 
@@ -202,7 +205,8 @@ describe('save-site-details', () => {
         coordinates: { latitude: '51.489676', longitude: '-0.231530' },
         circleWidth: '100',
         siteName: 'Test site',
-        activityDetails: { description: 'Test activity' }
+        activityDetails: { description: 'Test activity' },
+        constructionDrawings: undefined
       })
       expect(result[0]).not.toHaveProperty('someUiOnlyField')
     })
@@ -234,8 +238,47 @@ describe('save-site-details', () => {
         coordinateSystem: 'wgs84',
         coordinates: siteDetails[0].coordinates,
         siteName: 'Test polygon site',
-        activityDetails: null
+        activityDetails: null,
+        constructionDrawings: undefined
       })
+    })
+
+    test('preserves constructionDrawings for file-upload and manual-coordinate sites', () => {
+      const constructionDrawings = [
+        {
+          filename: 'drawing.pdf',
+          s3Location: {
+            s3Bucket: 'test-bucket',
+            s3Key: 'test-key',
+            checksumSha256: 'test-checksum'
+          }
+        }
+      ]
+
+      const fileUploadSite = {
+        ...mockMarineLicenceApplication.siteDetails[0],
+        constructionDrawings
+      }
+      const fileUploadResult = prepareFileUploadDataForSave(
+        [fileUploadSite],
+        mockRequest
+      )
+      expect(fileUploadResult[0].constructionDrawings).toBe(
+        constructionDrawings
+      )
+
+      const manualSite = {
+        coordinatesType: 'coordinates',
+        coordinatesEntry: 'single',
+        coordinateSystem: 'wgs84',
+        coordinates: { latitude: '51.489676', longitude: '-0.231530' },
+        circleWidth: '100',
+        siteName: 'Test site',
+        activityDetails: { description: 'Test activity' },
+        constructionDrawings
+      }
+      const manualResult = prepareManualCoordinateDataForSave([manualSite])
+      expect(manualResult[0].constructionDrawings).toBe(constructionDrawings)
     })
   })
 

--- a/src/server/common/helpers/marine-licence/session-cache/construction-drawing-utils.js
+++ b/src/server/common/helpers/marine-licence/session-cache/construction-drawing-utils.js
@@ -1,0 +1,33 @@
+import { updateMarineLicenceSiteDetails } from '#src/server/common/helpers/marine-licence/session-cache/utils.js'
+import { authenticatedPatchRequest } from '#src/server/common/helpers/authenticated-requests.js'
+import { apiRoutes } from '#src/server/common/constants/routes.js'
+
+export const siteHasConstructionDrawings = (marineLicence, siteIndex) =>
+  marineLicence.siteDetails[siteIndex]?.constructionDrawings?.length > 0
+
+export async function seedFirstConstructionDrawingIfNeeded(
+  request,
+  h,
+  marineLicence,
+  siteIndex
+) {
+  if (siteHasConstructionDrawings(marineLicence, siteIndex)) {
+    return
+  }
+
+  await authenticatedPatchRequest(request, apiRoutes.ADD_CONSTRUCTION_DRAWING, {
+    siteIndex,
+    id: marineLicence.id
+  })
+
+  const existingDrawings =
+    marineLicence.siteDetails[siteIndex]?.constructionDrawings || []
+
+  await updateMarineLicenceSiteDetails(
+    request,
+    h,
+    siteIndex,
+    'constructionDrawings',
+    [...existingDrawings, {}]
+  )
+}

--- a/src/server/common/helpers/marine-licence/session-cache/construction-drawing-utils.test.js
+++ b/src/server/common/helpers/marine-licence/session-cache/construction-drawing-utils.test.js
@@ -1,0 +1,69 @@
+import { vi } from 'vitest'
+import {
+  siteHasConstructionDrawings,
+  seedFirstConstructionDrawingIfNeeded
+} from '#src/server/common/helpers/marine-licence/session-cache/construction-drawing-utils.js'
+import { updateMarineLicenceSiteDetails } from '#src/server/common/helpers/marine-licence/session-cache/utils.js'
+import { authenticatedPatchRequest } from '#src/server/common/helpers/authenticated-requests.js'
+import { apiRoutes } from '#src/server/common/constants/routes.js'
+
+vi.mock('~/src/server/common/helpers/marine-licence/session-cache/utils.js')
+vi.mock('~/src/server/common/helpers/authenticated-requests.js')
+
+describe('#constructionDrawingUtils', () => {
+  const marineLicence = {
+    id: 'test-id',
+    siteDetails: [{ constructionDrawings: [] }]
+  }
+
+  describe('siteHasConstructionDrawings', () => {
+    test('returns false when there are no drawings', () => {
+      expect(siteHasConstructionDrawings(marineLicence, 0)).toBe(false)
+    })
+
+    test('returns true when there is at least one drawing', () => {
+      const withDrawing = {
+        siteDetails: [{ constructionDrawings: [{}] }]
+      }
+      expect(siteHasConstructionDrawings(withDrawing, 0)).toBe(true)
+    })
+  })
+
+  describe('seedFirstConstructionDrawingIfNeeded', () => {
+    const request = {}
+    const h = {}
+
+    afterEach(() => {
+      vi.clearAllMocks()
+    })
+
+    test('patches the backend and appends an empty drawing to the cache when none exist', async () => {
+      await seedFirstConstructionDrawingIfNeeded(request, h, marineLicence, 0)
+
+      expect(authenticatedPatchRequest).toHaveBeenCalledWith(
+        request,
+        apiRoutes.ADD_CONSTRUCTION_DRAWING,
+        { siteIndex: 0, id: marineLicence.id }
+      )
+      expect(updateMarineLicenceSiteDetails).toHaveBeenCalledWith(
+        request,
+        h,
+        0,
+        'constructionDrawings',
+        [{}]
+      )
+    })
+
+    test('does nothing when the site already has a construction drawing', async () => {
+      const withDrawing = {
+        id: 'test-id',
+        siteDetails: [{ constructionDrawings: [{ filename: 'existing.pdf' }] }]
+      }
+
+      await seedFirstConstructionDrawingIfNeeded(request, h, withDrawing, 0)
+
+      expect(authenticatedPatchRequest).not.toHaveBeenCalled()
+      expect(updateMarineLicenceSiteDetails).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/server/common/helpers/marine-licence/session-cache/site-details-utils.js
+++ b/src/server/common/helpers/marine-licence/session-cache/site-details-utils.js
@@ -1,3 +1,5 @@
+import { SUBTYPES_REQUIRING_CONSTRUCTION_DRAWING } from '#src/server/marine-licence/site-details/type-of-activity/constants.js'
+
 export const getSiteDetailsBySite = (project, siteIndex = 0) =>
   project.siteDetails?.[siteIndex] ?? {}
 
@@ -6,3 +8,18 @@ export const getActivityDetailsByIndex = (
   siteIndex = 0,
   activityIndex = 0
 ) => project.siteDetails?.[siteIndex].activityDetails[activityIndex] ?? {}
+
+export const siteHasOtherActivityRequiringDrawing = (
+  project,
+  siteIndex,
+  activityDetailsIndex
+) => {
+  const activityDetails =
+    project.siteDetails?.[siteIndex]?.activityDetails ?? []
+
+  return activityDetails.some(
+    (activity, index) =>
+      index !== activityDetailsIndex &&
+      SUBTYPES_REQUIRING_CONSTRUCTION_DRAWING.includes(activity.activitySubType)
+  )
+}

--- a/src/server/common/helpers/marine-licence/session-cache/site-details-utils.test.js
+++ b/src/server/common/helpers/marine-licence/session-cache/site-details-utils.test.js
@@ -1,7 +1,8 @@
 import { mockMarineLicenceApplication } from '#src/server/test-helpers/mocks/marine-licence-mocks.js'
 import {
   getSiteDetailsBySite,
-  getActivityDetailsByIndex
+  getActivityDetailsByIndex,
+  siteHasOtherActivityRequiringDrawing
 } from '#src/server/common/helpers/marine-licence/session-cache/site-details-utils.js'
 
 describe('getSiteDetailsBySite', () => {
@@ -59,5 +60,48 @@ describe('getActivityDetailsByIndex', () => {
   test('should correctly handle no existing data', () => {
     const site = getActivityDetailsByIndex({})
     expect(site).toEqual({})
+  })
+})
+
+describe('siteHasOtherActivityRequiringDrawing', () => {
+  const buildLicence = (activityDetails) => ({
+    ...mockMarineLicenceApplication,
+    siteDetails: [
+      { ...mockMarineLicenceApplication.siteDetails[0], activityDetails }
+    ]
+  })
+
+  test('returns true when another activity on the site still requires a drawing', () => {
+    const marineLicence = buildLicence([
+      { activitySubType: 'construction-type-2' },
+      { activitySubType: 'construction-type-1' }
+    ])
+
+    expect(siteHasOtherActivityRequiringDrawing(marineLicence, 0, 0)).toBe(true)
+  })
+
+  test('returns false when no other activity on the site requires a drawing', () => {
+    const marineLicence = buildLicence([
+      { activitySubType: 'construction-type-1' },
+      { activitySubType: 'construction-type-2' }
+    ])
+
+    expect(siteHasOtherActivityRequiringDrawing(marineLicence, 0, 0)).toBe(
+      false
+    )
+  })
+
+  test('ignores the activity at the given index itself', () => {
+    const marineLicence = buildLicence([
+      { activitySubType: 'construction-type-1' }
+    ])
+
+    expect(siteHasOtherActivityRequiringDrawing(marineLicence, 0, 0)).toBe(
+      false
+    )
+  })
+
+  test('returns false when there is no existing data', () => {
+    expect(siteHasOtherActivityRequiringDrawing({}, 0, 0)).toBe(false)
   })
 })

--- a/src/server/common/helpers/marine-licence/session-cache/site-utils.js
+++ b/src/server/common/helpers/marine-licence/session-cache/site-utils.js
@@ -27,6 +27,36 @@ export const validateSiteAndActivityParams = {
   }
 }
 
+export const validateSiteAndDrawingParams = {
+  method: (request, h) => {
+    const { site, drawing } = request.query
+
+    if (!site || !drawing) {
+      return h.redirect(marineLicenceRoutes.MARINE_LICENCE_TASK_LIST).takeover()
+    }
+
+    const siteIndex = Number.parseInt(site, 10) - 1
+    const drawingIndex = Number.parseInt(drawing, 10) - 1
+
+    const marineLicence = getMarineLicenceCache(request)
+    const siteDetails = marineLicence.siteDetails?.[siteIndex]
+
+    if (!siteDetails) {
+      return h.redirect(marineLicenceRoutes.MARINE_LICENCE_TASK_LIST).takeover()
+    }
+
+    const constructionDrawings = siteDetails.constructionDrawings ?? []
+    const isValidDrawingIndex =
+      drawingIndex === 0 || drawingIndex < constructionDrawings.length
+
+    if (!isValidDrawingIndex) {
+      return h.redirect(marineLicenceRoutes.MARINE_LICENCE_TASK_LIST).takeover()
+    }
+
+    return h.continue
+  }
+}
+
 export const validateSiteRequiredParam = {
   method: (request, h) => {
     const { site } = request.query

--- a/src/server/common/helpers/marine-licence/session-cache/site-utils.js
+++ b/src/server/common/helpers/marine-licence/session-cache/site-utils.js
@@ -47,7 +47,8 @@ export const validateSiteAndDrawingParams = {
 
     const constructionDrawings = siteDetails.constructionDrawings ?? []
     const isValidDrawingIndex =
-      drawingIndex === 0 || drawingIndex < constructionDrawings.length
+      drawingIndex >= 0 &&
+      (drawingIndex === 0 || drawingIndex < constructionDrawings.length)
 
     if (!isValidDrawingIndex) {
       return h.redirect(marineLicenceRoutes.MARINE_LICENCE_TASK_LIST).takeover()

--- a/src/server/common/helpers/marine-licence/session-cache/site-utils.test.js
+++ b/src/server/common/helpers/marine-licence/session-cache/site-utils.test.js
@@ -1,6 +1,7 @@
 import { vi } from 'vitest'
 import {
   validateSiteAndActivityParams,
+  validateSiteAndDrawingParams,
   validateSiteParam,
   validateSiteRequiredParam
 } from '#src/server/common/helpers/marine-licence/session-cache/site-utils.js'
@@ -68,6 +69,89 @@ describe('#validateSiteAndActivityParams', () => {
     const h = createMockH()
 
     const result = validateSiteAndActivityParams.method(request, h)
+
+    expect(result).toBe(h.continue)
+  })
+})
+
+describe('#validateSiteAndDrawingParams', () => {
+  beforeEach(() => {
+    vi.spyOn(utils, 'getMarineLicenceCache').mockReturnValue(
+      mockMarineLicenceApplication
+    )
+  })
+
+  test('redirects when site param is missing', () => {
+    const request = createMockRequest({ query: { drawing: '1' } })
+    const mockTakeover = vi.fn()
+    const h = createMockH({
+      redirect: vi.fn().mockReturnValue({ takeover: mockTakeover })
+    })
+
+    validateSiteAndDrawingParams.method(request, h)
+
+    expect(h.redirect).toHaveBeenCalledWith(
+      marineLicenceRoutes.MARINE_LICENCE_TASK_LIST
+    )
+    expect(mockTakeover).toHaveBeenCalled()
+  })
+
+  test('redirects when drawing param is missing', () => {
+    const request = createMockRequest({ query: { site: '1' } })
+    const h = createMockH()
+
+    validateSiteAndDrawingParams.method(request, h)
+
+    expect(h.redirect).toHaveBeenCalledWith(
+      marineLicenceRoutes.MARINE_LICENCE_TASK_LIST
+    )
+  })
+
+  test('redirects when site does not exist in cache', () => {
+    const request = createMockRequest({ query: { site: '99', drawing: '1' } })
+    const h = createMockH()
+
+    validateSiteAndDrawingParams.method(request, h)
+
+    expect(h.redirect).toHaveBeenCalledWith(
+      marineLicenceRoutes.MARINE_LICENCE_TASK_LIST
+    )
+  })
+
+  test('redirects when the drawing index does not exist for the site', () => {
+    const request = createMockRequest({ query: { site: '1', drawing: '2' } })
+    const h = createMockH()
+
+    validateSiteAndDrawingParams.method(request, h)
+
+    expect(h.redirect).toHaveBeenCalledWith(
+      marineLicenceRoutes.MARINE_LICENCE_TASK_LIST
+    )
+  })
+
+  test('continues for drawing 1 even when no drawings exist yet', () => {
+    const request = createMockRequest({ query: { site: '1', drawing: '1' } })
+    const h = createMockH()
+
+    const result = validateSiteAndDrawingParams.method(request, h)
+
+    expect(result).toBe(h.continue)
+  })
+
+  test('continues for an existing drawing index', () => {
+    vi.spyOn(utils, 'getMarineLicenceCache').mockReturnValue({
+      ...mockMarineLicenceApplication,
+      siteDetails: [
+        {
+          ...mockMarineLicenceApplication.siteDetails[0],
+          constructionDrawings: [{ filename: 'a.pdf' }, { filename: 'b.pdf' }]
+        }
+      ]
+    })
+    const request = createMockRequest({ query: { site: '1', drawing: '2' } })
+    const h = createMockH()
+
+    const result = validateSiteAndDrawingParams.method(request, h)
 
     expect(result).toBe(h.continue)
   })

--- a/src/server/common/helpers/marine-licence/session-cache/site-utils.test.js
+++ b/src/server/common/helpers/marine-licence/session-cache/site-utils.test.js
@@ -107,30 +107,21 @@ describe('#validateSiteAndDrawingParams', () => {
     )
   })
 
-  test('redirects when site does not exist in cache', () => {
-    const request = createMockRequest({ query: { site: '99', drawing: '1' } })
-    const h = createMockH()
-
-    validateSiteAndDrawingParams.method(request, h)
-
-    expect(h.redirect).toHaveBeenCalledWith(
-      marineLicenceRoutes.MARINE_LICENCE_TASK_LIST
-    )
-  })
-
-  test('redirects when the drawing index does not exist for the site', () => {
-    const request = createMockRequest({ query: { site: '1', drawing: '2' } })
-    const h = createMockH()
-
-    validateSiteAndDrawingParams.method(request, h)
-
-    expect(h.redirect).toHaveBeenCalledWith(
-      marineLicenceRoutes.MARINE_LICENCE_TASK_LIST
-    )
-  })
-
-  test('redirects when drawing is 0', () => {
-    const request = createMockRequest({ query: { site: '1', drawing: '0' } })
+  test.each([
+    {
+      name: 'redirects when site does not exist in cache',
+      query: { site: '99', drawing: '1' }
+    },
+    {
+      name: 'redirects when the drawing index does not exist for the site',
+      query: { site: '1', drawing: '2' }
+    },
+    {
+      name: 'redirects when drawing number is zero',
+      query: { site: '1', drawing: '0' }
+    }
+  ])('$name', ({ query }) => {
+    const request = createMockRequest({ query })
     const h = createMockH()
 
     validateSiteAndDrawingParams.method(request, h)

--- a/src/server/common/helpers/marine-licence/session-cache/site-utils.test.js
+++ b/src/server/common/helpers/marine-licence/session-cache/site-utils.test.js
@@ -129,6 +129,17 @@ describe('#validateSiteAndDrawingParams', () => {
     )
   })
 
+  test('redirects when drawing is 0', () => {
+    const request = createMockRequest({ query: { site: '1', drawing: '0' } })
+    const h = createMockH()
+
+    validateSiteAndDrawingParams.method(request, h)
+
+    expect(h.redirect).toHaveBeenCalledWith(
+      marineLicenceRoutes.MARINE_LICENCE_TASK_LIST
+    )
+  })
+
   test('continues for drawing 1 even when no drawings exist yet', () => {
     const request = createMockRequest({ query: { site: '1', drawing: '1' } })
     const h = createMockH()

--- a/src/server/common/helpers/site-details/site-name.js
+++ b/src/server/common/helpers/site-details/site-name.js
@@ -4,6 +4,10 @@ export const getSiteDataFromParam = (query = {}) => ({
   ...(query.activity && {
     activityDetailsIndex: Number.parseInt(query.activity, 10) - 1,
     activityDetailsNumber: Number.parseInt(query.activity, 10)
+  }),
+  ...(query.drawing && {
+    drawingIndex: Number.parseInt(query.drawing, 10) - 1,
+    drawingNumber: Number.parseInt(query.drawing, 10)
   })
 })
 

--- a/src/server/common/helpers/site-details/site-name.test.js
+++ b/src/server/common/helpers/site-details/site-name.test.js
@@ -12,6 +12,16 @@ describe('#site name utils', () => {
       })
     })
 
+    test('returns correct values when site and drawing params are provided', () => {
+      const result = getSiteDataFromParam({ site: '1', drawing: '2' })
+      expect(result).toEqual({
+        siteIndex: 0,
+        siteNumber: 1,
+        drawingIndex: 1,
+        drawingNumber: 2
+      })
+    })
+
     test('returns defaults when called with all undefined value', () => {
       const result = getSiteDataFromParam(undefined)
       expect(result).toEqual({

--- a/src/server/marine-licence/site-details/confirm-change-activity-type/controller.js
+++ b/src/server/marine-licence/site-details/confirm-change-activity-type/controller.js
@@ -1,11 +1,17 @@
 import {
   getMarineLicenceCache,
-  updateMarineLicenceSiteActivityDetails
+  updateMarineLicenceSiteActivityDetails,
+  updateMarineLicenceSiteDetails
 } from '#src/server/common/helpers/marine-licence/session-cache/utils.js'
+import { siteHasOtherActivityRequiringDrawing } from '#src/server/common/helpers/marine-licence/session-cache/site-details-utils.js'
 import { getSiteDataFromParam } from '#src/server/common/helpers/site-details/site-name.js'
 import { validateSiteAndActivityParams } from '#src/server/common/helpers/marine-licence/session-cache/site-utils.js'
 import { getActivityVariantFromSubType } from '#src/server/common/helpers/activity-details/activity-variants.js'
-import { marineLicenceRoutes } from '#src/server/common/constants/routes.js'
+import {
+  apiRoutes,
+  marineLicenceRoutes
+} from '#src/server/common/constants/routes.js'
+import { deleteConstructionDrawingsRequest } from '#src/server/common/helpers/marine-licence/construction-drawings-request.js'
 import { formatActivitySubTypeLabel } from '#src/server/common/helpers/review-site-details/activity-details.js'
 import {
   activityTypeValues,
@@ -80,6 +86,16 @@ export const confirmChangeActivityTypeSubmitController = {
       activityDetailsNumber
     } = getSiteDataFromParam({ site, activity })
 
+    const marineLicence = getMarineLicenceCache(request)
+    const hasExistingDrawings =
+      marineLicence.siteDetails[siteIndex]?.constructionDrawings?.length > 0
+    const otherActivityStillRequiresDrawing =
+      siteHasOtherActivityRequiringDrawing(
+        marineLicence,
+        siteIndex,
+        activityDetailsIndex
+      )
+
     await updateMarineLicenceSiteActivityDetails(
       request,
       h,
@@ -91,6 +107,23 @@ export const confirmChangeActivityTypeSubmitController = {
         activities: null
       }
     )
+
+    if (hasExistingDrawings && !otherActivityStillRequiresDrawing) {
+      await updateMarineLicenceSiteDetails(
+        request,
+        h,
+        siteIndex,
+        'constructionDrawings',
+        null
+      )
+      await deleteConstructionDrawingsRequest(request, {
+        route: apiRoutes.DELETE_CONSTRUCTION_DRAWINGS,
+        payload: { id: marineLicence.id, siteIndex },
+        logAction: 'marine-licence:delete-construction-drawings-failed',
+        reason: `siteIndex=${siteIndex}`,
+        errorMessage: 'Error deleting construction drawings'
+      })
+    }
 
     const activityVariant = getActivityVariantFromSubType(activitySubType)
 

--- a/src/server/marine-licence/site-details/confirm-change-activity-type/controller.test.js
+++ b/src/server/marine-licence/site-details/confirm-change-activity-type/controller.test.js
@@ -5,7 +5,11 @@ import {
   confirmChangeActivityTypeSubmitController
 } from '#src/server/marine-licence/site-details/confirm-change-activity-type/controller.js'
 import * as cacheUtils from '#src/server/common/helpers/marine-licence/session-cache/utils.js'
-import { marineLicenceRoutes } from '#src/server/common/constants/routes.js'
+import * as authenticatedRequests from '#src/server/common/helpers/authenticated-requests.js'
+import {
+  apiRoutes,
+  marineLicenceRoutes
+} from '#src/server/common/constants/routes.js'
 import {
   createMockRequest,
   createMockH
@@ -13,6 +17,7 @@ import {
 import { mockMarineLicenceApplication } from '#src/server/test-helpers/mocks/marine-licence-mocks.js'
 
 vi.mock('~/src/server/common/helpers/marine-licence/session-cache/utils.js')
+vi.mock('~/src/server/common/helpers/authenticated-requests.js')
 
 describe('confirmChangeActivityTypeController', () => {
   beforeEach(() => {
@@ -176,6 +181,142 @@ describe('confirmChangeActivityTypeController', () => {
       expect(h.redirect).toHaveBeenCalledWith(
         marineLicenceRoutes.MARINE_LICENCE_TASK_LIST
       )
+    })
+
+    it('deletes the site construction drawings when the site has existing drawings and no other activity needs them', async () => {
+      vi.mocked(cacheUtils.getMarineLicenceCache).mockReturnValue({
+        ...mockMarineLicenceApplication,
+        siteDetails: [
+          {
+            ...mockMarineLicenceApplication.siteDetails[0],
+            activityDetails: [
+              mockMarineLicenceApplication.siteDetails[0].activityDetails[0]
+            ],
+            constructionDrawings: [
+              { filename: 'drawing-1.pdf' },
+              { filename: 'drawing-2.pdf' }
+            ]
+          }
+        ]
+      })
+
+      const request = createMockRequest({
+        payload: {
+          site: '1',
+          activity: '1',
+          activityType: 'construction',
+          activitySubType: 'construction-type-2'
+        }
+      })
+      const h = createMockH()
+
+      await confirmChangeActivityTypeSubmitController.handler(request, h)
+
+      expect(cacheUtils.updateMarineLicenceSiteDetails).toHaveBeenCalledWith(
+        request,
+        h,
+        0,
+        'constructionDrawings',
+        null
+      )
+      expect(
+        authenticatedRequests.authenticatedPatchRequest
+      ).toHaveBeenCalledWith(request, apiRoutes.DELETE_CONSTRUCTION_DRAWINGS, {
+        id: mockMarineLicenceApplication.id,
+        siteIndex: 0
+      })
+    })
+
+    it('does not delete the site construction drawings when another activity on the site still requires one', async () => {
+      vi.mocked(cacheUtils.getMarineLicenceCache).mockReturnValue({
+        ...mockMarineLicenceApplication,
+        siteDetails: [
+          {
+            ...mockMarineLicenceApplication.siteDetails[0],
+            activityDetails: [
+              {
+                ...mockMarineLicenceApplication.siteDetails[0]
+                  .activityDetails[0],
+                activitySubType: 'construction-type-1'
+              },
+              {
+                ...mockMarineLicenceApplication.siteDetails[0]
+                  .activityDetails[0],
+                activitySubType: 'construction-type-1'
+              }
+            ],
+            constructionDrawings: [{ filename: 'drawing-1.pdf' }]
+          }
+        ]
+      })
+
+      const request = createMockRequest({
+        payload: {
+          site: '1',
+          activity: '1',
+          activityType: 'construction',
+          activitySubType: 'construction-type-2'
+        }
+      })
+      const h = createMockH()
+
+      await confirmChangeActivityTypeSubmitController.handler(request, h)
+
+      expect(cacheUtils.updateMarineLicenceSiteDetails).not.toHaveBeenCalled()
+      expect(
+        authenticatedRequests.authenticatedPatchRequest
+      ).not.toHaveBeenCalled()
+    })
+
+    it('does not attempt to delete drawings when the site has none', async () => {
+      const request = createMockRequest({
+        payload: {
+          site: '1',
+          activity: '1',
+          activityType: 'construction',
+          activitySubType: 'construction-type-2'
+        }
+      })
+      const h = createMockH()
+
+      await confirmChangeActivityTypeSubmitController.handler(request, h)
+
+      expect(cacheUtils.updateMarineLicenceSiteDetails).not.toHaveBeenCalled()
+      expect(
+        authenticatedRequests.authenticatedPatchRequest
+      ).not.toHaveBeenCalled()
+    })
+
+    it('throws a Boom error when the delete request fails', async () => {
+      vi.mocked(cacheUtils.getMarineLicenceCache).mockReturnValue({
+        ...mockMarineLicenceApplication,
+        siteDetails: [
+          {
+            ...mockMarineLicenceApplication.siteDetails[0],
+            activityDetails: [
+              mockMarineLicenceApplication.siteDetails[0].activityDetails[0]
+            ],
+            constructionDrawings: [{ filename: 'drawing-1.pdf' }]
+          }
+        ]
+      })
+      vi.mocked(
+        authenticatedRequests.authenticatedPatchRequest
+      ).mockRejectedValueOnce(new Error('API error'))
+
+      const request = createMockRequest({
+        payload: {
+          site: '1',
+          activity: '1',
+          activityType: 'construction',
+          activitySubType: 'construction-type-2'
+        }
+      })
+      const h = createMockH()
+
+      await expect(
+        confirmChangeActivityTypeSubmitController.handler(request, h)
+      ).rejects.toThrow('Error deleting construction drawings')
     })
   })
 })

--- a/src/server/marine-licence/site-details/delete-construction-drawing/controller.js
+++ b/src/server/marine-licence/site-details/delete-construction-drawing/controller.js
@@ -1,0 +1,87 @@
+import Boom from '@hapi/boom'
+import {
+  apiRoutes,
+  marineLicenceRoutes
+} from '#src/server/common/constants/routes.js'
+import { getMarineLicenceCache } from '#src/server/common/helpers/marine-licence/session-cache/utils.js'
+import { getSiteDataFromParam } from '#src/server/common/helpers/site-details/site-name.js'
+import { validateSiteAndDrawingParams } from '#src/server/common/helpers/marine-licence/session-cache/site-utils.js'
+import { authenticatedPatchRequest } from '#src/server/common/helpers/authenticated-requests.js'
+
+export const DELETE_CONSTRUCTION_DRAWING_VIEW_ROUTE =
+  'marine-licence/site-details/delete-construction-drawing/index'
+
+const DELETE_CONSTRUCTION_DRAWING_PAGE_TITLE = (siteNumber, drawingNumber) =>
+  `Are you sure you want to delete Site ${siteNumber} construction drawing ${drawingNumber}?`
+
+export const deleteConstructionDrawingController = {
+  options: {
+    pre: [validateSiteAndDrawingParams]
+  },
+  handler(request, h) {
+    const marineLicence = getMarineLicenceCache(request)
+    const { siteNumber, siteIndex, drawingIndex, drawingNumber } =
+      getSiteDataFromParam(request.query)
+
+    if (drawingNumber === 1) {
+      return h.redirect(marineLicenceRoutes.MARINE_LICENCE_REVIEW_SITE_DETAILS)
+    }
+
+    const heading = DELETE_CONSTRUCTION_DRAWING_PAGE_TITLE(
+      siteNumber,
+      drawingNumber
+    )
+
+    return h.view(DELETE_CONSTRUCTION_DRAWING_VIEW_ROUTE, {
+      pageTitle: heading,
+      heading,
+      siteNumber,
+      siteIndex,
+      drawingIndex,
+      drawingNumber,
+      projectName: marineLicence.projectName,
+      backLink: marineLicenceRoutes.MARINE_LICENCE_REVIEW_SITE_DETAILS,
+      marineLicenceRoutes
+    })
+  }
+}
+
+export const deleteConstructionDrawingSubmitController = {
+  options: {
+    pre: [validateSiteAndDrawingParams]
+  },
+  async handler(request, h) {
+    const marineLicence = getMarineLicenceCache(request)
+    const { siteIndex, drawingIndex } = request.payload
+
+    const parsedSiteIndex = Number.parseInt(siteIndex, 10)
+    const parsedDrawingIndex = Number.parseInt(drawingIndex, 10)
+
+    try {
+      await authenticatedPatchRequest(
+        request,
+        apiRoutes.DELETE_CONSTRUCTION_DRAWING,
+        {
+          id: marineLicence.id,
+          siteIndex: parsedSiteIndex,
+          drawingIndex: parsedDrawingIndex
+        }
+      )
+
+      return h.redirect(marineLicenceRoutes.MARINE_LICENCE_REVIEW_SITE_DETAILS)
+    } catch (error) {
+      request.logger.error(
+        {
+          err: error,
+          event: {
+            action: 'marine-licence:delete-construction-drawing-failed',
+            reference: marineLicence.id,
+            reason: `siteIndex=${parsedSiteIndex} drawingIndex=${parsedDrawingIndex}`
+          }
+        },
+        'Error deleting construction drawing'
+      )
+      throw Boom.internal('Error deleting construction drawing')
+    }
+  }
+}

--- a/src/server/marine-licence/site-details/delete-construction-drawing/controller.js
+++ b/src/server/marine-licence/site-details/delete-construction-drawing/controller.js
@@ -11,7 +11,7 @@ import { authenticatedPatchRequest } from '#src/server/common/helpers/authentica
 export const DELETE_CONSTRUCTION_DRAWING_VIEW_ROUTE =
   'marine-licence/site-details/delete-construction-drawing/index'
 
-const DELETE_CONSTRUCTION_DRAWING_PAGE_TITLE = (siteNumber, drawingNumber) =>
+const deleteConstructionDrawingPageTitle = (siteNumber, drawingNumber) =>
   `Are you sure you want to delete Site ${siteNumber} construction drawing ${drawingNumber}?`
 
 export const deleteConstructionDrawingController = {
@@ -27,7 +27,7 @@ export const deleteConstructionDrawingController = {
       return h.redirect(marineLicenceRoutes.MARINE_LICENCE_REVIEW_SITE_DETAILS)
     }
 
-    const heading = DELETE_CONSTRUCTION_DRAWING_PAGE_TITLE(
+    const heading = deleteConstructionDrawingPageTitle(
       siteNumber,
       drawingNumber
     )

--- a/src/server/marine-licence/site-details/delete-construction-drawing/controller.js
+++ b/src/server/marine-licence/site-details/delete-construction-drawing/controller.js
@@ -56,6 +56,10 @@ export const deleteConstructionDrawingSubmitController = {
     const parsedSiteIndex = Number.parseInt(siteIndex, 10)
     const parsedDrawingIndex = Number.parseInt(drawingIndex, 10)
 
+    if (parsedDrawingIndex === 0) {
+      return h.redirect(marineLicenceRoutes.MARINE_LICENCE_REVIEW_SITE_DETAILS)
+    }
+
     await deleteConstructionDrawingsRequest(request, {
       route: apiRoutes.DELETE_CONSTRUCTION_DRAWING,
       payload: {

--- a/src/server/marine-licence/site-details/delete-construction-drawing/controller.js
+++ b/src/server/marine-licence/site-details/delete-construction-drawing/controller.js
@@ -1,4 +1,3 @@
-import Boom from '@hapi/boom'
 import {
   apiRoutes,
   marineLicenceRoutes
@@ -6,7 +5,7 @@ import {
 import { getMarineLicenceCache } from '#src/server/common/helpers/marine-licence/session-cache/utils.js'
 import { getSiteDataFromParam } from '#src/server/common/helpers/site-details/site-name.js'
 import { validateSiteAndDrawingParams } from '#src/server/common/helpers/marine-licence/session-cache/site-utils.js'
-import { authenticatedPatchRequest } from '#src/server/common/helpers/authenticated-requests.js'
+import { deleteConstructionDrawingsRequest } from '#src/server/common/helpers/marine-licence/construction-drawings-request.js'
 
 export const DELETE_CONSTRUCTION_DRAWING_VIEW_ROUTE =
   'marine-licence/site-details/delete-construction-drawing/index'
@@ -57,31 +56,18 @@ export const deleteConstructionDrawingSubmitController = {
     const parsedSiteIndex = Number.parseInt(siteIndex, 10)
     const parsedDrawingIndex = Number.parseInt(drawingIndex, 10)
 
-    try {
-      await authenticatedPatchRequest(
-        request,
-        apiRoutes.DELETE_CONSTRUCTION_DRAWING,
-        {
-          id: marineLicence.id,
-          siteIndex: parsedSiteIndex,
-          drawingIndex: parsedDrawingIndex
-        }
-      )
+    await deleteConstructionDrawingsRequest(request, {
+      route: apiRoutes.DELETE_CONSTRUCTION_DRAWING,
+      payload: {
+        id: marineLicence.id,
+        siteIndex: parsedSiteIndex,
+        drawingIndex: parsedDrawingIndex
+      },
+      logAction: 'marine-licence:delete-construction-drawing-failed',
+      reason: `siteIndex=${parsedSiteIndex} drawingIndex=${parsedDrawingIndex}`,
+      errorMessage: 'Error deleting construction drawing'
+    })
 
-      return h.redirect(marineLicenceRoutes.MARINE_LICENCE_REVIEW_SITE_DETAILS)
-    } catch (error) {
-      request.logger.error(
-        {
-          err: error,
-          event: {
-            action: 'marine-licence:delete-construction-drawing-failed',
-            reference: marineLicence.id,
-            reason: `siteIndex=${parsedSiteIndex} drawingIndex=${parsedDrawingIndex}`
-          }
-        },
-        'Error deleting construction drawing'
-      )
-      throw Boom.internal('Error deleting construction drawing')
-    }
+    return h.redirect(marineLicenceRoutes.MARINE_LICENCE_REVIEW_SITE_DETAILS)
   }
 }

--- a/src/server/marine-licence/site-details/delete-construction-drawing/controller.test.js
+++ b/src/server/marine-licence/site-details/delete-construction-drawing/controller.test.js
@@ -1,0 +1,131 @@
+import { vi } from 'vitest'
+import {
+  DELETE_CONSTRUCTION_DRAWING_VIEW_ROUTE,
+  deleteConstructionDrawingController,
+  deleteConstructionDrawingSubmitController
+} from '#src/server/marine-licence/site-details/delete-construction-drawing/controller.js'
+import * as cacheUtils from '#src/server/common/helpers/marine-licence/session-cache/utils.js'
+import * as authenticatedRequests from '#src/server/common/helpers/authenticated-requests.js'
+import {
+  apiRoutes,
+  marineLicenceRoutes
+} from '#src/server/common/constants/routes.js'
+import {
+  createMockRequest,
+  createMockH
+} from '#src/server/test-helpers/mocks/helpers.js'
+import { mockMarineLicenceApplication } from '#src/server/test-helpers/mocks/marine-licence-mocks.js'
+
+vi.mock('~/src/server/common/helpers/marine-licence/session-cache/utils.js')
+vi.mock('~/src/server/common/helpers/authenticated-requests.js')
+
+const mockLicenceWithTwoDrawings = {
+  ...mockMarineLicenceApplication,
+  siteDetails: [
+    {
+      ...mockMarineLicenceApplication.siteDetails[0],
+      constructionDrawings: [
+        {
+          filename: 'drawing-one.pdf',
+          s3Location: { s3Bucket: 'b', s3Key: 'k1', checksumSha256: 'c1' }
+        },
+        {
+          filename: 'drawing-two.pdf',
+          s3Location: { s3Bucket: 'b', s3Key: 'k2', checksumSha256: 'c2' }
+        }
+      ]
+    }
+  ]
+}
+
+describe('deleteConstructionDrawingController', () => {
+  beforeEach(() => {
+    vi.mocked(cacheUtils.getMarineLicenceCache).mockReturnValue(
+      mockLicenceWithTwoDrawings
+    )
+  })
+
+  describe('GET handler', () => {
+    it('redirects to review site details when attempting to delete the first drawing', () => {
+      const request = createMockRequest({
+        query: { site: '1', drawing: '1' }
+      })
+      const h = createMockH()
+
+      deleteConstructionDrawingController.handler(request, h)
+
+      expect(h.redirect).toHaveBeenCalledWith(
+        marineLicenceRoutes.MARINE_LICENCE_REVIEW_SITE_DETAILS
+      )
+      expect(h.view).not.toHaveBeenCalled()
+    })
+
+    it('renders the confirmation view for a deletable drawing', () => {
+      const request = createMockRequest({
+        query: { site: '1', drawing: '2' }
+      })
+      const h = createMockH()
+
+      deleteConstructionDrawingController.handler(request, h)
+
+      expect(h.view).toHaveBeenCalledWith(
+        DELETE_CONSTRUCTION_DRAWING_VIEW_ROUTE,
+        {
+          pageTitle:
+            'Are you sure you want to delete Site 1 construction drawing 2?',
+          heading:
+            'Are you sure you want to delete Site 1 construction drawing 2?',
+          siteNumber: 1,
+          siteIndex: 0,
+          drawingIndex: 1,
+          drawingNumber: 2,
+          projectName: mockMarineLicenceApplication.projectName,
+          backLink: marineLicenceRoutes.MARINE_LICENCE_REVIEW_SITE_DETAILS,
+          marineLicenceRoutes
+        }
+      )
+    })
+  })
+
+  describe('POST handler', () => {
+    it('calls authenticatedPatchRequest with the correct payload and redirects to review', async () => {
+      vi.mocked(
+        authenticatedRequests.authenticatedPatchRequest
+      ).mockResolvedValue({})
+
+      const request = createMockRequest({
+        payload: { siteIndex: '0', drawingIndex: '1' }
+      })
+      const h = createMockH()
+
+      await deleteConstructionDrawingSubmitController.handler(request, h)
+
+      expect(
+        vi.mocked(authenticatedRequests.authenticatedPatchRequest)
+      ).toHaveBeenCalledWith(request, apiRoutes.DELETE_CONSTRUCTION_DRAWING, {
+        id: mockMarineLicenceApplication.id,
+        siteIndex: 0,
+        drawingIndex: 1
+      })
+
+      expect(h.redirect).toHaveBeenCalledWith(
+        marineLicenceRoutes.MARINE_LICENCE_REVIEW_SITE_DETAILS
+      )
+    })
+
+    it('throws when the API call fails', async () => {
+      vi.mocked(
+        authenticatedRequests.authenticatedPatchRequest
+      ).mockRejectedValueOnce(new Error('API error'))
+
+      const request = createMockRequest({
+        payload: { siteIndex: '0', drawingIndex: '1' }
+      })
+      const h = createMockH()
+
+      await expect(
+        deleteConstructionDrawingSubmitController.handler(request, h)
+      ).rejects.toThrow('Error deleting construction drawing')
+    })
+  })
+})

--- a/src/server/marine-licence/site-details/delete-construction-drawing/index.js
+++ b/src/server/marine-licence/site-details/delete-construction-drawing/index.js
@@ -1,0 +1,18 @@
+import { marineLicenceRoutes } from '#src/server/common/constants/routes.js'
+import {
+  deleteConstructionDrawingController,
+  deleteConstructionDrawingSubmitController
+} from '#src/server/marine-licence/site-details/delete-construction-drawing/controller.js'
+
+export const deleteConstructionDrawingRoutes = [
+  {
+    method: 'GET',
+    path: marineLicenceRoutes.MARINE_LICENCE_DELETE_CONSTRUCTION_DRAWING,
+    ...deleteConstructionDrawingController
+  },
+  {
+    method: 'POST',
+    path: marineLicenceRoutes.MARINE_LICENCE_DELETE_CONSTRUCTION_DRAWING,
+    ...deleteConstructionDrawingSubmitController
+  }
+]

--- a/src/server/marine-licence/site-details/delete-construction-drawing/index.njk
+++ b/src/server/marine-licence/site-details/delete-construction-drawing/index.njk
@@ -1,0 +1,51 @@
+{% extends 'layouts/page.njk' %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "cancel-button/macro.njk" import appCancelButton %}
+
+{% block beforeContent %}
+  {{ super() }}
+  <nav>
+    {{ govukBackLink({
+      text: "Back",
+      href: backLink
+    }) }}
+  </nav>
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">{{ heading }}</h1>
+
+      {{ govukInsetText({
+        text: 'Site ' + siteNumber + ' - Construction drawing ' + drawingNumber
+      }) }}
+
+      <form method="POST">
+        <input type="hidden" name="csrfToken" value="{{ csrfToken }}">
+        <input type="hidden" name="siteIndex" value="{{ siteIndex }}">
+        <input type="hidden" name="drawingIndex" value="{{ drawingIndex }}">
+
+        <div class="govuk-button-group">
+          {{ govukButton({
+            text: "Yes, delete file upload",
+            preventDoubleClick: true,
+            classes: "govuk-button--warning",
+            type: "submit",
+            attributes: {
+              "data-module": "govuk-button"
+            }
+          }) }}
+
+          {{ appCancelButton({
+            cancelLink: marineLicenceRoutes.MARINE_LICENCE_REVIEW_SITE_DETAILS
+          }) }}
+        </div>
+      </form>
+
+    </div>
+  </div>
+{% endblock %}

--- a/src/server/marine-licence/site-details/index.js
+++ b/src/server/marine-licence/site-details/index.js
@@ -22,6 +22,8 @@ import { deleteSiteRoutes } from '#src/server/marine-licence/site-details/delete
 import { deleteAllSitesRoutes } from '#src/server/marine-licence/site-details/delete-all-sites/index.js'
 import { changeSiteLocationRoutes } from '#src/server/marine-licence/site-details/change-site-location/index.js'
 import { uploadConstructionDrawingRoutes } from '#src/server/marine-licence/site-details/upload-construction-drawing/index.js'
+import { uploadConstructionDrawingWaitRoutes } from '#src/server/marine-licence/site-details/upload-construction-drawing-wait/index.js'
+import { deleteConstructionDrawingRoutes } from '#src/server/marine-licence/site-details/delete-construction-drawing/index.js'
 import { confirmChangeActivityTypeRoutes } from '#src/server/marine-licence/site-details/confirm-change-activity-type/index.js'
 
 export const siteDetailsRoutes = [
@@ -49,5 +51,7 @@ export const siteDetailsRoutes = [
   ...deleteAllSitesRoutes,
   ...changeSiteLocationRoutes,
   ...uploadConstructionDrawingRoutes,
+  ...uploadConstructionDrawingWaitRoutes,
+  ...deleteConstructionDrawingRoutes,
   ...confirmChangeActivityTypeRoutes
 ]

--- a/src/server/marine-licence/site-details/review-site-details/controller.js
+++ b/src/server/marine-licence/site-details/review-site-details/controller.js
@@ -132,10 +132,14 @@ async function handleAddConstructionDrawing(
 ) {
   const siteIndex = Number.parseInt(siteNumber, 10) - 1
 
-  // The first drawing card renders even before any backend entry exists, so
-  // "visible" count is always at least 1 - adding another must land one
-  // past whatever's currently shown, which may mean creating two entries
-  // the very first time (to materialise the already-visible first card too).
+  // The first drawing is normally seeded when the drawing-requiring activity
+  // type is set (see typeOfActivitySubmitController), so this loop usually
+  // adds exactly one. It's a defensive fallback for sites saved before that
+  // seeding existed: the drawing card always renders a first, placeholder
+  // card even with zero backend entries, so on legacy data with none yet,
+  // "visible" count is still at least 1 and we must land one past it -
+  // creating two entries in that one case (to materialise the already-visible
+  // first card too).
   const { constructionDrawings } = marineLicence.siteDetails[siteIndex]
   const currentDrawings = Array.isArray(constructionDrawings)
     ? constructionDrawings

--- a/src/server/marine-licence/site-details/review-site-details/controller.js
+++ b/src/server/marine-licence/site-details/review-site-details/controller.js
@@ -132,8 +132,8 @@ async function handleAddConstructionDrawing(
 ) {
   const siteIndex = Number.parseInt(siteNumber, 10) - 1
 
-  // The first drawing is normally seeded when the drawing-requiring activity
-  // type is set (see typeOfActivitySubmitController), so this loop usually
+  // The first drawing is normally seeded when the drawing-requiring
+  // checkbox page is submitted (see selectActivitySubmitController), so this loop usually
   // adds exactly one. It's a defensive fallback for sites saved before that
   // seeding existed: the drawing card always renders a first, placeholder
   // card even with zero backend entries, so on legacy data with none yet,

--- a/src/server/marine-licence/site-details/review-site-details/controller.js
+++ b/src/server/marine-licence/site-details/review-site-details/controller.js
@@ -124,6 +124,43 @@ async function handleAddActivity(request, h, marineLicence, siteNumber) {
   )
 }
 
+async function handleAddConstructionDrawing(
+  request,
+  h,
+  marineLicence,
+  siteNumber
+) {
+  const siteIndex = Number.parseInt(siteNumber, 10) - 1
+
+  // The first drawing card renders even before any backend entry exists, so
+  // "visible" count is always at least 1 - adding another must land one
+  // past whatever's currently shown, which may mean creating two entries
+  // the very first time (to materialise the already-visible first card too).
+  const { constructionDrawings } = marineLicence.siteDetails[siteIndex]
+  const currentDrawings = Array.isArray(constructionDrawings)
+    ? constructionDrawings
+    : []
+  const visibleCount = Math.max(currentDrawings.length, 1)
+  const drawingsToAdd = visibleCount + 1 - currentDrawings.length
+
+  for (let count = 0; count < drawingsToAdd; count += 1) {
+    await authenticatedPatchRequest(
+      request,
+      apiRoutes.ADD_CONSTRUCTION_DRAWING,
+      {
+        siteIndex,
+        id: marineLicence.id
+      }
+    )
+  }
+
+  const newDrawingNumber = visibleCount + 1
+
+  return h.redirect(
+    `${marineLicenceRoutes.MARINE_LICENCE_REVIEW_SITE_DETAILS}#construction-drawing-site-${siteNumber}-${newDrawingNumber}`
+  )
+}
+
 function handleReturnToRedirect(request, h) {
   const returnTo = request.yar.flash(RETURN_TO_CACHE_KEY)
   const redirectPath = Array.isArray(returnTo) ? returnTo[0] : returnTo
@@ -201,7 +238,7 @@ async function confirmSiteDetails(
 export const reviewSiteDetailsSubmitController = {
   async handler(request, h) {
     const { payload } = request
-    const { add, addActivity, siteNumber } = payload
+    const { add, addActivity, addConstructionDrawing, siteNumber } = payload
     const marineLicence = getMarineLicenceCache(request)
     const fromCheckYourAnswers = request.query?.from === 'check-your-answers'
     const returnToCheckYourAnswers = fromCheckYourAnswers
@@ -214,6 +251,10 @@ export const reviewSiteDetailsSubmitController = {
 
     if (addActivity) {
       return handleAddActivity(request, h, marineLicence, siteNumber)
+    }
+
+    if (addConstructionDrawing) {
+      return handleAddConstructionDrawing(request, h, marineLicence, siteNumber)
     }
 
     const marineLicenceService = getMarineLicenceService(request)

--- a/src/server/marine-licence/site-details/review-site-details/controller.test.js
+++ b/src/server/marine-licence/site-details/review-site-details/controller.test.js
@@ -647,5 +647,99 @@ describe('#reviewSiteDetails', () => {
         `${marineLicenceRoutes.MARINE_LICENCE_REVIEW_SITE_DETAILS}#activity-details-site-1-activity-2`
       )
     })
+
+    test('adds two drawing slots the first time, so the already-visible first card is materialised too', async () => {
+      getMarineLicenceCacheSpy.mockReturnValue({
+        id: 'test-id',
+        siteDetails: [{ activityDetails: [] }]
+      })
+      vi.mocked(
+        authenticatedRequests.authenticatedPatchRequest
+      ).mockResolvedValue({})
+
+      const h = createMockHandler('redirect')
+      const request = createMockRequest({
+        payload: {
+          addConstructionDrawing: 'addConstructionDrawing',
+          siteNumber: '1'
+        }
+      })
+
+      await reviewSiteDetailsSubmitController.handler(request, h)
+
+      expect(
+        vi.mocked(authenticatedRequests.authenticatedPatchRequest)
+      ).toHaveBeenCalledTimes(2)
+      expect(
+        vi.mocked(authenticatedRequests.authenticatedPatchRequest)
+      ).toHaveBeenCalledWith(request, apiRoutes.ADD_CONSTRUCTION_DRAWING, {
+        siteIndex: 0,
+        id: 'test-id'
+      })
+      expect(h.redirect).toHaveBeenCalledWith(
+        `${marineLicenceRoutes.MARINE_LICENCE_REVIEW_SITE_DETAILS}#construction-drawing-site-1-2`
+      )
+    })
+
+    test('adds a single drawing slot when one already exists', async () => {
+      getMarineLicenceCacheSpy.mockReturnValue({
+        id: 'test-id',
+        siteDetails: [
+          {
+            activityDetails: [],
+            constructionDrawings: [{ filename: 'existing.pdf' }]
+          }
+        ]
+      })
+      vi.mocked(
+        authenticatedRequests.authenticatedPatchRequest
+      ).mockResolvedValue({})
+
+      const h = createMockHandler('redirect')
+      const request = createMockRequest({
+        payload: {
+          addConstructionDrawing: 'addConstructionDrawing',
+          siteNumber: '1'
+        }
+      })
+
+      await reviewSiteDetailsSubmitController.handler(request, h)
+
+      expect(
+        vi.mocked(authenticatedRequests.authenticatedPatchRequest)
+      ).toHaveBeenCalledTimes(1)
+      expect(h.redirect).toHaveBeenCalledWith(
+        `${marineLicenceRoutes.MARINE_LICENCE_REVIEW_SITE_DETAILS}#construction-drawing-site-1-2`
+      )
+    })
+
+    test('treats a non-array constructionDrawings value as empty rather than producing NaN', async () => {
+      getMarineLicenceCacheSpy.mockReturnValue({
+        id: 'test-id',
+        siteDetails: [
+          {
+            activityDetails: [],
+            constructionDrawings: {}
+          }
+        ]
+      })
+      vi.mocked(
+        authenticatedRequests.authenticatedPatchRequest
+      ).mockResolvedValue({})
+
+      const h = createMockHandler('redirect')
+      const request = createMockRequest({
+        payload: {
+          addConstructionDrawing: 'addConstructionDrawing',
+          siteNumber: '1'
+        }
+      })
+
+      await reviewSiteDetailsSubmitController.handler(request, h)
+
+      expect(h.redirect).toHaveBeenCalledWith(
+        `${marineLicenceRoutes.MARINE_LICENCE_REVIEW_SITE_DETAILS}#construction-drawing-site-1-2`
+      )
+    })
   })
 })

--- a/src/server/marine-licence/site-details/review-site-details/file-upload-review.njk
+++ b/src/server/marine-licence/site-details/review-site-details/file-upload-review.njk
@@ -143,7 +143,9 @@
 
         {{ appMarineLicenceConstructionDrawingCard({
           siteNumber: site.siteNumber,
-          activityDetails: site.activityDetails
+          activityDetails: site.activityDetails,
+          constructionDrawings: site.constructionDrawings,
+          csrfToken: csrfToken
         }) }}
 
         {% endfor %}

--- a/src/server/marine-licence/site-details/review-site-details/index.njk
+++ b/src/server/marine-licence/site-details/review-site-details/index.njk
@@ -194,7 +194,9 @@
 
         {{ appMarineLicenceConstructionDrawingCard({
           siteNumber: site.siteNumber,
-          activityDetails: site.activityDetails
+          activityDetails: site.activityDetails,
+          constructionDrawings: site.constructionDrawings,
+          csrfToken: csrfToken
         }) }}
 
       {% endfor %}

--- a/src/server/marine-licence/site-details/review-site-details/index.njk
+++ b/src/server/marine-licence/site-details/review-site-details/index.njk
@@ -3,6 +3,7 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "incomplete-fields-warning/macro.njk" import appIncompleteFieldsWarning %}
 {% from "site-details-map/macro.njk" import appSiteDetailsMap %}
 {% from "marine-licence/activity-details-card/macro.njk" import appMarineLicenceActivityDetailsCard %}
 {% from "marine-licence/construction-drawing-card/macro.njk" import appMarineLicenceConstructionDrawingCard %}
@@ -33,9 +34,9 @@
         }) }}
       {% endif %}
 
-      <div class="govuk-inset-text">
-        The site details you've provided are saved.<br>You must complete all sections marked <span class='govuk-tag govuk-tag--red govuk-!-margin-bottom-2 govuk-!-margin-top-2'>Incomplete</span> before you can send your information.<br>If you cannot finish now, you can return to this page later.
-      </div>
+      {% if hasIncompleteFields %}
+        {{ appIncompleteFieldsWarning() }}
+      {% endif %}
 
       {% set multipleSiteRows = [
         {

--- a/src/server/marine-licence/site-details/review-site-details/utils.js
+++ b/src/server/marine-licence/site-details/review-site-details/utils.js
@@ -4,6 +4,7 @@ import { getFileUploadSummaryData } from '#src/server/common/helpers/review-site
 import { createSiteDetailsDataJson } from '#src/server/common/helpers/site-details.js'
 import { parseActivityDetails } from '#src/server/common/helpers/review-site-details/activity-details.js'
 import { buildManualCoordinateSummaryData } from '#src/server/common/helpers/review-site-details/manual-entry.js'
+import { SUBTYPES_REQUIRING_CONSTRUCTION_DRAWING } from '#src/server/marine-licence/site-details/type-of-activity/constants.js'
 
 export const MANUAL_ENTRY_REVIEW_VIEW_ROUTE =
   'marine-licence/site-details/review-site-details/index'
@@ -103,7 +104,8 @@ export const renderFileUploadReview = (h, options) => {
       siteName: site.siteName,
       siteNumber: index + 1,
       siteDetailsData,
-      activityDetails
+      activityDetails,
+      constructionDrawings: site.constructionDrawings
     }
   })
 
@@ -137,6 +139,7 @@ export const renderManualEntryReview = (h, options) => {
   ).map((site, index) => ({
     ...site,
     deleteSiteLink: `${marineLicenceRoutes.MARINE_LICENCE_DELETE_SITE}?site=${index + 1}`,
+    constructionDrawings: siteDetails[index]?.constructionDrawings,
     activityDetails: site.activityDetails.map((activity, actIndex) => ({
       ...activity,
       ...(actIndex > 0 && {
@@ -156,9 +159,18 @@ export const renderManualEntryReview = (h, options) => {
   })
 }
 
+const siteRequiresConstructionDrawing = (site) =>
+  (site.activityDetails ?? []).some((activity) =>
+    SUBTYPES_REQUIRING_CONSTRUCTION_DRAWING.includes(activity.activitySubType)
+  )
+
+const isMissingConstructionDrawing = (site) =>
+  siteRequiresConstructionDrawing(site) &&
+  !site.constructionDrawings?.[0]?.s3Location
+
 const hasMissingRequiredFields = (site) => {
   const isSiteNameMissing = !site.siteName || site.siteName.trim() === ''
-  return isSiteNameMissing
+  return isSiteNameMissing || isMissingConstructionDrawing(site)
 }
 
 export const hasIncompleteFields = (siteDetails) => {

--- a/src/server/marine-licence/site-details/review-site-details/utils.js
+++ b/src/server/marine-licence/site-details/review-site-details/utils.js
@@ -152,6 +152,7 @@ export const renderManualEntryReview = (h, options) => {
     ...reviewSiteDetailsPageData,
     backLink: getManualEntryBackLink(previousPage, returnToCheckYourAnswers),
     projectName: marineLicence.projectName,
+    hasIncompleteFields: hasIncompleteFields(siteDetails),
     summaryData,
     showMarinePlanPoliciesQuestion,
     errors,

--- a/src/server/marine-licence/site-details/select-activity/controller.js
+++ b/src/server/marine-licence/site-details/select-activity/controller.js
@@ -12,6 +12,8 @@ import { selectActivitySchema } from '#src/server/marine-licence/site-details/se
 import { createFailAction } from '#src/server/common/helpers/createFailAction.js'
 import { selectActivityErrorMessages } from '#src/server/common/validation/select-activity/constants.js'
 import { validateSiteAndActivityParams } from '#src/server/common/helpers/marine-licence/session-cache/site-utils.js'
+import { seedFirstConstructionDrawingIfNeeded } from '#src/server/common/helpers/marine-licence/session-cache/construction-drawing-utils.js'
+import { SUBTYPES_REQUIRING_CONSTRUCTION_DRAWING } from '#src/server/marine-licence/site-details/type-of-activity/constants.js'
 
 export const SELECT_ACTIVITY_VIEW_ROUTE =
   'marine-licence/site-details/select-activity/index'
@@ -120,6 +122,13 @@ export const selectActivitySubmitController = {
       activityDetailsNumber
     } = getSiteDataFromParam(request.query)
 
+    const marineLicence = getMarineLicenceCache(request)
+    const activityDetails = getActivityDetailsByIndex(
+      marineLicence,
+      siteIndex,
+      activityDetailsIndex
+    )
+
     const userHasSelectedOther = [payload.activities].flat().includes('other')
 
     await updateMarineLicenceSiteActivityDetails(
@@ -134,6 +143,19 @@ export const selectActivitySubmitController = {
         }
       }
     )
+
+    if (
+      SUBTYPES_REQUIRING_CONSTRUCTION_DRAWING.includes(
+        activityDetails.activitySubType
+      )
+    ) {
+      await seedFirstConstructionDrawingIfNeeded(
+        request,
+        h,
+        marineLicence,
+        siteIndex
+      )
+    }
 
     await saveSiteDetailsToBackend(request, h, { siteIndex })
 

--- a/src/server/marine-licence/site-details/select-activity/controller.test.js
+++ b/src/server/marine-licence/site-details/select-activity/controller.test.js
@@ -14,10 +14,14 @@ import {
   createMockH
 } from '#src/server/test-helpers/mocks/helpers.js'
 import { getActivityOptions } from '#src/server/marine-licence/site-details/select-activity/utils.js'
+import { seedFirstConstructionDrawingIfNeeded } from '#src/server/common/helpers/marine-licence/session-cache/construction-drawing-utils.js'
 
 vi.mock('~/src/server/common/helpers/marine-licence/session-cache/utils.js')
 vi.mock('~/src/server/common/helpers/marine-licence/save-site-details.js')
 vi.mock('~/src/server/common/helpers/createFailAction.js')
+vi.mock(
+  '~/src/server/common/helpers/marine-licence/session-cache/construction-drawing-utils.js'
+)
 
 describe('#selectActivity', () => {
   beforeEach(() => {
@@ -206,6 +210,52 @@ describe('#selectActivity', () => {
         '/marine-licence/review-site-details#activity-details-site-1-activity-1'
       )
       expect(redirectH.redirect).toHaveBeenCalled()
+    })
+
+    describe('construction drawing seeding', () => {
+      test('seeds a construction drawing when the activity subtype requires one', async () => {
+        const redirectH = createMockH()
+        const request = createMockRequest({
+          query: { site: 1, activity: 1 },
+          payload: {
+            activities: ['CON1'],
+            otherActivity: ''
+          }
+        })
+
+        await selectActivitySubmitController.handler(request, redirectH)
+
+        expect(seedFirstConstructionDrawingIfNeeded).toHaveBeenCalledWith(
+          request,
+          redirectH,
+          mockMarineLicenceApplication,
+          0
+        )
+      })
+
+      test('does not seed a construction drawing when the activity subtype does not require one', async () => {
+        const mockMarineLicenceApplicationNoDrawing = structuredClone(
+          mockMarineLicenceApplication
+        )
+        mockMarineLicenceApplicationNoDrawing.siteDetails[0].activityDetails[0].activitySubType =
+          'construction-type-2'
+        vi.mocked(getMarineLicenceCache).mockReturnValueOnce(
+          mockMarineLicenceApplicationNoDrawing
+        )
+
+        const redirectH = createMockH()
+        const request = createMockRequest({
+          query: { site: 1, activity: 1 },
+          payload: {
+            activities: ['CON1'],
+            otherActivity: ''
+          }
+        })
+
+        await selectActivitySubmitController.handler(request, redirectH)
+
+        expect(seedFirstConstructionDrawingIfNeeded).not.toHaveBeenCalled()
+      })
     })
   })
 })

--- a/src/server/marine-licence/site-details/type-of-activity/controller.js
+++ b/src/server/marine-licence/site-details/type-of-activity/controller.js
@@ -13,7 +13,11 @@ import { getActivityVariantFromSubType } from '#src/server/common/helpers/activi
 import { validateSiteAndActivityParams } from '#src/server/common/helpers/marine-licence/session-cache/site-utils.js'
 import { getActivityDetailsBackLink } from '#src/server/marine-licence/site-details/utils/back-link.js'
 import { SUBTYPES_REQUIRING_CONSTRUCTION_DRAWING } from '#src/server/marine-licence/site-details/type-of-activity/constants.js'
-import { marineLicenceRoutes } from '#src/server/common/constants/routes.js'
+import {
+  apiRoutes,
+  marineLicenceRoutes
+} from '#src/server/common/constants/routes.js'
+import { authenticatedPatchRequest } from '#src/server/common/helpers/authenticated-requests.js'
 
 export const typeOfActivityErrorMessages = {
   ACTIVITY_TYPE_REQUIRED: 'Select the type of activity',
@@ -24,6 +28,16 @@ export const typeOfActivityErrorMessages = {
 
 export const MARINE_LICENCE_TYPE_OF_ACTIVITY_VIEW_ROUTE =
   'marine-licence/site-details/type-of-activity/index'
+
+const siteHasConstructionDrawings = (marineLicence, siteIndex) =>
+  marineLicence.siteDetails[siteIndex]?.constructionDrawings?.length > 0
+
+async function seedFirstConstructionDrawing(request, marineLicence, siteIndex) {
+  await authenticatedPatchRequest(request, apiRoutes.ADD_CONSTRUCTION_DRAWING, {
+    siteIndex,
+    id: marineLicence.id
+  })
+}
 
 const subTypePayload = (activityType, activitySubType) => ({
   activitySubTypeConstruction:
@@ -163,6 +177,13 @@ export const typeOfActivitySubmitController = {
         ...(activityTypeChanged && { activities: null })
       }
     )
+
+    if (
+      willBeDrawingRequired &&
+      !siteHasConstructionDrawings(marineLicence, siteIndex)
+    ) {
+      await seedFirstConstructionDrawing(request, marineLicence, siteIndex)
+    }
 
     const getPageToNavigateTo = getActivityVariantFromSubType(activitySubType)
 

--- a/src/server/marine-licence/site-details/type-of-activity/controller.js
+++ b/src/server/marine-licence/site-details/type-of-activity/controller.js
@@ -13,11 +13,7 @@ import { getActivityVariantFromSubType } from '#src/server/common/helpers/activi
 import { validateSiteAndActivityParams } from '#src/server/common/helpers/marine-licence/session-cache/site-utils.js'
 import { getActivityDetailsBackLink } from '#src/server/marine-licence/site-details/utils/back-link.js'
 import { SUBTYPES_REQUIRING_CONSTRUCTION_DRAWING } from '#src/server/marine-licence/site-details/type-of-activity/constants.js'
-import {
-  apiRoutes,
-  marineLicenceRoutes
-} from '#src/server/common/constants/routes.js'
-import { authenticatedPatchRequest } from '#src/server/common/helpers/authenticated-requests.js'
+import { marineLicenceRoutes } from '#src/server/common/constants/routes.js'
 
 export const typeOfActivityErrorMessages = {
   ACTIVITY_TYPE_REQUIRED: 'Select the type of activity',
@@ -28,16 +24,6 @@ export const typeOfActivityErrorMessages = {
 
 export const MARINE_LICENCE_TYPE_OF_ACTIVITY_VIEW_ROUTE =
   'marine-licence/site-details/type-of-activity/index'
-
-const siteHasConstructionDrawings = (marineLicence, siteIndex) =>
-  marineLicence.siteDetails[siteIndex]?.constructionDrawings?.length > 0
-
-async function seedFirstConstructionDrawing(request, marineLicence, siteIndex) {
-  await authenticatedPatchRequest(request, apiRoutes.ADD_CONSTRUCTION_DRAWING, {
-    siteIndex,
-    id: marineLicence.id
-  })
-}
 
 const subTypePayload = (activityType, activitySubType) => ({
   activitySubTypeConstruction:
@@ -177,13 +163,6 @@ export const typeOfActivitySubmitController = {
         ...(activityTypeChanged && { activities: null })
       }
     )
-
-    if (
-      willBeDrawingRequired &&
-      !siteHasConstructionDrawings(marineLicence, siteIndex)
-    ) {
-      await seedFirstConstructionDrawing(request, marineLicence, siteIndex)
-    }
 
     const getPageToNavigateTo = getActivityVariantFromSubType(activitySubType)
 

--- a/src/server/marine-licence/site-details/type-of-activity/controller.js
+++ b/src/server/marine-licence/site-details/type-of-activity/controller.js
@@ -2,7 +2,10 @@ import {
   getMarineLicenceCache,
   updateMarineLicenceSiteActivityDetails
 } from '#src/server/common/helpers/marine-licence/session-cache/utils.js'
-import { getActivityDetailsByIndex } from '#src/server/common/helpers/marine-licence/session-cache/site-details-utils.js'
+import {
+  getActivityDetailsByIndex,
+  siteHasOtherActivityRequiringDrawing
+} from '#src/server/common/helpers/marine-licence/session-cache/site-details-utils.js'
 import { typeOfActivitySchema } from '#src/server/marine-licence/site-details/type-of-activity/schema.js'
 import { getSiteDataFromParam } from '#src/server/common/helpers/site-details/site-name.js'
 import { createFailAction } from '#src/server/common/helpers/createFailAction.js'
@@ -131,7 +134,19 @@ export const typeOfActivitySubmitController = {
     const willBeDrawingRequired =
       SUBTYPES_REQUIRING_CONSTRUCTION_DRAWING.includes(activitySubType)
 
-    if (activityTypeChanged && wasDrawingRequired && !willBeDrawingRequired) {
+    const otherActivityStillRequiresDrawing =
+      siteHasOtherActivityRequiringDrawing(
+        marineLicence,
+        siteIndex,
+        activityDetailsIndex
+      )
+
+    if (
+      activityTypeChanged &&
+      wasDrawingRequired &&
+      !willBeDrawingRequired &&
+      !otherActivityStillRequiresDrawing
+    ) {
       return h.redirect(
         `${marineLicenceRoutes.MARINE_LICENCE_CONFIRM_CHANGE_ACTIVITY_TYPE}?site=${siteNumber}&activity=${activityDetailsNumber}&activityType=${payload.activityType}&activitySubType=${activitySubType}`
       )

--- a/src/server/marine-licence/site-details/type-of-activity/controller.test.js
+++ b/src/server/marine-licence/site-details/type-of-activity/controller.test.js
@@ -10,8 +10,6 @@ import {
   updateMarineLicenceSiteActivityDetails
 } from '#src/server/common/helpers/marine-licence/session-cache/utils.js'
 import { createFailAction } from '#src/server/common/helpers/createFailAction.js'
-import { authenticatedPatchRequest } from '#src/server/common/helpers/authenticated-requests.js'
-import { apiRoutes } from '#src/server/common/constants/routes.js'
 import { mockMarineLicenceApplication } from '#src/server/test-helpers/mocks/marine-licence-mocks.js'
 import {
   createMockRequest,
@@ -20,7 +18,6 @@ import {
 
 vi.mock('~/src/server/common/helpers/marine-licence/session-cache/utils.js')
 vi.mock('~/src/server/common/helpers/createFailAction.js')
-vi.mock('~/src/server/common/helpers/authenticated-requests.js')
 
 describe('#typeOfActivity', () => {
   beforeEach(() => {
@@ -243,112 +240,6 @@ describe('#typeOfActivity', () => {
         expect(redirectH.redirect).toHaveBeenCalledWith(
           '/marine-licence/activity-details/what-deposit-activity-are-you-continuing?site=1&activity=1'
         )
-      })
-    })
-
-    describe('gaining a drawing-requiring activity', () => {
-      const createGainingDrawingRequest = () =>
-        createMockRequest({
-          query: { site: 1, activity: 1 },
-          payload: {
-            activityType: 'construction',
-            activitySubTypeConstruction: 'construction-type-1',
-            activitySubTypeDeposit: '',
-            activitySubTypeRemoval: ''
-          }
-        })
-
-      test('seeds the first construction drawing when the new subtype requires one and the site has none yet', async () => {
-        vi.mocked(getMarineLicenceCache).mockReturnValueOnce({
-          ...mockMarineLicenceApplication,
-          siteDetails: [
-            {
-              ...mockMarineLicenceApplication.siteDetails[0],
-              activityDetails: [
-                {
-                  ...mockMarineLicenceApplication.siteDetails[0]
-                    .activityDetails[0],
-                  activityType: 'construction',
-                  activitySubType: 'construction-type-2'
-                }
-              ]
-            }
-          ]
-        })
-        const h = createMockH()
-        const request = createGainingDrawingRequest()
-
-        await typeOfActivitySubmitController.handler(request, h)
-
-        expect(authenticatedPatchRequest).toHaveBeenCalledWith(
-          request,
-          apiRoutes.ADD_CONSTRUCTION_DRAWING,
-          {
-            siteIndex: 0,
-            id: mockMarineLicenceApplication.id
-          }
-        )
-      })
-
-      test('does not seed a construction drawing when the site already has one', async () => {
-        vi.mocked(getMarineLicenceCache).mockReturnValueOnce({
-          ...mockMarineLicenceApplication,
-          siteDetails: [
-            {
-              ...mockMarineLicenceApplication.siteDetails[0],
-              activityDetails: [
-                {
-                  ...mockMarineLicenceApplication.siteDetails[0]
-                    .activityDetails[0],
-                  activityType: 'construction',
-                  activitySubType: 'construction-type-2'
-                }
-              ],
-              constructionDrawings: [{ filename: 'existing.pdf' }]
-            }
-          ]
-        })
-        const h = createMockH()
-
-        await typeOfActivitySubmitController.handler(
-          createGainingDrawingRequest(),
-          h
-        )
-
-        expect(authenticatedPatchRequest).not.toHaveBeenCalled()
-      })
-
-      test('does not seed a construction drawing when the new subtype does not require one', async () => {
-        vi.mocked(getMarineLicenceCache).mockReturnValueOnce({
-          ...mockMarineLicenceApplication,
-          siteDetails: [
-            {
-              ...mockMarineLicenceApplication.siteDetails[0],
-              activityDetails: [
-                {
-                  ...mockMarineLicenceApplication.siteDetails[0]
-                    .activityDetails[0],
-                  activityType: 'construction',
-                  activitySubType: 'construction-type-1'
-                }
-              ]
-            }
-          ]
-        })
-        const h = createMockH()
-        const request = createMockRequest({
-          query: { site: 1, activity: 1 },
-          payload: {
-            activityType: 'construction',
-            activitySubTypeConstruction: 'construction-type-2',
-            activitySubTypeDeposit: '',
-            activitySubTypeRemoval: ''
-          }
-        })
-
-        await typeOfActivitySubmitController.handler(request, h)
-
-        expect(authenticatedPatchRequest).not.toHaveBeenCalled()
       })
     })
   })

--- a/src/server/marine-licence/site-details/type-of-activity/controller.test.js
+++ b/src/server/marine-licence/site-details/type-of-activity/controller.test.js
@@ -10,6 +10,8 @@ import {
   updateMarineLicenceSiteActivityDetails
 } from '#src/server/common/helpers/marine-licence/session-cache/utils.js'
 import { createFailAction } from '#src/server/common/helpers/createFailAction.js'
+import { authenticatedPatchRequest } from '#src/server/common/helpers/authenticated-requests.js'
+import { apiRoutes } from '#src/server/common/constants/routes.js'
 import { mockMarineLicenceApplication } from '#src/server/test-helpers/mocks/marine-licence-mocks.js'
 import {
   createMockRequest,
@@ -18,6 +20,7 @@ import {
 
 vi.mock('~/src/server/common/helpers/marine-licence/session-cache/utils.js')
 vi.mock('~/src/server/common/helpers/createFailAction.js')
+vi.mock('~/src/server/common/helpers/authenticated-requests.js')
 
 describe('#typeOfActivity', () => {
   beforeEach(() => {
@@ -240,6 +243,112 @@ describe('#typeOfActivity', () => {
         expect(redirectH.redirect).toHaveBeenCalledWith(
           '/marine-licence/activity-details/what-deposit-activity-are-you-continuing?site=1&activity=1'
         )
+      })
+    })
+
+    describe('gaining a drawing-requiring activity', () => {
+      const createGainingDrawingRequest = () =>
+        createMockRequest({
+          query: { site: 1, activity: 1 },
+          payload: {
+            activityType: 'construction',
+            activitySubTypeConstruction: 'construction-type-1',
+            activitySubTypeDeposit: '',
+            activitySubTypeRemoval: ''
+          }
+        })
+
+      test('seeds the first construction drawing when the new subtype requires one and the site has none yet', async () => {
+        vi.mocked(getMarineLicenceCache).mockReturnValueOnce({
+          ...mockMarineLicenceApplication,
+          siteDetails: [
+            {
+              ...mockMarineLicenceApplication.siteDetails[0],
+              activityDetails: [
+                {
+                  ...mockMarineLicenceApplication.siteDetails[0]
+                    .activityDetails[0],
+                  activityType: 'construction',
+                  activitySubType: 'construction-type-2'
+                }
+              ]
+            }
+          ]
+        })
+        const h = createMockH()
+        const request = createGainingDrawingRequest()
+
+        await typeOfActivitySubmitController.handler(request, h)
+
+        expect(authenticatedPatchRequest).toHaveBeenCalledWith(
+          request,
+          apiRoutes.ADD_CONSTRUCTION_DRAWING,
+          {
+            siteIndex: 0,
+            id: mockMarineLicenceApplication.id
+          }
+        )
+      })
+
+      test('does not seed a construction drawing when the site already has one', async () => {
+        vi.mocked(getMarineLicenceCache).mockReturnValueOnce({
+          ...mockMarineLicenceApplication,
+          siteDetails: [
+            {
+              ...mockMarineLicenceApplication.siteDetails[0],
+              activityDetails: [
+                {
+                  ...mockMarineLicenceApplication.siteDetails[0]
+                    .activityDetails[0],
+                  activityType: 'construction',
+                  activitySubType: 'construction-type-2'
+                }
+              ],
+              constructionDrawings: [{ filename: 'existing.pdf' }]
+            }
+          ]
+        })
+        const h = createMockH()
+
+        await typeOfActivitySubmitController.handler(
+          createGainingDrawingRequest(),
+          h
+        )
+
+        expect(authenticatedPatchRequest).not.toHaveBeenCalled()
+      })
+
+      test('does not seed a construction drawing when the new subtype does not require one', async () => {
+        vi.mocked(getMarineLicenceCache).mockReturnValueOnce({
+          ...mockMarineLicenceApplication,
+          siteDetails: [
+            {
+              ...mockMarineLicenceApplication.siteDetails[0],
+              activityDetails: [
+                {
+                  ...mockMarineLicenceApplication.siteDetails[0]
+                    .activityDetails[0],
+                  activityType: 'construction',
+                  activitySubType: 'construction-type-1'
+                }
+              ]
+            }
+          ]
+        })
+        const h = createMockH()
+        const request = createMockRequest({
+          query: { site: 1, activity: 1 },
+          payload: {
+            activityType: 'construction',
+            activitySubTypeConstruction: 'construction-type-2',
+            activitySubTypeDeposit: '',
+            activitySubTypeRemoval: ''
+          }
+        })
+
+        await typeOfActivitySubmitController.handler(request, h)
+
+        expect(authenticatedPatchRequest).not.toHaveBeenCalled()
       })
     })
   })

--- a/src/server/marine-licence/site-details/type-of-activity/controller.test.js
+++ b/src/server/marine-licence/site-details/type-of-activity/controller.test.js
@@ -116,6 +116,17 @@ describe('#typeOfActivity', () => {
 
     describe('changing away from a drawing-requiring activity', () => {
       test('redirects to the confirmation guard when changing to a different activity type entirely', async () => {
+        vi.mocked(getMarineLicenceCache).mockReturnValueOnce({
+          ...mockMarineLicenceApplication,
+          siteDetails: [
+            {
+              ...mockMarineLicenceApplication.siteDetails[0],
+              activityDetails: [
+                mockMarineLicenceApplication.siteDetails[0].activityDetails[0]
+              ]
+            }
+          ]
+        })
         const redirectH = createMockH()
         const request = createMockRequest({
           query: { site: 1, activity: 1 },
@@ -132,6 +143,56 @@ describe('#typeOfActivity', () => {
         expect(updateMarineLicenceSiteActivityDetails).not.toHaveBeenCalled()
         expect(redirectH.redirect).toHaveBeenCalledWith(
           '/marine-licence/confirm-change-activity-type?site=1&activity=1&activityType=deposit&activitySubType=deposit-type-1'
+        )
+      })
+
+      test('does not guard when another activity on the site still requires a drawing', async () => {
+        vi.mocked(getMarineLicenceCache).mockReturnValueOnce({
+          ...mockMarineLicenceApplication,
+          siteDetails: [
+            {
+              ...mockMarineLicenceApplication.siteDetails[0],
+              activityDetails: [
+                {
+                  ...mockMarineLicenceApplication.siteDetails[0]
+                    .activityDetails[0],
+                  activitySubType: 'construction-type-1'
+                },
+                {
+                  ...mockMarineLicenceApplication.siteDetails[0]
+                    .activityDetails[0],
+                  activitySubType: 'construction-type-1'
+                }
+              ]
+            }
+          ]
+        })
+        const redirectH = createMockH()
+        const request = createMockRequest({
+          query: { site: 1, activity: 1 },
+          payload: {
+            activityType: 'deposit',
+            activitySubTypeConstruction: '',
+            activitySubTypeDeposit: 'deposit-type-1',
+            activitySubTypeRemoval: ''
+          }
+        })
+
+        await typeOfActivitySubmitController.handler(request, redirectH)
+
+        expect(updateMarineLicenceSiteActivityDetails).toHaveBeenCalledWith(
+          request,
+          redirectH,
+          0,
+          0,
+          {
+            activities: null,
+            activityType: 'deposit',
+            activitySubType: 'deposit-type-1'
+          }
+        )
+        expect(redirectH.redirect).toHaveBeenCalledWith(
+          '/marine-licence/activity-details/what-deposit-activity-are-you-continuing?site=1&activity=1'
         )
       })
 

--- a/src/server/marine-licence/site-details/upload-construction-drawing-wait/controller.js
+++ b/src/server/marine-licence/site-details/upload-construction-drawing-wait/controller.js
@@ -1,0 +1,192 @@
+import {
+  marineLicenceRoutes,
+  apiRoutes
+} from '#src/server/common/constants/routes.js'
+import {
+  getMarineLicenceCache,
+  updateMarineLicenceSiteDetails
+} from '#src/server/common/helpers/marine-licence/session-cache/utils.js'
+import { getCdpUploadService } from '#src/services/cdp-upload-service/index.js'
+import { getCdpErrorMessageFromCode } from '#src/server/common/helpers/file-upload/file-upload.js'
+import { handleReadyStatus } from '#src/server/common/helpers/file-upload/upload-status-handler.js'
+import { DEFAULT_ERROR_MESSAGE } from '#src/server/common/helpers/file-upload/error-messages.js'
+import {
+  UPLOAD_AND_WAIT_VIEW_ROUTE,
+  uploadAndWaitPageSettings
+} from '#src/server/common/helpers/file-upload/constants.js'
+import { authenticatedPatchRequest } from '#src/server/common/helpers/authenticated-requests.js'
+import { config } from '#src/config/config.js'
+import { getConstructionDrawingBackLink } from '#src/server/marine-licence/site-details/utils/back-link.js'
+
+async function storeUploadError(request, h, errorDetails, siteIndex) {
+  await updateMarineLicenceSiteDetails(request, h, siteIndex, 'uploadError', {
+    message: errorDetails.message,
+    fieldName: errorDetails.fieldName,
+    fileType: 'construction-drawing'
+  })
+  await updateMarineLicenceSiteDetails(
+    request,
+    h,
+    siteIndex,
+    'uploadConfig',
+    null
+  )
+}
+
+async function handleRejectedStatus(status, uploadConfig, request, h) {
+  const errorMessage = status.errorCode
+    ? getCdpErrorMessageFromCode(status.errorCode, 'construction-drawing')
+    : DEFAULT_ERROR_MESSAGE
+
+  request.logger.error(
+    {
+      error: {
+        code: status.errorCode,
+        message: status.message,
+        type: 'construction-drawing'
+      }
+    },
+    'ConstructionDrawingUpload: CDP rejection error'
+  )
+
+  await storeUploadError(
+    request,
+    h,
+    { message: errorMessage, fieldName: 'file' },
+    uploadConfig.siteIndex
+  )
+
+  return h.redirect(
+    `${marineLicenceRoutes.MARINE_LICENCE_UPLOAD_CONSTRUCTION_DRAWING}?site=${uploadConfig.siteIndex + 1}&drawing=${uploadConfig.drawingIndex + 1}`
+  )
+}
+
+function handleProcessingStatus(status, marineLicence, h) {
+  return h.view(UPLOAD_AND_WAIT_VIEW_ROUTE, {
+    ...uploadAndWaitPageSettings,
+    projectName: marineLicence.projectName,
+    isProcessing: true,
+    filename: status.filename,
+    tryAgainLink: marineLicenceRoutes.MARINE_LICENCE_REVIEW_SITE_DETAILS,
+    cancelLink: marineLicenceRoutes.MARINE_LICENCE_REVIEW_SITE_DETAILS
+  })
+}
+
+async function processValidatedFile(
+  status,
+  uploadConfig,
+  request,
+  h,
+  marineLicence
+) {
+  const { siteIndex, drawingIndex } = uploadConfig
+  const cdpUploadConfig = config.get('cdpUploader')
+
+  await authenticatedPatchRequest(
+    request,
+    apiRoutes.UPDATE_CONSTRUCTION_DRAWING,
+    {
+      id: marineLicence.id,
+      siteIndex,
+      drawingIndex,
+      filename: status.filename,
+      s3Location: {
+        s3Bucket: cdpUploadConfig.s3Bucket,
+        s3Key: status.s3Location.s3Key,
+        checksumSha256: status.s3Location.checksumSha256
+      }
+    }
+  )
+
+  await updateMarineLicenceSiteDetails(
+    request,
+    h,
+    siteIndex,
+    'uploadConfig',
+    null
+  )
+
+  return h.redirect(
+    getConstructionDrawingBackLink(siteIndex + 1, drawingIndex + 1)
+  )
+}
+
+async function processUploadStatus(status, context) {
+  const { uploadConfig, request, h, marineLicence } = context
+
+  if (status.status === 'pending' || status.status === 'scanning') {
+    return handleProcessingStatus(status, marineLicence, h)
+  }
+
+  if (status.status === 'ready') {
+    const redirect = await handleReadyStatus(status, uploadConfig, request, h, {
+      storeUploadError: (req, hh, errorDetails) =>
+        storeUploadError(req, hh, errorDetails, uploadConfig.siteIndex),
+      fileUploadRoute: `${marineLicenceRoutes.MARINE_LICENCE_UPLOAD_CONSTRUCTION_DRAWING}?site=${uploadConfig.siteIndex + 1}&drawing=${uploadConfig.drawingIndex + 1}`
+    })
+    if (redirect) {
+      return redirect
+    }
+    return processValidatedFile(status, uploadConfig, request, h, marineLicence)
+  }
+
+  if (status.status === 'rejected' || status.status === 'error') {
+    return handleRejectedStatus(status, uploadConfig, request, h)
+  }
+
+  request.logger.warn(
+    { uploadId: uploadConfig.uploadId, status: status.status },
+    'ConstructionDrawingUpload: Unknown upload status'
+  )
+
+  return h.redirect(marineLicenceRoutes.MARINE_LICENCE_REVIEW_SITE_DETAILS)
+}
+
+export const uploadConstructionDrawingWaitController = {
+  async handler(request, h) {
+    const marineLicence = getMarineLicenceCache(request)
+    const { site } = request.query
+
+    if (!site) {
+      return h.redirect(marineLicenceRoutes.MARINE_LICENCE_REVIEW_SITE_DETAILS)
+    }
+
+    const siteIndex = Number.parseInt(site, 10) - 1
+    const siteDetails = marineLicence.siteDetails?.[siteIndex]
+    const { uploadConfig } = siteDetails ?? {}
+
+    if (!uploadConfig) {
+      return h.redirect(marineLicenceRoutes.MARINE_LICENCE_REVIEW_SITE_DETAILS)
+    }
+
+    try {
+      const cdpService = getCdpUploadService()
+      const status = await cdpService.getStatus(
+        uploadConfig.uploadId,
+        uploadConfig.statusUrl
+      )
+
+      return await processUploadStatus(status, {
+        uploadConfig,
+        request,
+        h,
+        marineLicence
+      })
+    } catch (error) {
+      request.logger.error(
+        { err: error, uploadId: uploadConfig.uploadId },
+        'ConstructionDrawingUpload: ERROR: Failed to check upload status'
+      )
+
+      await updateMarineLicenceSiteDetails(
+        request,
+        h,
+        siteIndex,
+        'uploadConfig',
+        null
+      )
+
+      return h.redirect(marineLicenceRoutes.MARINE_LICENCE_REVIEW_SITE_DETAILS)
+    }
+  }
+}

--- a/src/server/marine-licence/site-details/upload-construction-drawing-wait/controller.js
+++ b/src/server/marine-licence/site-details/upload-construction-drawing-wait/controller.js
@@ -18,11 +18,13 @@ import { authenticatedPatchRequest } from '#src/server/common/helpers/authentica
 import { config } from '#src/config/config.js'
 import { getConstructionDrawingBackLink } from '#src/server/marine-licence/site-details/utils/back-link.js'
 
+const CONSTRUCTION_DRAWING_FILETYPE = 'construction-drawing'
+
 async function storeUploadError(request, h, errorDetails, siteIndex) {
   await updateMarineLicenceSiteDetails(request, h, siteIndex, 'uploadError', {
     message: errorDetails.message,
     fieldName: errorDetails.fieldName,
-    fileType: 'construction-drawing'
+    fileType: CONSTRUCTION_DRAWING_FILETYPE
   })
   await updateMarineLicenceSiteDetails(
     request,
@@ -35,7 +37,10 @@ async function storeUploadError(request, h, errorDetails, siteIndex) {
 
 async function handleRejectedStatus(status, uploadConfig, request, h) {
   const errorMessage = status.errorCode
-    ? getCdpErrorMessageFromCode(status.errorCode, 'construction-drawing')
+    ? getCdpErrorMessageFromCode(
+        status.errorCode,
+        CONSTRUCTION_DRAWING_FILETYPE
+      )
     : DEFAULT_ERROR_MESSAGE
 
   request.logger.error(
@@ -43,7 +48,7 @@ async function handleRejectedStatus(status, uploadConfig, request, h) {
       error: {
         code: status.errorCode,
         message: status.message,
-        type: 'construction-drawing'
+        type: CONSTRUCTION_DRAWING_FILETYPE
       }
     },
     'ConstructionDrawingUpload: CDP rejection error'

--- a/src/server/marine-licence/site-details/upload-construction-drawing-wait/controller.test.js
+++ b/src/server/marine-licence/site-details/upload-construction-drawing-wait/controller.test.js
@@ -1,0 +1,277 @@
+import { vi } from 'vitest'
+import { uploadConstructionDrawingWaitController } from '#src/server/marine-licence/site-details/upload-construction-drawing-wait/controller.js'
+import { UPLOAD_AND_WAIT_VIEW_ROUTE } from '#src/server/common/helpers/file-upload/constants.js'
+import * as mlCacheUtils from '#src/server/common/helpers/marine-licence/session-cache/utils.js'
+import * as cdpUploadService from '#src/services/cdp-upload-service/index.js'
+import * as geoParseUpload from '#src/server/common/helpers/file-upload/geo-parse-upload.js'
+import * as authenticatedRequests from '#src/server/common/helpers/authenticated-requests.js'
+import {
+  apiRoutes,
+  marineLicenceRoutes
+} from '#src/server/common/constants/routes.js'
+import { config } from '#src/config/config.js'
+import {
+  createMockRequest,
+  createMockH
+} from '#src/server/test-helpers/mocks/helpers.js'
+
+vi.mock('~/src/server/common/helpers/marine-licence/session-cache/utils.js')
+vi.mock('~/src/services/cdp-upload-service/index.js')
+vi.mock('~/src/server/common/helpers/authenticated-requests.js')
+vi.mock(
+  '~/src/server/common/helpers/file-upload/geo-parse-upload.js',
+  async () => {
+    const actual = await vi.importActual(
+      '~/src/server/common/helpers/file-upload/geo-parse-upload.js'
+    )
+    return { ...actual, validateUploadedFile: vi.fn() }
+  }
+)
+vi.mock('~/src/config/config.js')
+
+vi.mock('~/src/server/common/helpers/logging/logger-options.js', () => ({
+  loggerOptions: {
+    enabled: true,
+    ignorePaths: ['/health'],
+    redact: {
+      paths: []
+    }
+  }
+}))
+
+vi.mock('~/src/server/common/helpers/logging/logger.js', () => ({
+  createLogger: vi.fn().mockReturnValue({
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn()
+  })
+}))
+
+const mockUploadConfig = {
+  uploadId: 'test-upload-id',
+  statusUrl: 'test-status-url',
+  fileType: 'construction-drawing',
+  siteIndex: 0,
+  drawingIndex: 1
+}
+
+const mockMarineLicence = (overrides = {}) => ({
+  id: 'test-licence-id',
+  projectName: 'Test Project',
+  siteDetails: [{ uploadConfig: mockUploadConfig }],
+  ...overrides
+})
+
+describe('uploadConstructionDrawingWaitController', () => {
+  let mockCdpService
+
+  beforeEach(() => {
+    config.get.mockReturnValue({ s3Bucket: 'test-bucket' })
+
+    mockCdpService = { getStatus: vi.fn() }
+    vi.mocked(cdpUploadService.getCdpUploadService).mockReturnValue(
+      mockCdpService
+    )
+    vi.mocked(mlCacheUtils.getMarineLicenceCache).mockReturnValue(
+      mockMarineLicence()
+    )
+    vi.mocked(mlCacheUtils.updateMarineLicenceSiteDetails).mockImplementation(
+      () => {}
+    )
+  })
+
+  it('redirects to review site details when the site query param is missing', async () => {
+    const request = createMockRequest({ query: {} })
+    const h = createMockH()
+
+    await uploadConstructionDrawingWaitController.handler(request, h)
+
+    expect(h.redirect).toHaveBeenCalledWith(
+      marineLicenceRoutes.MARINE_LICENCE_REVIEW_SITE_DETAILS
+    )
+  })
+
+  it('redirects to review site details when there is no upload in progress for the site', async () => {
+    vi.mocked(mlCacheUtils.getMarineLicenceCache).mockReturnValue(
+      mockMarineLicence({ siteDetails: [{}] })
+    )
+    const request = createMockRequest({ query: { site: '1' } })
+    const h = createMockH()
+
+    await uploadConstructionDrawingWaitController.handler(request, h)
+
+    expect(h.redirect).toHaveBeenCalledWith(
+      marineLicenceRoutes.MARINE_LICENCE_REVIEW_SITE_DETAILS
+    )
+  })
+
+  it('shows the waiting page while the file is pending or scanning', async () => {
+    mockCdpService.getStatus.mockResolvedValue({
+      status: 'scanning',
+      filename: 'drawing.pdf'
+    })
+    const request = createMockRequest({ query: { site: '1' } })
+    const h = createMockH()
+
+    await uploadConstructionDrawingWaitController.handler(request, h)
+
+    expect(h.view).toHaveBeenCalledWith(
+      UPLOAD_AND_WAIT_VIEW_ROUTE,
+      expect.objectContaining({ isProcessing: true, filename: 'drawing.pdf' })
+    )
+  })
+
+  it('persists the drawing and redirects to the anchored card when the file is ready and valid', async () => {
+    mockCdpService.getStatus.mockResolvedValue({
+      status: 'ready',
+      filename: 'drawing.pdf',
+      s3Location: {
+        s3Key: 'test-key',
+        checksumSha256: 'test-checksum'
+      }
+    })
+    vi.mocked(geoParseUpload.validateUploadedFile).mockResolvedValue({
+      isValid: true
+    })
+    const request = createMockRequest({ query: { site: '1' } })
+    const h = createMockH()
+
+    await uploadConstructionDrawingWaitController.handler(request, h)
+
+    expect(
+      authenticatedRequests.authenticatedPatchRequest
+    ).toHaveBeenCalledWith(request, apiRoutes.UPDATE_CONSTRUCTION_DRAWING, {
+      id: 'test-licence-id',
+      siteIndex: 0,
+      drawingIndex: 1,
+      filename: 'drawing.pdf',
+      s3Location: {
+        s3Bucket: 'test-bucket',
+        s3Key: 'test-key',
+        checksumSha256: 'test-checksum'
+      }
+    })
+
+    expect(mlCacheUtils.updateMarineLicenceSiteDetails).toHaveBeenCalledWith(
+      request,
+      h,
+      0,
+      'uploadConfig',
+      null
+    )
+
+    expect(h.redirect).toHaveBeenCalledWith(
+      '/marine-licence/review-site-details#construction-drawing-site-1-2'
+    )
+  })
+
+  it('stores an error and redirects back to the upload screen when the file extension is invalid', async () => {
+    mockCdpService.getStatus.mockResolvedValue({
+      status: 'ready',
+      filename: 'drawing.exe',
+      s3Location: { s3Key: 'test-key', checksumSha256: 'test-checksum' }
+    })
+    vi.mocked(geoParseUpload.validateUploadedFile).mockResolvedValue({
+      isValid: false,
+      errorMessage:
+        'The selected file must be a PDF or image (.bmp, .gif, .jpg, .jpeg, .png, .tif) file'
+    })
+    const request = createMockRequest({ query: { site: '1' } })
+    const h = createMockH()
+
+    await uploadConstructionDrawingWaitController.handler(request, h)
+
+    expect(mlCacheUtils.updateMarineLicenceSiteDetails).toHaveBeenCalledWith(
+      request,
+      h,
+      0,
+      'uploadError',
+      expect.objectContaining({
+        message:
+          'The selected file must be a PDF or image (.bmp, .gif, .jpg, .jpeg, .png, .tif) file'
+      })
+    )
+    expect(h.redirect).toHaveBeenCalledWith(
+      `${marineLicenceRoutes.MARINE_LICENCE_UPLOAD_CONSTRUCTION_DRAWING}?site=1&drawing=2`
+    )
+  })
+
+  it('maps a CDP virus rejection to the correct message and redirects back to the upload screen', async () => {
+    mockCdpService.getStatus.mockResolvedValue({
+      status: 'rejected',
+      errorCode: 'VIRUS_DETECTED',
+      message: 'virus found'
+    })
+    const request = createMockRequest({ query: { site: '1' } })
+    const h = createMockH()
+
+    await uploadConstructionDrawingWaitController.handler(request, h)
+
+    expect(mlCacheUtils.updateMarineLicenceSiteDetails).toHaveBeenCalledWith(
+      request,
+      h,
+      0,
+      'uploadError',
+      expect.objectContaining({
+        message: 'The selected file contains a virus'
+      })
+    )
+    expect(h.redirect).toHaveBeenCalledWith(
+      `${marineLicenceRoutes.MARINE_LICENCE_UPLOAD_CONSTRUCTION_DRAWING}?site=1&drawing=2`
+    )
+  })
+
+  it('maps a CDP file-too-large rejection to the 10MB-specific message', async () => {
+    mockCdpService.getStatus.mockResolvedValue({
+      status: 'rejected',
+      errorCode: 'FILE_TOO_LARGE',
+      message: 'too big'
+    })
+    const request = createMockRequest({ query: { site: '1' } })
+    const h = createMockH()
+
+    await uploadConstructionDrawingWaitController.handler(request, h)
+
+    expect(mlCacheUtils.updateMarineLicenceSiteDetails).toHaveBeenCalledWith(
+      request,
+      h,
+      0,
+      'uploadError',
+      expect.objectContaining({
+        message: 'The selected file must be smaller than 10 MB'
+      })
+    )
+  })
+
+  it('redirects to review site details for an unknown status', async () => {
+    mockCdpService.getStatus.mockResolvedValue({ status: 'unknown' })
+    const request = createMockRequest({ query: { site: '1' } })
+    const h = createMockH()
+
+    await uploadConstructionDrawingWaitController.handler(request, h)
+
+    expect(h.redirect).toHaveBeenCalledWith(
+      marineLicenceRoutes.MARINE_LICENCE_REVIEW_SITE_DETAILS
+    )
+  })
+
+  it('clears the upload config and redirects when checking status fails', async () => {
+    mockCdpService.getStatus.mockRejectedValue(new Error('network error'))
+    const request = createMockRequest({ query: { site: '1' } })
+    const h = createMockH()
+
+    await uploadConstructionDrawingWaitController.handler(request, h)
+
+    expect(mlCacheUtils.updateMarineLicenceSiteDetails).toHaveBeenCalledWith(
+      request,
+      h,
+      0,
+      'uploadConfig',
+      null
+    )
+    expect(h.redirect).toHaveBeenCalledWith(
+      marineLicenceRoutes.MARINE_LICENCE_REVIEW_SITE_DETAILS
+    )
+  })
+})

--- a/src/server/marine-licence/site-details/upload-construction-drawing-wait/index.js
+++ b/src/server/marine-licence/site-details/upload-construction-drawing-wait/index.js
@@ -1,0 +1,10 @@
+import { uploadConstructionDrawingWaitController } from '#src/server/marine-licence/site-details/upload-construction-drawing-wait/controller.js'
+import { marineLicenceRoutes } from '#src/server/common/constants/routes.js'
+
+export const uploadConstructionDrawingWaitRoutes = [
+  {
+    method: 'GET',
+    path: marineLicenceRoutes.MARINE_LICENCE_UPLOAD_CONSTRUCTION_DRAWING_WAIT,
+    ...uploadConstructionDrawingWaitController
+  }
+]

--- a/src/server/marine-licence/site-details/upload-construction-drawing/controller.js
+++ b/src/server/marine-licence/site-details/upload-construction-drawing/controller.js
@@ -1,30 +1,86 @@
-import { getMarineLicenceCache } from '#src/server/common/helpers/marine-licence/session-cache/utils.js'
+import { getCdpUploadService } from '#src/services/cdp-upload-service/index.js'
+import { config } from '#src/config/config.js'
+import { marineLicenceRoutes } from '#src/server/common/constants/routes.js'
+import {
+  getMarineLicenceCache,
+  updateMarineLicenceSiteDetails
+} from '#src/server/common/helpers/marine-licence/session-cache/utils.js'
 import { getSiteDataFromParam } from '#src/server/common/helpers/site-details/site-name.js'
-import { validateSiteAndActivityParams } from '#src/server/common/helpers/marine-licence/session-cache/site-utils.js'
-import { getActivityDetailsBackLink } from '#src/server/marine-licence/site-details/utils/back-link.js'
+import { validateSiteAndDrawingParams } from '#src/server/common/helpers/marine-licence/session-cache/site-utils.js'
+import { getConstructionDrawingBackLink } from '#src/server/marine-licence/site-details/utils/back-link.js'
+import {
+  CONSTRUCTION_DRAWING_ACCEPT_ATTRIBUTE,
+  createFileUploadErrorDisplay
+} from '#src/server/common/helpers/file-upload/file-upload.js'
 
 export const UPLOAD_CONSTRUCTION_DRAWING_VIEW_ROUTE =
   'marine-licence/site-details/upload-construction-drawing/index'
 
-const UPLOAD_CONSTRUCTION_DRAWING_PAGE_TITLE = 'Upload a construction drawing'
+const CONSTRUCTION_DRAWING_S3_PATH = 'marine-licence/construction-drawings'
+const TEN_MB = 10 * 1024 * 1024
 
 export const uploadConstructionDrawingController = {
   options: {
-    pre: [validateSiteAndActivityParams]
+    pre: [validateSiteAndDrawingParams]
   },
-  handler(request, h) {
+  async handler(request, h) {
     const marineLicence = getMarineLicenceCache(request)
-    const { siteNumber, activityDetailsNumber } = getSiteDataFromParam(
-      request.query
+    const { siteIndex, siteNumber, drawingIndex, drawingNumber } =
+      getSiteDataFromParam(request.query)
+
+    const site = marineLicence.siteDetails?.[siteIndex] ?? {}
+    const { uploadError } = site
+
+    let errorSummary, errors
+    if (uploadError) {
+      const errorDisplay = createFileUploadErrorDisplay(uploadError, request)
+      errorSummary = errorDisplay.errorSummary
+      errors = errorDisplay.errors
+
+      await updateMarineLicenceSiteDetails(
+        request,
+        h,
+        siteIndex,
+        'uploadError',
+        null
+      )
+    }
+
+    const cdpService = getCdpUploadService()
+    const s3Bucket = config.get('cdpUploader').s3Bucket
+    const uploadConfig = await cdpService.initiate({
+      redirectUrl: `${marineLicenceRoutes.MARINE_LICENCE_UPLOAD_CONSTRUCTION_DRAWING_WAIT}?site=${siteNumber}`,
+      s3Path: CONSTRUCTION_DRAWING_S3_PATH,
+      s3Bucket,
+      maxFileSize: TEN_MB
+    })
+
+    await updateMarineLicenceSiteDetails(
+      request,
+      h,
+      siteIndex,
+      'uploadConfig',
+      {
+        uploadId: uploadConfig.uploadId,
+        statusUrl: uploadConfig.statusUrl,
+        fileType: 'construction-drawing',
+        siteIndex,
+        drawingIndex
+      }
     )
 
     return h.view(UPLOAD_CONSTRUCTION_DRAWING_VIEW_ROUTE, {
-      pageTitle: UPLOAD_CONSTRUCTION_DRAWING_PAGE_TITLE,
-      heading: UPLOAD_CONSTRUCTION_DRAWING_PAGE_TITLE,
+      pageTitle: `Site ${siteNumber}: Upload construction drawing ${drawingNumber}`,
+      heading: `Site ${siteNumber}: Upload construction drawing ${drawingNumber}`,
       projectName: marineLicence.projectName,
       siteNumber,
-      activityDetailsNumber,
-      backLink: getActivityDetailsBackLink(siteNumber, activityDetailsNumber)
+      drawingNumber,
+      uploadUrl: uploadConfig.uploadUrl,
+      acceptAttribute: CONSTRUCTION_DRAWING_ACCEPT_ATTRIBUTE,
+      backLink: getConstructionDrawingBackLink(siteNumber, drawingNumber),
+      cancelLink: getConstructionDrawingBackLink(siteNumber, drawingNumber),
+      errorSummary,
+      errors
     })
   }
 }

--- a/src/server/marine-licence/site-details/upload-construction-drawing/controller.test.js
+++ b/src/server/marine-licence/site-details/upload-construction-drawing/controller.test.js
@@ -4,6 +4,7 @@ import {
   uploadConstructionDrawingController
 } from '#src/server/marine-licence/site-details/upload-construction-drawing/controller.js'
 import * as cacheUtils from '#src/server/common/helpers/marine-licence/session-cache/utils.js'
+import * as cdpUploadService from '#src/services/cdp-upload-service/index.js'
 import {
   createMockRequest,
   createMockH
@@ -11,33 +12,130 @@ import {
 import { mockMarineLicenceApplication } from '#src/server/test-helpers/mocks/marine-licence-mocks.js'
 
 vi.mock('~/src/server/common/helpers/marine-licence/session-cache/utils.js')
+vi.mock('~/src/services/cdp-upload-service/index.js')
 
 describe('uploadConstructionDrawingController', () => {
+  const mockUploadConfig = {
+    uploadId: 'test-upload-id',
+    uploadUrl: 'https://upload.example.com',
+    statusUrl: 'https://status.example.com',
+    maxFileSize: 10 * 1024 * 1024
+  }
+
   beforeEach(() => {
     vi.mocked(cacheUtils.getMarineLicenceCache).mockReturnValue(
       mockMarineLicenceApplication
     )
+    vi.mocked(cdpUploadService.getCdpUploadService).mockReturnValue({
+      initiate: vi.fn().mockResolvedValue(mockUploadConfig)
+    })
   })
 
-  it('renders the holding page for the given site and activity', () => {
+  it('renders the upload screen for the given site and drawing', async () => {
     const request = createMockRequest({
-      query: { site: '1', activity: '2' }
+      query: { site: '1', drawing: '1' }
     })
     const h = createMockH()
 
-    uploadConstructionDrawingController.handler(request, h)
+    await uploadConstructionDrawingController.handler(request, h)
 
     expect(h.view).toHaveBeenCalledWith(
       UPLOAD_CONSTRUCTION_DRAWING_VIEW_ROUTE,
-      {
-        pageTitle: 'Upload a construction drawing',
-        heading: 'Upload a construction drawing',
+      expect.objectContaining({
+        pageTitle: 'Site 1: Upload construction drawing 1',
+        heading: 'Site 1: Upload construction drawing 1',
         projectName: mockMarineLicenceApplication.projectName,
         siteNumber: 1,
-        activityDetailsNumber: 2,
+        drawingNumber: 1,
+        uploadUrl: mockUploadConfig.uploadUrl,
+        acceptAttribute: '.pdf,.bmp,.gif,.jpg,.jpeg,.png,.tif',
         backLink:
-          '/marine-licence/review-site-details#activity-details-site-1-activity-2'
-      }
+          '/marine-licence/review-site-details#construction-drawing-site-1-1',
+        cancelLink:
+          '/marine-licence/review-site-details#construction-drawing-site-1-1'
+      })
+    )
+  })
+
+  it('initiates a CDP upload constrained to 10MB', async () => {
+    const initiate = vi.fn().mockResolvedValue(mockUploadConfig)
+    vi.mocked(cdpUploadService.getCdpUploadService).mockReturnValue({
+      initiate
+    })
+
+    const request = createMockRequest({
+      query: { site: '1', drawing: '2' }
+    })
+    const h = createMockH()
+
+    await uploadConstructionDrawingController.handler(request, h)
+
+    expect(initiate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        maxFileSize: 10 * 1024 * 1024,
+        s3Path: 'marine-licence/construction-drawings'
+      })
+    )
+  })
+
+  it('stores the upload config against the site, keyed by drawing index', async () => {
+    const request = createMockRequest({
+      query: { site: '1', drawing: '2' }
+    })
+    const h = createMockH()
+
+    await uploadConstructionDrawingController.handler(request, h)
+
+    expect(cacheUtils.updateMarineLicenceSiteDetails).toHaveBeenCalledWith(
+      request,
+      h,
+      0,
+      'uploadConfig',
+      expect.objectContaining({
+        fileType: 'construction-drawing',
+        siteIndex: 0,
+        drawingIndex: 1
+      })
+    )
+  })
+
+  it('displays an error and clears it from the session when one is present', async () => {
+    vi.mocked(cacheUtils.getMarineLicenceCache).mockReturnValue({
+      ...mockMarineLicenceApplication,
+      siteDetails: [
+        {
+          ...mockMarineLicenceApplication.siteDetails[0],
+          uploadError: {
+            message: 'The selected file contains a virus',
+            fieldName: 'file'
+          }
+        }
+      ]
+    })
+
+    const request = createMockRequest({
+      query: { site: '1', drawing: '1' }
+    })
+    const h = createMockH()
+
+    await uploadConstructionDrawingController.handler(request, h)
+
+    expect(h.view).toHaveBeenCalledWith(
+      UPLOAD_CONSTRUCTION_DRAWING_VIEW_ROUTE,
+      expect.objectContaining({
+        errorSummary: [
+          expect.objectContaining({
+            text: 'The selected file contains a virus'
+          })
+        ]
+      })
+    )
+    expect(cacheUtils.updateMarineLicenceSiteDetails).toHaveBeenCalledWith(
+      request,
+      h,
+      0,
+      'uploadError',
+      null
     )
   })
 })

--- a/src/server/marine-licence/site-details/upload-construction-drawing/index.njk
+++ b/src/server/marine-licence/site-details/upload-construction-drawing/index.njk
@@ -1,24 +1,75 @@
 {% extends 'layouts/page.njk' %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/file-upload/macro.njk" import govukFileUpload %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "cancel-button/macro.njk" import appCancelButton %}
 
 {% block beforeContent %}
-{{ super() }}
-<nav>
-  {{ govukBackLink({
-    text: "Back",
-    href: backLink
-  }) }}
-</nav>
+  {{ super() }}
+  <nav>
+    {{ govukBackLink({
+      text: "Back",
+      href: backLink
+    }) }}
+  </nav>
 {% endblock %}
+
+{% set formLabel %}
+  {% if projectName %}
+    <span class="govuk-caption-l">{{ projectName }}</span>
+  {% endif %}
+
+  <h1 class="govuk-heading-l">{{ heading }}</h1>
+
+  <p class="govuk-body">Upload a drawing showing what you plan to build or change at this site. Only upload drawings that show the work you're telling us about in this application.</p>
+
+  <p class="govuk-body">If your drawing is part of a larger document, upload only the pages that show this work. Do not upload full project plans or documents that cover other work.</p>
+
+  <p class="govuk-body">The file must be a PDF or image (.bmp, .gif, .jpg, .jpeg, .png, .tif) and no larger than 10MB.</p>
+{% endset %}
 
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <span class="govuk-caption-l">{{ projectName }}</span>
-      <span class="govuk-caption-l">Site {{ siteNumber }} - Activity {{ activityDetailsNumber }}</span>
-      <h1 class="govuk-heading-l">{{ heading }}</h1>
 
-      <p class="govuk-body">This part of the service is not yet available. You'll be able to upload your construction drawing here soon.</p>
+      {% if errorSummary %}
+        {{ govukErrorSummary({
+          titleText: "There is a problem",
+          errorList: errorSummary
+        }) }}
+      {% endif %}
+
+      <form action="{{ uploadUrl }}" method="post" enctype="multipart/form-data" novalidate>
+
+        {{ govukFileUpload({
+            id: "file-id",
+            name: "file",
+            label: {
+              html: formLabel,
+              for: "file-id"
+            },
+            multiple: false,
+            javascript: true,
+            errorMessage: { text: errors['file'].text } if errors and errors['file'] else false,
+            attributes: {
+              "accept": acceptAttribute
+            }
+        }) }}
+
+        <div class="govuk-button-group">
+          {{ govukButton({
+            text: "Save and continue",
+            type: "submit",
+            classes: "govuk-button--primary"
+          }) }}
+
+          {{ appCancelButton({
+            cancelLink: cancelLink
+          }) }}
+        </div>
+
+      </form>
     </div>
   </div>
 {% endblock %}

--- a/src/server/marine-licence/site-details/utils/back-link.js
+++ b/src/server/marine-licence/site-details/utils/back-link.js
@@ -5,6 +5,9 @@ import { getSiteParam } from '#src/server/common/helpers/site-details/site-numbe
 export const getActivityDetailsBackLink = (siteNumber, activityDetailsNumber) =>
   `${marineLicenceRoutes.MARINE_LICENCE_REVIEW_SITE_DETAILS}#activity-details-site-${siteNumber}-activity-${activityDetailsNumber}`
 
+export const getConstructionDrawingBackLink = (siteNumber, drawingNumber) =>
+  `${marineLicenceRoutes.MARINE_LICENCE_REVIEW_SITE_DETAILS}#construction-drawing-site-${siteNumber}-${drawingNumber}`
+
 export const getCoordinateSystemBackLink = (
   action,
   siteNumber,

--- a/src/services/cdp-upload-service/cdp-upload-service.js
+++ b/src/services/cdp-upload-service/cdp-upload-service.js
@@ -100,13 +100,19 @@ export class CdpUploadService {
     )
   }
 
-  async initiate({ redirectUrl, s3Bucket, allowedMimeTypes, s3Path = '' }) {
+  async initiate({
+    redirectUrl,
+    s3Bucket,
+    allowedMimeTypes,
+    maxFileSize,
+    s3Path = ''
+  }) {
     this._validateInitiateParams({ redirectUrl, s3Bucket })
 
     const mimeTypes = allowedMimeTypes ?? this.allowedMimeTypes
     const requestPayload = {
       redirect: redirectUrl,
-      maxFileSize: this.config.maxFileSize,
+      maxFileSize: maxFileSize ?? this.config.maxFileSize,
       s3Path,
       s3Bucket
     }

--- a/src/services/cdp-upload-service/cdp-upload-service.test.js
+++ b/src/services/cdp-upload-service/cdp-upload-service.test.js
@@ -160,6 +160,36 @@ describe('#CdpUploadService', () => {
         expect(result.allowedTypes).toEqual(overrideMimeTypes)
       })
 
+      test('Should override the default maxFileSize when provided', async () => {
+        // Given
+        const mockResponse = {
+          uploadId: mockUploadId,
+          uploadUrl: mockUploadUrl
+        }
+
+        Wreck.post.mockResolvedValue({
+          res: { statusCode: 200 },
+          payload: mockResponse
+        })
+
+        const tenMb = 10 * 1024 * 1024
+
+        // When
+        await service.initiate({
+          redirectUrl: mockRedirectUrl,
+          s3Bucket: config.get('cdpUploader').s3Bucket,
+          maxFileSize: tenMb
+        })
+
+        // Then
+        expect(Wreck.post).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.objectContaining({
+            payload: expect.stringContaining(`"maxFileSize":${tenMb}`)
+          })
+        )
+      })
+
       test('Should include s3Path when provided', async () => {
         // Given
         const s3Path = 'uploads/kml-files'

--- a/tests/integration/accessibility/marine-licence-page-accessibility.test.js
+++ b/tests/integration/accessibility/marine-licence-page-accessibility.test.js
@@ -179,6 +179,27 @@ const marineLicencePages = [
     url: `${marineLicenceRoutes.MARINE_LICENCE_UPLOAD_CONSTRUCTION_DRAWING}?site=1&drawing=1`,
     title: 'Site 1: Upload construction drawing 1'
   },
+  // TODO: Uncomment when meta refresh a11y issue is resolved (same issue as upload-and-wait)
+  // {
+  //   url: marineLicenceRoutes.MARINE_LICENCE_UPLOAD_CONSTRUCTION_DRAWING_WAIT,
+  //   title: 'Upload construction drawing'
+  // },
+  {
+    url: `${marineLicenceRoutes.MARINE_LICENCE_DELETE_CONSTRUCTION_DRAWING}?site=1&drawing=2`,
+    title: 'Are you sure you want to delete Site 1 construction drawing 2?',
+    marineLicence: {
+      ...mockMarineLicenceApplication,
+      siteDetails: [
+        {
+          ...mockMarineLicenceApplication.siteDetails[0],
+          constructionDrawings: [
+            { filename: 'drawing-1.pdf' },
+            { filename: 'drawing-2.pdf' }
+          ]
+        }
+      ]
+    }
+  },
   {
     url: `${marineLicenceRoutes.MARINE_LICENCE_CONFIRM_CHANGE_ACTIVITY_TYPE}?site=1&activity=1&activityType=deposit&activitySubType=deposit-type-1`,
     title:

--- a/tests/integration/accessibility/marine-licence-page-accessibility.test.js
+++ b/tests/integration/accessibility/marine-licence-page-accessibility.test.js
@@ -176,8 +176,8 @@ const marineLicencePages = [
     title: 'Are you sure you want to delete this activity?'
   },
   {
-    url: `${marineLicenceRoutes.MARINE_LICENCE_UPLOAD_CONSTRUCTION_DRAWING}?site=1&activity=1`,
-    title: 'Upload a construction drawing'
+    url: `${marineLicenceRoutes.MARINE_LICENCE_UPLOAD_CONSTRUCTION_DRAWING}?site=1&drawing=1`,
+    title: 'Site 1: Upload construction drawing 1'
   },
   {
     url: `${marineLicenceRoutes.MARINE_LICENCE_CONFIRM_CHANGE_ACTIVITY_TYPE}?site=1&activity=1&activityType=deposit&activitySubType=deposit-type-1`,

--- a/tests/integration/marine-licence/confirm-change-activity-type.test.js
+++ b/tests/integration/marine-licence/confirm-change-activity-type.test.js
@@ -1,3 +1,4 @@
+import { vi } from 'vitest'
 import { within } from '@testing-library/dom'
 import {
   mockMarineLicence,
@@ -5,11 +6,17 @@ import {
 } from '~/tests/integration/shared/test-setup-helpers.js'
 import { loadPage } from '~/tests/integration/shared/app-server.js'
 import { mockMarineLicenceApplication } from '#src/server/test-helpers/mocks/marine-licence-mocks.js'
-import { marineLicenceRoutes } from '#src/server/common/constants/routes.js'
+import {
+  apiRoutes,
+  marineLicenceRoutes
+} from '#src/server/common/constants/routes.js'
 import {
   makeGetRequest,
   makePostRequest
 } from '#src/server/test-helpers/server-requests.js'
+import * as authenticatedRequests from '#src/server/common/helpers/authenticated-requests.js'
+
+vi.mock('#src/server/common/helpers/authenticated-requests.js')
 
 describe('Confirm change activity type', () => {
   mockMarineLicence(mockMarineLicenceApplication)
@@ -69,6 +76,76 @@ describe('Confirm change activity type', () => {
     expect(response.statusCode).toBe(302)
     expect(response.headers.location).toBe(
       '/marine-licence/activity-details/what-are-you-maintaining?site=1&activity=1'
+    )
+  })
+
+  test('confirming deletes the site construction drawings when no other activity on the site needs one', async () => {
+    mockMarineLicence({
+      ...mockMarineLicenceApplication,
+      siteDetails: [
+        {
+          ...mockMarineLicenceApplication.siteDetails[0],
+          activityDetails: [
+            mockMarineLicenceApplication.siteDetails[0].activityDetails[0]
+          ],
+          constructionDrawings: [{ filename: 'drawing-1.pdf' }]
+        }
+      ]
+    })
+
+    const response = await makePostRequest({
+      url: `${marineLicenceRoutes.MARINE_LICENCE_CONFIRM_CHANGE_ACTIVITY_TYPE}?site=1&activity=1`,
+      server: getServer(),
+      formData: {
+        site: '1',
+        activity: '1',
+        activityType: 'construction',
+        activitySubType: 'construction-type-2'
+      }
+    })
+
+    expect(response.statusCode).toBe(302)
+    expect(
+      vi.mocked(authenticatedRequests.authenticatedPatchRequest)
+    ).toHaveBeenCalledWith(
+      expect.anything(),
+      apiRoutes.DELETE_CONSTRUCTION_DRAWINGS,
+      {
+        id: mockMarineLicenceApplication.id,
+        siteIndex: 0
+      }
+    )
+  })
+
+  test('confirming does not delete the site construction drawings when another activity on the site still requires one', async () => {
+    mockMarineLicence({
+      ...mockMarineLicenceApplication,
+      siteDetails: [
+        {
+          ...mockMarineLicenceApplication.siteDetails[0],
+          constructionDrawings: [{ filename: 'drawing-1.pdf' }]
+        }
+      ]
+    })
+
+    const response = await makePostRequest({
+      url: `${marineLicenceRoutes.MARINE_LICENCE_CONFIRM_CHANGE_ACTIVITY_TYPE}?site=1&activity=1`,
+      server: getServer(),
+      formData: {
+        site: '1',
+        activity: '1',
+        activityType: 'construction',
+        activitySubType: 'construction-type-2'
+      }
+    })
+
+    expect(response.statusCode).toBe(302)
+    expect(
+      vi.mocked(authenticatedRequests.authenticatedPatchRequest)
+    ).not.toHaveBeenCalledWith(
+      expect.anything(),
+      apiRoutes.DELETE_CONSTRUCTION_DRAWINGS,
+      expect.anything()
     )
   })
 })

--- a/tests/integration/marine-licence/review-site-details-construction-drawing.test.js
+++ b/tests/integration/marine-licence/review-site-details-construction-drawing.test.js
@@ -17,7 +17,7 @@ describe('Review site details - construction drawing card', () => {
   const getServer = setupTestServer()
 
   describe('file upload coordinates journey', () => {
-    test('renders drawing cards and the "Add another" button after the activity cards, in the correct order', async () => {
+    test('renders one drawing card and the "Add another" button after the activity cards, in the correct order', async () => {
       mockMarineLicence(mockMarineLicenceApplication)
 
       const document = await loadPage({
@@ -29,19 +29,16 @@ describe('Review site details - construction drawing card', () => {
         'activity-details-site-1-activity-1',
         'activity-details-site-1-activity-2',
         'add-another-activity-site-1',
-        'construction-drawing-site-1-activity-1',
-        'construction-drawing-site-1-activity-2',
+        'construction-drawing-site-1-1',
         'add-another-construction-drawing-site-1'
       ])
 
       const addDrawingButton = document.querySelector(
         '#add-another-construction-drawing-site-1'
       )
-      expect(addDrawingButton.tagName).toBe('A')
-      expect(addDrawingButton).toHaveAttribute(
-        'href',
-        'upload-construction-drawing?site=1&activity=1'
-      )
+      expect(addDrawingButton.tagName).toBe('BUTTON')
+      expect(addDrawingButton).toHaveAttribute('type', 'submit')
+      expect(addDrawingButton).toHaveAttribute('name', 'addConstructionDrawing')
     })
 
     test('does not render drawing cards or button when no activity requires a drawing', async () => {
@@ -71,6 +68,62 @@ describe('Review site details - construction drawing card', () => {
       expect(
         document.querySelector('#add-another-construction-drawing-site-1')
       ).toBeNull()
+    })
+  })
+
+  describe('multiple drawings for a site', () => {
+    test('numbers each drawing card sequentially and only shows a delete link from the second drawing onwards', async () => {
+      mockMarineLicence({
+        ...mockMarineLicenceApplication,
+        siteDetails: [
+          {
+            ...mockMarineLicenceApplication.siteDetails[0],
+            constructionDrawings: [
+              {
+                filename: 'drawing-one.pdf',
+                s3Location: {
+                  s3Bucket: 'test-bucket',
+                  s3Key: 'test-key-1',
+                  checksumSha256: 'test-checksum-1'
+                }
+              },
+              {
+                filename: 'drawing-two.pdf',
+                s3Location: {
+                  s3Bucket: 'test-bucket',
+                  s3Key: 'test-key-2',
+                  checksumSha256: 'test-checksum-2'
+                }
+              }
+            ]
+          }
+        ]
+      })
+
+      const document = await loadPage({
+        requestUrl: marineLicenceRoutes.MARINE_LICENCE_REVIEW_SITE_DETAILS,
+        server: getServer()
+      })
+
+      expect(
+        document.querySelector('#construction-drawing-site-1-1')
+      ).not.toBeNull()
+      expect(
+        document.querySelector('#construction-drawing-site-1-2')
+      ).not.toBeNull()
+
+      const firstCardDeleteLink = document
+        .querySelector('#construction-drawing-site-1-1')
+        .querySelector('a[href*="delete-construction-drawing"]')
+      const secondCardDeleteLink = document
+        .querySelector('#construction-drawing-site-1-2')
+        .querySelector('a[href*="delete-construction-drawing"]')
+
+      expect(firstCardDeleteLink).toBeNull()
+      expect(secondCardDeleteLink).toHaveAttribute(
+        'href',
+        'delete-construction-drawing?site=1&drawing=2'
+      )
     })
   })
 
@@ -104,7 +157,7 @@ describe('Review site details - construction drawing card', () => {
       expect(getCardOrder(document)).toEqual([
         'activity-details-site-1-activity-1',
         'add-another-activity-site-1',
-        'construction-drawing-site-1-activity-1',
+        'construction-drawing-site-1-1',
         'add-another-construction-drawing-site-1'
       ])
     })

--- a/tests/integration/marine-licence/select-activity.test.js
+++ b/tests/integration/marine-licence/select-activity.test.js
@@ -12,6 +12,7 @@ import {
   expectFieldsetError,
   expectInputValue
 } from '~/tests/integration/shared/expect-utils.js'
+import { updateMarineLicenceSiteDetails } from '#src/server/common/helpers/marine-licence/session-cache/utils.js'
 
 describe('Type of activity (marine licence)', () => {
   const getServer = setupTestServer()
@@ -128,6 +129,53 @@ describe('Type of activity (marine licence)', () => {
     expect(response.statusCode).toBe(statusCodes.redirect)
     expect(response.headers.location).toBe(
       `${marineLicenceRoutes.MARINE_LICENCE_REVIEW_SITE_DETAILS}#activity-details-site-1-activity-1`
+    )
+  })
+
+  test('seeds the first construction drawing on submission when the activity subtype requires one', async () => {
+    mockMarineLicence(mockMarineLicenceApplication)
+
+    const response = await makePostRequest({
+      url: `/marine-licence/activity-details/${variantUsedForTesting}?site=1&activity=1`,
+      server: getServer(),
+      formData: {
+        activities: ['CON1'],
+        otherActivity: 'Test activity'
+      }
+    })
+
+    expect(response.statusCode).toBe(statusCodes.redirect)
+    expect(updateMarineLicenceSiteDetails).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      0,
+      'constructionDrawings',
+      [{}]
+    )
+  })
+
+  test('does not seed a construction drawing when the activity subtype does not require one', async () => {
+    const maintenanceApplication = structuredClone(mockMarineLicenceApplication)
+    maintenanceApplication.siteDetails[0].activityDetails[0].activitySubType =
+      'construction-type-2'
+    mockMarineLicence(maintenanceApplication)
+
+    const response = await makePostRequest({
+      url: '/marine-licence/activity-details/what-are-you-maintaining?site=1&activity=1',
+      server: getServer(),
+      formData: {
+        activities: ['CON1'],
+        otherActivity: 'Test activity'
+      }
+    })
+
+    expect(response.statusCode).toBe(statusCodes.redirect)
+    expect(updateMarineLicenceSiteDetails).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      0,
+      'constructionDrawings',
+      expect.anything()
     )
   })
 

--- a/tests/integration/marine-licence/type-of-activity.test.js
+++ b/tests/integration/marine-licence/type-of-activity.test.js
@@ -188,8 +188,18 @@ describe('Type of activity (marine licence)', () => {
     )
   })
 
-  test('redirects to the change-activity guard when moving away from a drawing-requiring activity', async () => {
-    mockMarineLicence(mockMarineLicenceApplication)
+  test('redirects to the change-activity guard when moving away from a drawing-requiring activity and no other activity on the site needs one', async () => {
+    mockMarineLicence({
+      ...mockMarineLicenceApplication,
+      siteDetails: [
+        {
+          ...mockMarineLicenceApplication.siteDetails[0],
+          activityDetails: [
+            mockMarineLicenceApplication.siteDetails[0].activityDetails[0]
+          ]
+        }
+      ]
+    })
 
     const response = await makePostRequest({
       url: `${marineLicenceRoutes.MARINE_LICENCE_TYPE_OF_ACTIVITY}?site=1&activity=1`,
@@ -203,6 +213,24 @@ describe('Type of activity (marine licence)', () => {
     expect(response.statusCode).toBe(statusCodes.redirect)
     expect(response.headers.location).toBe(
       '/marine-licence/confirm-change-activity-type?site=1&activity=1&activityType=deposit&activitySubType=deposit-type-2'
+    )
+  })
+
+  test('does not redirect to the change-activity guard when another activity on the site still requires a drawing', async () => {
+    mockMarineLicence(mockMarineLicenceApplication)
+
+    const response = await makePostRequest({
+      url: `${marineLicenceRoutes.MARINE_LICENCE_TYPE_OF_ACTIVITY}?site=1&activity=1`,
+      server: getServer(),
+      formData: {
+        activityType: 'deposit',
+        activitySubTypeDeposit: 'deposit-type-2'
+      }
+    })
+
+    expect(response.statusCode).toBe(statusCodes.redirect)
+    expect(response.headers.location).toBe(
+      '/marine-licence/activity-details/what-new-deposit-activity-are-you-doing?site=1&activity=1'
     )
   })
 })

--- a/tests/integration/marine-licence/type-of-activity.test.js
+++ b/tests/integration/marine-licence/type-of-activity.test.js
@@ -1,5 +1,9 @@
+import { vi } from 'vitest'
 import { getByRole, getByText } from '@testing-library/dom'
-import { marineLicenceRoutes } from '~/src/server/common/constants/routes.js'
+import {
+  apiRoutes,
+  marineLicenceRoutes
+} from '~/src/server/common/constants/routes.js'
 import {
   mockMarineLicence,
   setupTestServer
@@ -8,6 +12,9 @@ import { loadPage } from '~/tests/integration/shared/app-server.js'
 import { makePostRequest } from '~/src/server/test-helpers/server-requests.js'
 import { statusCodes } from '~/src/server/common/constants/status-codes.js'
 import { mockMarineLicenceApplication } from '#src/server/test-helpers/mocks/marine-licence-mocks.js'
+import * as authenticatedRequests from '#src/server/common/helpers/authenticated-requests.js'
+
+vi.mock('#src/server/common/helpers/authenticated-requests.js')
 
 describe('Type of activity (marine licence)', () => {
   const getServer = setupTestServer()
@@ -231,6 +238,45 @@ describe('Type of activity (marine licence)', () => {
     expect(response.statusCode).toBe(statusCodes.redirect)
     expect(response.headers.location).toBe(
       '/marine-licence/activity-details/what-new-deposit-activity-are-you-doing?site=1&activity=1'
+    )
+  })
+
+  test('seeds the first construction drawing when the new subtype newly requires one', async () => {
+    mockMarineLicence({
+      ...mockMarineLicenceApplication,
+      siteDetails: [
+        {
+          ...mockMarineLicenceApplication.siteDetails[0],
+          activityDetails: [
+            {
+              ...mockMarineLicenceApplication.siteDetails[0].activityDetails[0],
+              activityType: 'deposit',
+              activitySubType: 'deposit-type-1'
+            }
+          ]
+        }
+      ]
+    })
+
+    const response = await makePostRequest({
+      url: `${marineLicenceRoutes.MARINE_LICENCE_TYPE_OF_ACTIVITY}?site=1&activity=1`,
+      server: getServer(),
+      formData: {
+        activityType: 'construction',
+        activitySubTypeConstruction: 'construction-type-1'
+      }
+    })
+
+    expect(response.statusCode).toBe(statusCodes.redirect)
+    expect(
+      vi.mocked(authenticatedRequests.authenticatedPatchRequest)
+    ).toHaveBeenCalledWith(
+      expect.anything(),
+      apiRoutes.ADD_CONSTRUCTION_DRAWING,
+      {
+        siteIndex: 0,
+        id: mockMarineLicenceApplication.id
+      }
     )
   })
 })

--- a/tests/integration/marine-licence/type-of-activity.test.js
+++ b/tests/integration/marine-licence/type-of-activity.test.js
@@ -1,9 +1,5 @@
-import { vi } from 'vitest'
 import { getByRole, getByText } from '@testing-library/dom'
-import {
-  apiRoutes,
-  marineLicenceRoutes
-} from '~/src/server/common/constants/routes.js'
+import { marineLicenceRoutes } from '~/src/server/common/constants/routes.js'
 import {
   mockMarineLicence,
   setupTestServer
@@ -12,9 +8,6 @@ import { loadPage } from '~/tests/integration/shared/app-server.js'
 import { makePostRequest } from '~/src/server/test-helpers/server-requests.js'
 import { statusCodes } from '~/src/server/common/constants/status-codes.js'
 import { mockMarineLicenceApplication } from '#src/server/test-helpers/mocks/marine-licence-mocks.js'
-import * as authenticatedRequests from '#src/server/common/helpers/authenticated-requests.js'
-
-vi.mock('#src/server/common/helpers/authenticated-requests.js')
 
 describe('Type of activity (marine licence)', () => {
   const getServer = setupTestServer()
@@ -238,45 +231,6 @@ describe('Type of activity (marine licence)', () => {
     expect(response.statusCode).toBe(statusCodes.redirect)
     expect(response.headers.location).toBe(
       '/marine-licence/activity-details/what-new-deposit-activity-are-you-doing?site=1&activity=1'
-    )
-  })
-
-  test('seeds the first construction drawing when the new subtype newly requires one', async () => {
-    mockMarineLicence({
-      ...mockMarineLicenceApplication,
-      siteDetails: [
-        {
-          ...mockMarineLicenceApplication.siteDetails[0],
-          activityDetails: [
-            {
-              ...mockMarineLicenceApplication.siteDetails[0].activityDetails[0],
-              activityType: 'deposit',
-              activitySubType: 'deposit-type-1'
-            }
-          ]
-        }
-      ]
-    })
-
-    const response = await makePostRequest({
-      url: `${marineLicenceRoutes.MARINE_LICENCE_TYPE_OF_ACTIVITY}?site=1&activity=1`,
-      server: getServer(),
-      formData: {
-        activityType: 'construction',
-        activitySubTypeConstruction: 'construction-type-1'
-      }
-    })
-
-    expect(response.statusCode).toBe(statusCodes.redirect)
-    expect(
-      vi.mocked(authenticatedRequests.authenticatedPatchRequest)
-    ).toHaveBeenCalledWith(
-      expect.anything(),
-      apiRoutes.ADD_CONSTRUCTION_DRAWING,
-      {
-        siteIndex: 0,
-        id: mockMarineLicenceApplication.id
-      }
     )
   })
 })

--- a/tests/integration/marine-licence/upload-construction-drawing.test.js
+++ b/tests/integration/marine-licence/upload-construction-drawing.test.js
@@ -1,3 +1,4 @@
+import { vi } from 'vitest'
 import { within } from '@testing-library/dom'
 import {
   mockMarineLicence,
@@ -6,27 +7,47 @@ import {
 import { loadPage } from '~/tests/integration/shared/app-server.js'
 import { mockMarineLicenceApplication } from '#src/server/test-helpers/mocks/marine-licence-mocks.js'
 import { marineLicenceRoutes } from '#src/server/common/constants/routes.js'
+import * as cdpUploadService from '~/src/services/cdp-upload-service/index.js'
 
-describe('Upload construction drawing (placeholder)', () => {
-  mockMarineLicence(mockMarineLicenceApplication)
+vi.mock('~/src/services/cdp-upload-service/index.js')
 
+describe('Upload construction drawing', () => {
   const getServer = setupTestServer()
 
-  test('displays a holding page for the not-yet-built upload journey', async () => {
+  beforeEach(() => {
+    vi.mocked(cdpUploadService.getCdpUploadService).mockReturnValue({
+      initiate: vi.fn().mockResolvedValue({
+        uploadId: 'test-upload-id',
+        uploadUrl: 'https://upload.example.com',
+        statusUrl: 'https://status.example.com',
+        maxFileSize: 10 * 1024 * 1024
+      })
+    })
+  })
+
+  test('displays the upload screen for the given site and drawing', async () => {
+    mockMarineLicence(mockMarineLicenceApplication)
+
     const document = await loadPage({
-      requestUrl: `${marineLicenceRoutes.MARINE_LICENCE_UPLOAD_CONSTRUCTION_DRAWING}?site=1&activity=1`,
+      requestUrl: `${marineLicenceRoutes.MARINE_LICENCE_UPLOAD_CONSTRUCTION_DRAWING}?site=1&drawing=1`,
       server: getServer()
     })
 
     within(document).getByRole('heading', {
       level: 1,
-      name: 'Upload a construction drawing'
+      name: 'Site 1: Upload construction drawing 1'
     })
 
     const backLink = within(document).getByRole('link', { name: 'Back' })
     expect(backLink).toHaveAttribute(
       'href',
-      '/marine-licence/review-site-details#activity-details-site-1-activity-1'
+      '/marine-licence/review-site-details#construction-drawing-site-1-1'
+    )
+
+    const fileInput = document.querySelector('input[type="file"]')
+    expect(fileInput).toHaveAttribute(
+      'accept',
+      '.pdf,.bmp,.gif,.jpg,.jpeg,.png,.tif'
     )
   })
 })

--- a/tests/integration/marine-licence/url-param-validation.test.js
+++ b/tests/integration/marine-licence/url-param-validation.test.js
@@ -31,6 +31,11 @@ describe('Param validation', () => {
     { url: marineLicenceRoutes.MARINE_LICENCE_DELETE_SITE }
   ]
 
+  const pagesWithSiteAndDrawingParams = [
+    { url: marineLicenceRoutes.MARINE_LICENCE_UPLOAD_CONSTRUCTION_DRAWING },
+    { url: marineLicenceRoutes.MARINE_LICENCE_DELETE_CONSTRUCTION_DRAWING }
+  ]
+
   const expectsTaskListRedirect = async (requestUrl) => {
     const response = await makeGetRequest({
       server: getServer(),
@@ -69,6 +74,24 @@ describe('Param validation', () => {
     })
   }
 
+  const drawingScenarios = (url) => {
+    test('redirects when drawing param is missing', async () => {
+      await expectsTaskListRedirect(`${url}?site=1`)
+    })
+    test('redirects when drawing param does not exist for the site', async () => {
+      await expectsTaskListRedirect(`${url}?site=1&drawing=999`)
+    })
+  }
+
+  const siteWithDrawingScenarios = (url) => {
+    test('redirects when site param is missing', async () => {
+      await expectsTaskListRedirect(`${url}?drawing=1`)
+    })
+    test('redirects when site param is not valid', async () => {
+      await expectsTaskListRedirect(`${url}?site=999&drawing=1`)
+    })
+  }
+
   describe.each(pagesWithSiteAndActivityParams)(
     'site and activity params - $url',
     ({ url }) => {
@@ -79,5 +102,13 @@ describe('Param validation', () => {
 
   describe.each(pagesWithSiteParamOnly)('site param only - $url', ({ url }) =>
     siteOnlyScenarios(url)
+  )
+
+  describe.each(pagesWithSiteAndDrawingParams)(
+    'site and drawing params - $url',
+    ({ url }) => {
+      siteWithDrawingScenarios(url)
+      drawingScenarios(url)
+    }
   )
 })

--- a/tests/integration/review-site-details/marine-licence-fixtures/file-upload-fixtures.js
+++ b/tests/integration/review-site-details/marine-licence-fixtures/file-upload-fixtures.js
@@ -9,7 +9,24 @@ import {
 export const testScenarios = [
   {
     name: 'File Upload - KML - Complete site details',
-    marineLicence: mockMarineLicenceApplication,
+    marineLicence: {
+      ...mockMarineLicenceApplication,
+      siteDetails: [
+        {
+          ...mockMarineLicenceApplication.siteDetails[0],
+          constructionDrawings: [
+            {
+              filename: 'tech-drawing.pdf',
+              s3Location: {
+                s3Bucket: 'test-bucket',
+                s3Key: 'test-key',
+                checksumSha256: 'test-checksum'
+              }
+            }
+          ]
+        }
+      ]
+    },
     expectedPageContent: {
       projectName: 'Test Project',
       backLink: marineLicenceRoutes.MARINE_LICENCE_FILE_UPLOAD,


### PR DESCRIPTION
## Summary

ML-1475: implements construction drawing upload for sites with an activity
type that requires one — the "step 2" upload flow following on from ML-1469.

- Upload a construction drawing per site (PDF or image, max 10MB) using the
  existing CDP upload-and-poll pattern, with a wait page and CDP status
  polling
- Add extra drawings for a site, and delete any drawing after the first
  (the first is required and can't be removed)
- Review-site-details page now renders a card per drawing, showing upload
  status and a delete link where applicable
- A site with a drawing-required activity is treated as incomplete until
  its first drawing is uploaded
- If an activity is changed to a type that no longer requires a drawing
  (and no other activity on the site still needs one), the site's drawings
  are automatically deleted

Depends-On: https://github.com/DEFRA/marine-licensing-journey-tests/pull/340
Depends-On: https://github.com/DEFRA/marine-licensing-backend/pull/563
