### PR TITLE
ML-1479: Reject and resubmit an application

### DIFF
--- a/src/server/common/components/marine-licence/application-details-card/template.njk
+++ b/src/server/common/components/marine-licence/application-details-card/template.njk
@@ -32,7 +32,7 @@
   }
 },{
   key: {
-    text: "Date rejected"
+    text: "Date marked as unable to progress"
   },
   value: {
     text: params.rejectedDate
@@ -45,7 +45,15 @@
   value: {
     text: params.transferredDate
   }
-} if params.isTransferred), rows) %}
+} if params.isTransferred,
+{
+  key: {
+    text: "Reasons marked as unable to progress"
+  },
+  value: {
+    html: params.rejectedReasons
+  }
+} if params.isRejected), rows) %}
 
 
 {{ govukSummaryList({

--- a/src/server/common/components/marine-licence/application-details-card/template.njk
+++ b/src/server/common/components/marine-licence/application-details-card/template.njk
@@ -32,12 +32,20 @@
   }
 },{
   key: {
+    text: "Date rejected"
+  },
+  value: {
+    text: params.rejectedDate
+  }
+} if params.isRejected, 
+{
+  key: {
     text: "Date of transfer"
   },
   value: {
     text: params.transferredDate
   }
-}), rows) %}
+} if params.isTransferred), rows) %}
 
 
 {{ govukSummaryList({

--- a/src/server/common/components/marine-licence/application-details-card/template.test.js
+++ b/src/server/common/components/marine-licence/application-details-card/template.test.js
@@ -55,6 +55,7 @@ describe('Marine Licence Application Details Card Component', () => {
         applicationReference: 'TEST-REF',
         submittedAt: '01 01 2026',
         rejectedDate: '02 02 2026',
+        rejectedReasons: '<p>Test reason</p>',
         isRejected: true
       }
     )
@@ -75,7 +76,10 @@ describe('Marine Licence Application Details Card Component', () => {
     expect(htmlContent).toContain('Date submitted')
     expect(htmlContent).toContain('01 01 2026')
 
-    expect(htmlContent).toContain('Date rejected')
+    expect(htmlContent).toContain('Date marked as unable to progress')
     expect(htmlContent).toContain('02 02 2026')
+
+    expect(htmlContent).toContain('Reasons marked as unable to progress')
+    expect(htmlContent).toContain('<p>Test reason</p>')
   })
 })

--- a/src/server/common/components/marine-licence/application-details-card/template.test.js
+++ b/src/server/common/components/marine-licence/application-details-card/template.test.js
@@ -1,27 +1,36 @@
 import { renderComponent } from '#src/server/test-helpers/component-helpers.js'
 
 describe('Marine Licence Application Details Card Component', () => {
-  let $component
-
-  beforeEach(() => {
-    $component = renderComponent('marine-licence/application-details-card', {
-      statusTag: '<a>Test</a>',
-      applicationReference: 'TEST-REF',
-      submittedAt: '01 01 2026',
-      transferredDate: '02 01 2026'
-    })
-  })
-
   test('Should render Application details card component', () => {
-    expect($component('#application-details-card')).toHaveLength(1)
+    const $componentTransferred = renderComponent(
+      'marine-licence/application-details-card',
+      {
+        statusTag: '<a>Test</a>',
+        applicationReference: 'TEST-REF',
+        submittedAt: '01 01 2026',
+        transferredDate: '02 01 2026',
+        isTransferred: true
+      }
+    )
+    expect($componentTransferred('#application-details-card')).toHaveLength(1)
   })
 
-  test('Should have correct card title', () => {
-    expect($component('.govuk-summary-card__title').text().trim()).toBe(
-      'Application details'
+  test('Should have correct card content for transferred application', () => {
+    const $componentTransferred = renderComponent(
+      'marine-licence/application-details-card',
+      {
+        statusTag: '<a>Test</a>',
+        applicationReference: 'TEST-REF',
+        submittedAt: '01 01 2026',
+        transferredDate: '02 01 2026',
+        isTransferred: true
+      }
     )
+    expect(
+      $componentTransferred('.govuk-summary-card__title').text().trim()
+    ).toBe('Application details')
 
-    const htmlContent = $component.html()
+    const htmlContent = $componentTransferred.html()
     expect(htmlContent).toContain('Application type')
     expect(htmlContent).toContain('Marine licence application')
 
@@ -36,5 +45,37 @@ describe('Marine Licence Application Details Card Component', () => {
 
     expect(htmlContent).toContain('Date of transfer')
     expect(htmlContent).toContain('02 01 2026')
+  })
+
+  test('Should have correct card content for rejected application', () => {
+    const $componentRejected = renderComponent(
+      'marine-licence/application-details-card',
+      {
+        statusTag: '<a>Test</a>',
+        applicationReference: 'TEST-REF',
+        submittedAt: '01 01 2026',
+        rejectedDate: '02 02 2026',
+        isRejected: true
+      }
+    )
+    expect($componentRejected('.govuk-summary-card__title').text().trim()).toBe(
+      'Application details'
+    )
+
+    const htmlContent = $componentRejected.html()
+    expect(htmlContent).toContain('Application type')
+    expect(htmlContent).toContain('Marine licence application')
+
+    expect(htmlContent).toContain('Status')
+    expect(htmlContent).toContain('<a>Test</a>')
+
+    expect(htmlContent).toContain('Reference number')
+    expect(htmlContent).toContain('TEST-REF')
+
+    expect(htmlContent).toContain('Date submitted')
+    expect(htmlContent).toContain('01 01 2026')
+
+    expect(htmlContent).toContain('Date rejected')
+    expect(htmlContent).toContain('02 02 2026')
   })
 })

--- a/src/server/common/constants/projects.js
+++ b/src/server/common/constants/projects.js
@@ -1,10 +1,13 @@
 export const PROJECT_STATUS = {
   DRAFT: 'Draft',
   ACTIVE: 'Active',
+  REJECTED: 'Rejected',
   SUBMITTED: 'Submitted',
   TRANSFERRED: 'Transferred',
   WITHDRAWN: 'Withdrawn'
 }
+
+export const UNABLE_TO_PROGRESS = 'Unable to progress'
 
 export const PROJECT_TYPE = {
   EXEMPTION: 'exemption',

--- a/src/server/common/constants/routes.js
+++ b/src/server/common/constants/routes.js
@@ -219,5 +219,6 @@ export const apiRoutes = {
     '/marine-licence/calculate-marine-plan-policies',
   MARINE_LICENCE_MARINE_PLAN_POLICY_RESPONSE:
     '/marine-licence/marine-plan-policy-response',
-  CONFIRM_SITE_DETAILS: '/marine-licence/confirm-site-details'
+  CONFIRM_SITE_DETAILS: '/marine-licence/confirm-site-details',
+  COPY_MARINE_LICENCE: '/marine-licence/copy-marine-licence'
 }

--- a/src/server/common/constants/routes.js
+++ b/src/server/common/constants/routes.js
@@ -62,6 +62,7 @@ export const marineLicenceRoutes = {
   MARINE_LICENCE_CONFIRMATION: '/marine-licence/confirmation',
   MARINE_LICENCE_APPLICATION_TRANSFERRED:
     '/marine-licence/application-transferred',
+  MARINE_LICENCE_APPLICATION_REJECTED: '/marine-licence/application-rejected',
   MARINE_LICENCE_PROJECT_NAME: '/marine-licence/project-name',
   MARINE_LICENCE_TASK_LIST: '/marine-licence/task-list',
   MARINE_LICENCE_DELETE: '/marine-licence/delete',

--- a/src/server/common/constants/routes.js
+++ b/src/server/common/constants/routes.js
@@ -63,6 +63,7 @@ export const marineLicenceRoutes = {
   MARINE_LICENCE_APPLICATION_TRANSFERRED:
     '/marine-licence/application-transferred',
   MARINE_LICENCE_APPLICATION_REJECTED: '/marine-licence/application-rejected',
+  MARINE_LICENCE_UPDATE_AND_RESUBMIT: '/marine-licence/update-and-resubmit',
   MARINE_LICENCE_PROJECT_NAME: '/marine-licence/project-name',
   MARINE_LICENCE_TASK_LIST: '/marine-licence/task-list',
   MARINE_LICENCE_DELETE: '/marine-licence/delete',

--- a/src/server/common/helpers/marine-licence/validate-marine-licence-id-params.js
+++ b/src/server/common/helpers/marine-licence/validate-marine-licence-id-params.js
@@ -1,0 +1,19 @@
+import joi from 'joi'
+
+export const MARINE_LICENCE_ID_LENGTH = 24
+
+export const marineLicenceIdSchema = joi
+  .string()
+  .hex()
+  .length(MARINE_LICENCE_ID_LENGTH)
+  .required()
+
+export const marineLicenceIdParamsSchema = joi.object({
+  marineLicenceId: marineLicenceIdSchema
+})
+
+export const validateMarineLicenceIdParams = {
+  validate: {
+    params: marineLicenceIdParamsSchema
+  }
+}

--- a/src/server/common/helpers/marine-licence/validate-marine-licence-id-params.test.js
+++ b/src/server/common/helpers/marine-licence/validate-marine-licence-id-params.test.js
@@ -1,0 +1,27 @@
+import {
+  marineLicenceIdParamsSchema,
+  MARINE_LICENCE_ID_LENGTH
+} from '#src/server/common/helpers/marine-licence/validate-marine-licence-id-params.js'
+
+describe('#marineLicenceIdParamsSchema', () => {
+  const validId = 'a'.repeat(MARINE_LICENCE_ID_LENGTH)
+
+  test('accepts a valid marineLicenceId', () => {
+    const { error, value } = marineLicenceIdParamsSchema.validate({
+      marineLicenceId: validId
+    })
+
+    expect(error).toBeUndefined()
+    expect(value).toEqual({ marineLicenceId: validId })
+  })
+
+  test.each([
+    ['missing', {}],
+    ['empty', { marineLicenceId: '' }],
+    ['invalid format', { marineLicenceId: 'not-an-object-id' }]
+  ])('rejects when marineLicenceId is %s', (_label, params) => {
+    const { error } = marineLicenceIdParamsSchema.validate(params)
+
+    expect(error).toBeDefined()
+  })
+})

--- a/src/server/common/helpers/ui/get-tag-style.js
+++ b/src/server/common/helpers/ui/get-tag-style.js
@@ -8,6 +8,8 @@ export const getTagStyle = (status) => {
       return 'govuk-tag--grey'
     case PROJECT_STATUS.TRANSFERRED:
       return 'govuk-tag--magenta'
+    case PROJECT_STATUS.REJECTED:
+      return 'govuk-tag--orange'
     default:
       return 'govuk-tag--green'
   }

--- a/src/server/common/helpers/ui/get-tag-style.test.js
+++ b/src/server/common/helpers/ui/get-tag-style.test.js
@@ -17,6 +17,10 @@ describe('getTagStyle', () => {
     expect(getTagStyle('Transferred')).toBe('govuk-tag--magenta')
   })
 
+  it('should return magenta for Rejected', () => {
+    expect(getTagStyle('Rejected')).toBe('govuk-tag--orange')
+  })
+
   it('should return green for unknown status', () => {
     expect(getTagStyle('SomeOtherStatus')).toBe('govuk-tag--green')
   })

--- a/src/server/common/helpers/ui/get-tag-style.test.js
+++ b/src/server/common/helpers/ui/get-tag-style.test.js
@@ -17,7 +17,7 @@ describe('getTagStyle', () => {
     expect(getTagStyle('Transferred')).toBe('govuk-tag--magenta')
   })
 
-  it('should return magenta for Rejected', () => {
+  it('should return orange for Rejected', () => {
     expect(getTagStyle('Rejected')).toBe('govuk-tag--orange')
   })
 

--- a/src/server/dashboard/utils.js
+++ b/src/server/dashboard/utils.js
@@ -37,6 +37,13 @@ const getViewDetailsRoute = (projectType, status) => {
     return marineLicenceRoutes.MARINE_LICENCE_APPLICATION_TRANSFERRED
   }
 
+  if (
+    projectType === MARINE_LICENCE_KEY &&
+    status === PROJECT_STATUS.REJECTED
+  ) {
+    return marineLicenceRoutes.MARINE_LICENCE_APPLICATION_REJECTED
+  }
+
   return projectType === MARINE_LICENCE_KEY
     ? marineLicenceRoutes.MARINE_LICENCE_VIEW_DETAILS
     : routes.VIEW_DETAILS

--- a/src/server/dashboard/utils.js
+++ b/src/server/dashboard/utils.js
@@ -4,7 +4,10 @@ import {
   marineLicenceRoutes
 } from '#src/server/common/constants/routes.js'
 import { EXEMPTION_TYPE } from '#src/server/common/constants/exemptions.js'
-import { PROJECT_STATUS } from '#src/server/common/constants/projects.js'
+import {
+  PROJECT_STATUS,
+  UNABLE_TO_PROGRESS
+} from '#src/server/common/constants/projects.js'
 import { getTagStyle } from '#src/server/common/helpers/ui/get-tag-style.js'
 import escapeHtml from 'lodash/escape.js'
 import {
@@ -87,6 +90,14 @@ export const getActionButtons = (project) => {
     : `<a href="${viewRoute}/${project.id}" class="govuk-link govuk-link--no-visited-state" aria-label="View details of ${escapedProjectName}">View details</a>`
 }
 
+export const getStatusLabelText = (status) => {
+  if (status === PROJECT_STATUS.REJECTED) {
+    return UNABLE_TO_PROGRESS
+  }
+
+  return escapeHtml(status)
+}
+
 export const formatProjectsForDisplay = (projects, isEmployee = false) =>
   projects.map((project) => {
     const { status, projectType } = project
@@ -103,7 +114,7 @@ export const formatProjectsForDisplay = (projects, isEmployee = false) =>
       },
       { text: project.applicationReference || '-' },
       {
-        html: `<strong class="govuk-tag ${getTagStyle(status)}">${escapeHtml(project.status)}</strong>`,
+        html: `<strong class="govuk-tag ${getTagStyle(status)}">${getStatusLabelText(project.status)}</strong>`,
         attributes: {
           'data-sort-value': project.status
         }

--- a/src/server/dashboard/utils.test.js
+++ b/src/server/dashboard/utils.test.js
@@ -376,6 +376,20 @@ describe('getActionButtons', () => {
       `<a href="${marineLicenceRoutes.MARINE_LICENCE_APPLICATION_TRANSFERRED}/ml123" class="govuk-link govuk-link--no-visited-state" aria-label="View details of Marine Licence Project">View details</a>`
     )
   })
+
+  it('returns rejected page link for rejected marine licence', () => {
+    const rejected = {
+      id: 'ml123',
+      projectName: 'Marine Licence Project',
+      projectType: 'MARINE_LICENCE',
+      status: 'Rejected',
+      isOwnProject: true
+    }
+    const result = getActionButtons(rejected)
+    expect(result).toBe(
+      `<a href="${marineLicenceRoutes.MARINE_LICENCE_APPLICATION_REJECTED}/ml123" class="govuk-link govuk-link--no-visited-state" aria-label="View details of Marine Licence Project">View details</a>`
+    )
+  })
 })
 
 describe('#getStatusLabelText', () => {

--- a/src/server/dashboard/utils.test.js
+++ b/src/server/dashboard/utils.test.js
@@ -2,12 +2,17 @@ import { vi } from 'vitest'
 import {
   sortProjectsByStatus,
   formatProjectsForDisplay,
-  getActionButtons
+  getActionButtons,
+  getStatusLabelText
 } from './utils.js'
 import {
   routes,
   marineLicenceRoutes
 } from '#src/server/common/constants/routes.js'
+import {
+  PROJECT_STATUS,
+  UNABLE_TO_PROGRESS
+} from '#src/server/common/constants/projects.js'
 
 vi.mock('~/src/config/nunjucks/filters/format-date.js', () => ({
   formatDate: vi.fn((date) => {
@@ -369,6 +374,26 @@ describe('getActionButtons', () => {
     const result = getActionButtons(transferred)
     expect(result).toBe(
       `<a href="${marineLicenceRoutes.MARINE_LICENCE_APPLICATION_TRANSFERRED}/ml123" class="govuk-link govuk-link--no-visited-state" aria-label="View details of Marine Licence Project">View details</a>`
+    )
+  })
+})
+
+describe('#getStatusLabelText', () => {
+  it('returns UNABLE_TO_PROGRESS for Rejected status', () => {
+    expect(getStatusLabelText(PROJECT_STATUS.REJECTED)).toBe(UNABLE_TO_PROGRESS)
+  })
+
+  it('returns the status unchanged for non-Rejected statuses', () => {
+    expect(getStatusLabelText(PROJECT_STATUS.DRAFT)).toBe('Draft')
+    expect(getStatusLabelText(PROJECT_STATUS.ACTIVE)).toBe('Active')
+    expect(getStatusLabelText(PROJECT_STATUS.SUBMITTED)).toBe('Submitted')
+    expect(getStatusLabelText(PROJECT_STATUS.TRANSFERRED)).toBe('Transferred')
+    expect(getStatusLabelText(PROJECT_STATUS.WITHDRAWN)).toBe('Withdrawn')
+  })
+
+  it('escapes HTML in the status value', () => {
+    expect(getStatusLabelText('<script>alert(1)</script>')).toBe(
+      '&lt;script&gt;alert(1)&lt;/script&gt;'
     )
   })
 })

--- a/src/server/marine-licence/application-rejected/controller.js
+++ b/src/server/marine-licence/application-rejected/controller.js
@@ -1,0 +1,61 @@
+import Boom from '@hapi/boom'
+import {
+  marineLicenceRoutes,
+  routes
+} from '#src/server/common/constants/routes.js'
+import { getMarineLicenceService } from '#src/services/marine-licence-service/index.js'
+import { PROJECT_STATUS } from '#src/server/common/constants/projects.js'
+import { validateMarineLicenceIdParams } from '#src/server/common/helpers/marine-licence/validate-marine-licence-id-params.js'
+
+export const APPLICATION_REJECTED_VIEW_ROUTE =
+  'marine-licence/application-rejected/index'
+
+const pageTitle = 'We are unable to progress your application'
+
+const applicationRejectedSettings = {
+  pageTitle,
+  heading: pageTitle
+}
+
+export const applicationRejectedController = {
+  options: validateMarineLicenceIdParams,
+  async handler(request, h) {
+    const { marineLicenceId } = request.params
+
+    try {
+      const service = getMarineLicenceService(request)
+      const marineLicence = await service.getMarineLicenceById(marineLicenceId)
+
+      if (marineLicence.status !== PROJECT_STATUS.REJECTED) {
+        return h.redirect(routes.DASHBOARD)
+      }
+
+      const { rejectedReasons, rejectedInformation } = marineLicence
+
+      return h.view(APPLICATION_REJECTED_VIEW_ROUTE, {
+        ...applicationRejectedSettings,
+        projectName: marineLicence.projectName,
+        applicationReference: marineLicence.applicationReference,
+        rejectedReasons: rejectedReasons
+          ? rejectedReasons.split(',')
+          : rejectedReasons,
+        rejectedInformation,
+        viewDetailsUrl: `${marineLicenceRoutes.MARINE_LICENCE_VIEW_DETAILS}/${marineLicenceId}`
+      })
+    } catch (error) {
+      if (error.isBoom) {
+        throw error
+      }
+
+      request.logger.error(error, 'Error displaying application rejected page')
+      throw Boom.internal('Error displaying application rejected page')
+    }
+  }
+}
+
+export const applicationRejectedSubmitController = {
+  options: validateMarineLicenceIdParams,
+  async handler(_request, h) {
+    return h.response()
+  }
+}

--- a/src/server/marine-licence/application-rejected/controller.test.js
+++ b/src/server/marine-licence/application-rejected/controller.test.js
@@ -7,21 +7,30 @@ import {
 } from '#src/server/marine-licence/application-rejected/controller.js'
 import { getMarineLicenceService } from '#src/services/marine-licence-service/index.js'
 import { mockRejectedMarineLicenceApplication } from '#src/server/test-helpers/mocks/marine-licence-mocks.js'
-import { PROJECT_STATUS } from '#src/server/common/constants/projects.js'
 
 vi.mock('#src/services/marine-licence-service/index.js')
 
-describe('#applicationRejected', () => {
-  const mockLicence = {
-    ...mockRejectedMarineLicenceApplication,
-    status: PROJECT_STATUS.REJECTED
-  }
+const expectedViewOutput = {
+  pageTitle: 'We are unable to progress your application',
+  heading: 'We are unable to progress your application',
+  marineLicenceId: mockRejectedMarineLicenceApplication.id,
+  projectName: mockRejectedMarineLicenceApplication.projectName,
+  applicationReference:
+    mockRejectedMarineLicenceApplication.applicationReference,
+  rejectedReasons: ['Site location', 'Water Framework Directive'],
+  rejectedInformation: mockRejectedMarineLicenceApplication.rejectedInformation,
+  viewDetailsUrl: `${marineLicenceRoutes.MARINE_LICENCE_VIEW_DETAILS}/${mockRejectedMarineLicenceApplication.id}`,
+  updateAndResubmitUrl: `${marineLicenceRoutes.MARINE_LICENCE_UPDATE_AND_RESUBMIT}/${mockRejectedMarineLicenceApplication.id}`
+}
 
+describe('#applicationRejected', () => {
   let mockMarineLicenceService
 
   beforeEach(() => {
     mockMarineLicenceService = {
-      getMarineLicenceById: vi.fn().mockResolvedValue(mockLicence)
+      getMarineLicenceById: vi
+        .fn()
+        .mockResolvedValue(mockRejectedMarineLicenceApplication)
     }
     vi.mocked(getMarineLicenceService).mockReturnValue(mockMarineLicenceService)
   })
@@ -29,7 +38,7 @@ describe('#applicationRejected', () => {
   describe('#applicationRejectedController', () => {
     test('should render view with data from the service', async () => {
       const request = {
-        params: { marineLicenceId: mockLicence.id },
+        params: { marineLicenceId: mockRejectedMarineLicenceApplication.id },
         logger: { error: vi.fn() }
       }
       const h = { view: vi.fn() }
@@ -39,17 +48,42 @@ describe('#applicationRejected', () => {
       expect(getMarineLicenceService).toHaveBeenCalledWith(request)
       expect(
         mockMarineLicenceService.getMarineLicenceById
-      ).toHaveBeenCalledWith(mockLicence.id)
+      ).toHaveBeenCalledWith(mockRejectedMarineLicenceApplication.id)
+      expect(h.view).toHaveBeenCalledWith(
+        APPLICATION_REJECTED_VIEW_ROUTE,
+        expectedViewOutput
+      )
+    })
+
+    test('leaves rejectedReasons unset when not present', async () => {
+      const mockRejectedMarineLicenceApplicationWithoutRejectedReasons = {
+        ...mockRejectedMarineLicenceApplication
+      }
+      delete mockRejectedMarineLicenceApplicationWithoutRejectedReasons.rejectedReasons
+
+      mockMarineLicenceService = {
+        getMarineLicenceById: vi
+          .fn()
+          .mockResolvedValueOnce(
+            mockRejectedMarineLicenceApplicationWithoutRejectedReasons
+          )
+      }
+
+      vi.mocked(getMarineLicenceService).mockReturnValue(
+        mockMarineLicenceService
+      )
+
+      const request = {
+        params: { marineLicenceId: mockRejectedMarineLicenceApplication.id },
+        logger: { error: vi.fn() }
+      }
+      const h = { view: vi.fn() }
+
+      await applicationRejectedController.handler(request, h)
+
       expect(h.view).toHaveBeenCalledWith(APPLICATION_REJECTED_VIEW_ROUTE, {
-        pageTitle: 'We are unable to progress your application',
-        heading: 'We are unable to progress your application',
-        marineLicenceId: mockLicence.id,
-        projectName: mockLicence.projectName,
-        applicationReference: mockLicence.applicationReference,
-        rejectedReasons: ['Site location', 'Water Framework Directive'],
-        rejectedInformation: mockLicence.rejectedInformation,
-        viewDetailsUrl: `${marineLicenceRoutes.MARINE_LICENCE_VIEW_DETAILS}/${mockLicence.id}`,
-        updateAndResubmitUrl: `${marineLicenceRoutes.MARINE_LICENCE_UPDATE_AND_RESUBMIT}/${mockLicence.id}`
+        ...expectedViewOutput,
+        rejectedReasons: undefined
       })
     })
 
@@ -59,7 +93,7 @@ describe('#applicationRejected', () => {
       )
 
       const request = {
-        params: { marineLicenceId: mockLicence.id },
+        params: { marineLicenceId: mockRejectedMarineLicenceApplication.id },
         logger: { error: vi.fn() }
       }
       const h = { view: vi.fn() }
@@ -77,7 +111,7 @@ describe('#applicationRejected', () => {
       mockMarineLicenceService.getMarineLicenceById.mockRejectedValue(error)
 
       const request = {
-        params: { marineLicenceId: mockLicence.id },
+        params: { marineLicenceId: mockRejectedMarineLicenceApplication.id },
         logger: { error: vi.fn() }
       }
       const h = { view: vi.fn() }

--- a/src/server/marine-licence/application-rejected/controller.test.js
+++ b/src/server/marine-licence/application-rejected/controller.test.js
@@ -1,0 +1,110 @@
+import { vi } from 'vitest'
+import Boom from '@hapi/boom'
+import { marineLicenceRoutes } from '#src/server/common/constants/routes.js'
+import {
+  applicationRejectedController,
+  applicationRejectedSubmitController,
+  APPLICATION_REJECTED_VIEW_ROUTE
+} from '#src/server/marine-licence/application-rejected/controller.js'
+import { getMarineLicenceService } from '#src/services/marine-licence-service/index.js'
+import { mockRejectedMarineLicenceApplication } from '#src/server/test-helpers/mocks/marine-licence-mocks.js'
+import { PROJECT_STATUS } from '#src/server/common/constants/projects.js'
+
+vi.mock('#src/services/marine-licence-service/index.js')
+
+describe('#applicationRejected', () => {
+  const mockLicence = {
+    ...mockRejectedMarineLicenceApplication,
+    status: PROJECT_STATUS.REJECTED
+  }
+
+  let mockMarineLicenceService
+
+  beforeEach(() => {
+    mockMarineLicenceService = {
+      getMarineLicenceById: vi.fn().mockResolvedValue(mockLicence)
+    }
+    vi.mocked(getMarineLicenceService).mockReturnValue(mockMarineLicenceService)
+  })
+
+  describe('#applicationRejectedController', () => {
+    test('should render view with data from the service', async () => {
+      const request = {
+        params: { marineLicenceId: mockLicence.id },
+        logger: { error: vi.fn() }
+      }
+      const h = { view: vi.fn() }
+
+      await applicationRejectedController.handler(request, h)
+
+      expect(getMarineLicenceService).toHaveBeenCalledWith(request)
+      expect(
+        mockMarineLicenceService.getMarineLicenceById
+      ).toHaveBeenCalledWith(mockLicence.id)
+      expect(h.view).toHaveBeenCalledWith(APPLICATION_REJECTED_VIEW_ROUTE, {
+        pageTitle: 'We are unable to progress your application',
+        heading: 'We are unable to progress your application',
+        projectName: mockLicence.projectName,
+        applicationReference: mockLicence.applicationReference,
+        rejectedReasons: ['Site location', 'Water Framework Directive'],
+        rejectedInformation: mockLicence.rejectedInformation,
+        viewDetailsUrl: `${marineLicenceRoutes.MARINE_LICENCE_VIEW_DETAILS}/${mockLicence.id}`
+      })
+    })
+
+    test('should propagate Boom errors from the service', async () => {
+      mockMarineLicenceService.getMarineLicenceById.mockRejectedValue(
+        Boom.notFound('Not found')
+      )
+
+      const request = {
+        params: { marineLicenceId: mockLicence.id },
+        logger: { error: vi.fn() }
+      }
+      const h = { view: vi.fn() }
+
+      await expect(
+        applicationRejectedController.handler(request, h)
+      ).rejects.toMatchObject({
+        isBoom: true,
+        output: { statusCode: 404 }
+      })
+    })
+
+    test('should throw internal error for unexpected failures', async () => {
+      const error = new Error('Unexpected failure')
+      mockMarineLicenceService.getMarineLicenceById.mockRejectedValue(error)
+
+      const request = {
+        params: { marineLicenceId: mockLicence.id },
+        logger: { error: vi.fn() }
+      }
+      const h = { view: vi.fn() }
+
+      await expect(
+        applicationRejectedController.handler(request, h)
+      ).rejects.toMatchObject({
+        isBoom: true,
+        output: { statusCode: 500 }
+      })
+      expect(request.logger.error).toHaveBeenCalledWith(
+        error,
+        'Error displaying application rejected page'
+      )
+    })
+  })
+
+  describe('#applicationRejectedSubmitController', () => {
+    test('should do nothing', async () => {
+      const request = {
+        params: { marineLicenceId: mockLicence.id }
+      }
+      const h = { response: vi.fn() }
+
+      await applicationRejectedSubmitController.handler(request, h)
+
+      expect(h.response).toHaveBeenCalled()
+      expect(getMarineLicenceService).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/server/marine-licence/application-rejected/index.js
+++ b/src/server/marine-licence/application-rejected/index.js
@@ -1,0 +1,18 @@
+import {
+  applicationRejectedController,
+  applicationRejectedSubmitController
+} from '#src/server/marine-licence/application-rejected/controller.js'
+import { marineLicenceRoutes } from '#src/server/common/constants/routes.js'
+
+export const applicationRejectedRoutes = [
+  {
+    method: 'GET',
+    path: `${marineLicenceRoutes.MARINE_LICENCE_APPLICATION_REJECTED}/{marineLicenceId}`,
+    ...applicationRejectedController
+  },
+  {
+    method: 'POST',
+    path: `${marineLicenceRoutes.MARINE_LICENCE_APPLICATION_REJECTED}/{marineLicenceId}`,
+    ...applicationRejectedSubmitController
+  }
+]

--- a/src/server/marine-licence/application-rejected/index.js
+++ b/src/server/marine-licence/application-rejected/index.js
@@ -1,7 +1,4 @@
-import {
-  applicationRejectedController,
-  applicationRejectedSubmitController
-} from '#src/server/marine-licence/application-rejected/controller.js'
+import { applicationRejectedController } from '#src/server/marine-licence/application-rejected/controller.js'
 import { marineLicenceRoutes } from '#src/server/common/constants/routes.js'
 
 export const applicationRejectedRoutes = [
@@ -9,10 +6,5 @@ export const applicationRejectedRoutes = [
     method: 'GET',
     path: `${marineLicenceRoutes.MARINE_LICENCE_APPLICATION_REJECTED}/{marineLicenceId}`,
     ...applicationRejectedController
-  },
-  {
-    method: 'POST',
-    path: `${marineLicenceRoutes.MARINE_LICENCE_APPLICATION_REJECTED}/{marineLicenceId}`,
-    ...applicationRejectedSubmitController
   }
 ]

--- a/src/server/marine-licence/application-rejected/index.njk
+++ b/src/server/marine-licence/application-rejected/index.njk
@@ -1,0 +1,55 @@
+{% extends 'layouts/page.njk' %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <span class="govuk-caption-l">{{ projectName }}</span>
+      <h1 class="govuk-heading-l">{{ heading }}</h1>
+
+      <p class="govuk-body">We have reviewed your application ({{ applicationReference }}) and we are unable to progress it as submitted.</p>
+
+      <h2 class="govuk-heading-m">Why we are unable to progress your application</h2>
+
+      <p class="govuk-body">We've identified issues with the following sections of your application:</p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        {% for reason in rejectedReasons %}
+          <li>{{ reason }}</li>
+        {% endfor %}
+      </ul>
+
+      <p class="govuk-body">{{ rejectedInformation }}</p>
+
+      <h2 class="govuk-heading-m">Charges for reviewing your application</h2>
+
+      <p class="govuk-body">We will charge you for the time we have spent reviewing your application to date. We will send you an invoice separately.</p>
+
+      <h2 class="govuk-heading-m">What you can do</h2>
+
+      <p class="govuk-body">You can apply again for the same project. To support you with this, we will copy your existing application into a new draft application, so you can fix the issues we've identified before you submit.</p>
+
+      <p class="govuk-body">This will be a new application, meaning:</p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>you will get a new fee estimate</li>
+        <li>your new application will have a new reference number</li>
+      </ul>
+
+      <form method="POST">
+        <input type="hidden" name="csrfToken" value="{{ csrfToken }}" />
+        {{ govukButton({
+          text: "Apply again",
+          preventDoubleClick: true,
+          attributes: {
+            "data-module": "govuk-button"
+          }
+        }) }}
+      </form>
+
+      <p class="govuk-body"><a class="govuk-link" href="{{ viewDetailsUrl }}">View your original application</a></p>
+
+    </div>
+  </div>
+{% endblock %}

--- a/src/server/marine-licence/application-rejected/index.njk
+++ b/src/server/marine-licence/application-rejected/index.njk
@@ -32,7 +32,7 @@
 
       <p class="govuk-body">This will be a new application, meaning:</p>
 
-      <ul class="govuk-list govuk-list--bullet">
+      <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
         <li>you will get a new fee estimate</li>
         <li>your new application will have a new reference number</li>
       </ul>

--- a/src/server/marine-licence/application-rejected/index.njk
+++ b/src/server/marine-licence/application-rejected/index.njk
@@ -37,16 +37,13 @@
         <li>your new application will have a new reference number</li>
       </ul>
 
-      <form method="POST">
-        <input type="hidden" name="csrfToken" value="{{ csrfToken }}" />
-        {{ govukButton({
-          text: "Apply again",
-          preventDoubleClick: true,
-          attributes: {
-            "data-module": "govuk-button"
-          }
-        }) }}
-      </form>
+      {{ govukButton({
+        text: "Apply again",
+        href: updateAndResubmitUrl,
+        attributes: {
+          "data-module": "govuk-button"
+        }
+      }) }}
 
       <p class="govuk-body"><a class="govuk-link" href="{{ viewDetailsUrl }}">View your original application</a></p>
 

--- a/src/server/marine-licence/application-transferred/controller.js
+++ b/src/server/marine-licence/application-transferred/controller.js
@@ -6,6 +6,7 @@ import {
 import { MCMS_LOGIN_URL } from '#src/server/common/constants/mcms.js'
 import { getMarineLicenceService } from '#src/services/marine-licence-service/index.js'
 import { PROJECT_STATUS } from '#src/server/common/constants/projects.js'
+import { validateMarineLicenceIdParams } from '#src/server/common/helpers/marine-licence/validate-marine-licence-id-params.js'
 
 export const APPLICATION_TRANSFERRED_VIEW_ROUTE =
   'marine-licence/application-transferred/index'
@@ -26,6 +27,7 @@ const applicationTransferredSettings = {
 }
 
 export const applicationTransferredController = {
+  options: validateMarineLicenceIdParams,
   async handler(request, h) {
     const { marineLicenceId } = request.params
 

--- a/src/server/marine-licence/index.js
+++ b/src/server/marine-licence/index.js
@@ -22,6 +22,7 @@ import { marinePlanPoliciesRoutes } from '#src/server/marine-licence/marine-plan
 import { feeEstimateRoutes } from '#src/server/marine-licence/fee-estimate/index.js'
 import { feeEstimateAreYouSureRoutes } from '#src/server/marine-licence/fee-estimate-are-you-sure/index.js'
 import { applicationTransferredRoutes } from '#src/server/marine-licence/application-transferred/index.js'
+import { applicationRejectedRoutes } from '#src/server/marine-licence/application-rejected/index.js'
 
 export const marineLicence = {
   plugin: {
@@ -51,7 +52,8 @@ export const marineLicence = {
         ...marinePlanPoliciesRoutes,
         ...feeEstimateRoutes,
         ...feeEstimateAreYouSureRoutes,
-        ...applicationTransferredRoutes
+        ...applicationTransferredRoutes,
+        ...applicationRejectedRoutes
       ])
     }
   }

--- a/src/server/marine-licence/index.js
+++ b/src/server/marine-licence/index.js
@@ -23,6 +23,7 @@ import { feeEstimateRoutes } from '#src/server/marine-licence/fee-estimate/index
 import { feeEstimateAreYouSureRoutes } from '#src/server/marine-licence/fee-estimate-are-you-sure/index.js'
 import { applicationTransferredRoutes } from '#src/server/marine-licence/application-transferred/index.js'
 import { applicationRejectedRoutes } from '#src/server/marine-licence/application-rejected/index.js'
+import { updateAndResubmitRoutes } from '#src/server/marine-licence/update-and-resubmit/index.js'
 
 export const marineLicence = {
   plugin: {
@@ -53,7 +54,8 @@ export const marineLicence = {
         ...feeEstimateRoutes,
         ...feeEstimateAreYouSureRoutes,
         ...applicationTransferredRoutes,
-        ...applicationRejectedRoutes
+        ...applicationRejectedRoutes,
+        ...updateAndResubmitRoutes
       ])
     }
   }

--- a/src/server/marine-licence/update-and-resubmit/controller.js
+++ b/src/server/marine-licence/update-and-resubmit/controller.js
@@ -7,17 +7,17 @@ import { getMarineLicenceService } from '#src/services/marine-licence-service/in
 import { PROJECT_STATUS } from '#src/server/common/constants/projects.js'
 import { validateMarineLicenceIdParams } from '#src/server/common/helpers/marine-licence/validate-marine-licence-id-params.js'
 
-export const APPLICATION_REJECTED_VIEW_ROUTE =
-  'marine-licence/application-rejected/index'
+export const UPDATE_AND_RESUBMIT_VIEW_ROUTE =
+  'marine-licence/update-and-resubmit/index'
 
-const pageTitle = 'We are unable to progress your application'
+const pageTitle = 'Apply again for this project'
 
-const applicationRejectedSettings = {
+const updateAndResubmitSettings = {
   pageTitle,
   heading: pageTitle
 }
 
-export const applicationRejectedController = {
+export const updateAndResubmitController = {
   options: validateMarineLicenceIdParams,
   async handler(request, h) {
     const { marineLicenceId } = request.params
@@ -30,27 +30,29 @@ export const applicationRejectedController = {
         return h.redirect(routes.DASHBOARD)
       }
 
-      const { rejectedReasons, rejectedInformation } = marineLicence
+      const applicationRejectedLink = `${marineLicenceRoutes.MARINE_LICENCE_APPLICATION_REJECTED}/${marineLicenceId}`
 
-      return h.view(APPLICATION_REJECTED_VIEW_ROUTE, {
-        ...applicationRejectedSettings,
-        marineLicenceId,
+      return h.view(UPDATE_AND_RESUBMIT_VIEW_ROUTE, {
+        ...updateAndResubmitSettings,
         projectName: marineLicence.projectName,
         applicationReference: marineLicence.applicationReference,
-        rejectedReasons: rejectedReasons
-          ? rejectedReasons.split(',')
-          : rejectedReasons,
-        rejectedInformation,
-        viewDetailsUrl: `${marineLicenceRoutes.MARINE_LICENCE_VIEW_DETAILS}/${marineLicenceId}`,
-        updateAndResubmitUrl: `${marineLicenceRoutes.MARINE_LICENCE_UPDATE_AND_RESUBMIT}/${marineLicenceId}`
+        backLink: applicationRejectedLink,
+        cancelLink: applicationRejectedLink
       })
     } catch (error) {
       if (error.isBoom) {
         throw error
       }
 
-      request.logger.error(error, 'Error displaying application rejected page')
-      throw Boom.internal('Error displaying application rejected page')
+      request.logger.error(error, 'Error displaying update and resubmit page')
+      throw Boom.internal('Error displaying update and resubmit page')
     }
+  }
+}
+
+export const updateAndResubmitSubmitController = {
+  options: validateMarineLicenceIdParams,
+  async handler(_request, h) {
+    return h.response()
   }
 }

--- a/src/server/marine-licence/update-and-resubmit/controller.js
+++ b/src/server/marine-licence/update-and-resubmit/controller.js
@@ -1,11 +1,14 @@
 import Boom from '@hapi/boom'
 import {
+  apiRoutes,
   marineLicenceRoutes,
   routes
 } from '#src/server/common/constants/routes.js'
 import { getMarineLicenceService } from '#src/services/marine-licence-service/index.js'
 import { PROJECT_STATUS } from '#src/server/common/constants/projects.js'
 import { validateMarineLicenceIdParams } from '#src/server/common/helpers/marine-licence/validate-marine-licence-id-params.js'
+import { authenticatedPostRequest } from '#src/server/common/helpers/authenticated-requests.js'
+import { clearMarineLicenceCache } from '#src/server/common/helpers/marine-licence/session-cache/utils.js'
 
 export const UPDATE_AND_RESUBMIT_VIEW_ROUTE =
   'marine-licence/update-and-resubmit/index'
@@ -52,7 +55,26 @@ export const updateAndResubmitController = {
 
 export const updateAndResubmitSubmitController = {
   options: validateMarineLicenceIdParams,
-  async handler(_request, h) {
-    return h.response()
+  async handler(request, h) {
+    const { marineLicenceId } = request.params
+
+    try {
+      const { payload } = await authenticatedPostRequest(
+        request,
+        apiRoutes.COPY_MARINE_LICENCE,
+        { id: marineLicenceId }
+      )
+
+      await clearMarineLicenceCache(request, h)
+
+      const { id: newMarineLicenceId } = payload.value
+
+      return h.redirect(
+        `${marineLicenceRoutes.MARINE_LICENCE_TASK_LIST}/${newMarineLicenceId}`
+      )
+    } catch (error) {
+      request.logger.error(error, 'Error copying marine licence')
+      return h.redirect(routes.DASHBOARD)
+    }
   }
 }

--- a/src/server/marine-licence/update-and-resubmit/controller.test.js
+++ b/src/server/marine-licence/update-and-resubmit/controller.test.js
@@ -2,16 +2,17 @@ import { vi } from 'vitest'
 import Boom from '@hapi/boom'
 import { marineLicenceRoutes } from '#src/server/common/constants/routes.js'
 import {
-  applicationRejectedController,
-  APPLICATION_REJECTED_VIEW_ROUTE
-} from '#src/server/marine-licence/application-rejected/controller.js'
+  updateAndResubmitController,
+  updateAndResubmitSubmitController,
+  UPDATE_AND_RESUBMIT_VIEW_ROUTE
+} from '#src/server/marine-licence/update-and-resubmit/controller.js'
 import { getMarineLicenceService } from '#src/services/marine-licence-service/index.js'
 import { mockRejectedMarineLicenceApplication } from '#src/server/test-helpers/mocks/marine-licence-mocks.js'
 import { PROJECT_STATUS } from '#src/server/common/constants/projects.js'
 
 vi.mock('#src/services/marine-licence-service/index.js')
 
-describe('#applicationRejected', () => {
+describe('#updateAndResubmit', () => {
   const mockLicence = {
     ...mockRejectedMarineLicenceApplication,
     status: PROJECT_STATUS.REJECTED
@@ -26,7 +27,7 @@ describe('#applicationRejected', () => {
     vi.mocked(getMarineLicenceService).mockReturnValue(mockMarineLicenceService)
   })
 
-  describe('#applicationRejectedController', () => {
+  describe('#updateAndResubmitController', () => {
     test('should render view with data from the service', async () => {
       const request = {
         params: { marineLicenceId: mockLicence.id },
@@ -34,22 +35,19 @@ describe('#applicationRejected', () => {
       }
       const h = { view: vi.fn() }
 
-      await applicationRejectedController.handler(request, h)
+      await updateAndResubmitController.handler(request, h)
 
       expect(getMarineLicenceService).toHaveBeenCalledWith(request)
       expect(
         mockMarineLicenceService.getMarineLicenceById
       ).toHaveBeenCalledWith(mockLicence.id)
-      expect(h.view).toHaveBeenCalledWith(APPLICATION_REJECTED_VIEW_ROUTE, {
-        pageTitle: 'We are unable to progress your application',
-        heading: 'We are unable to progress your application',
-        marineLicenceId: mockLicence.id,
+      expect(h.view).toHaveBeenCalledWith(UPDATE_AND_RESUBMIT_VIEW_ROUTE, {
+        pageTitle: 'Apply again for this project',
+        heading: 'Apply again for this project',
         projectName: mockLicence.projectName,
         applicationReference: mockLicence.applicationReference,
-        rejectedReasons: ['Site location', 'Water Framework Directive'],
-        rejectedInformation: mockLicence.rejectedInformation,
-        viewDetailsUrl: `${marineLicenceRoutes.MARINE_LICENCE_VIEW_DETAILS}/${mockLicence.id}`,
-        updateAndResubmitUrl: `${marineLicenceRoutes.MARINE_LICENCE_UPDATE_AND_RESUBMIT}/${mockLicence.id}`
+        backLink: `${marineLicenceRoutes.MARINE_LICENCE_APPLICATION_REJECTED}/${mockLicence.id}`,
+        cancelLink: `${marineLicenceRoutes.MARINE_LICENCE_APPLICATION_REJECTED}/${mockLicence.id}`
       })
     })
 
@@ -65,7 +63,7 @@ describe('#applicationRejected', () => {
       const h = { view: vi.fn() }
 
       await expect(
-        applicationRejectedController.handler(request, h)
+        updateAndResubmitController.handler(request, h)
       ).rejects.toMatchObject({
         isBoom: true,
         output: { statusCode: 404 }
@@ -83,15 +81,29 @@ describe('#applicationRejected', () => {
       const h = { view: vi.fn() }
 
       await expect(
-        applicationRejectedController.handler(request, h)
+        updateAndResubmitController.handler(request, h)
       ).rejects.toMatchObject({
         isBoom: true,
         output: { statusCode: 500 }
       })
       expect(request.logger.error).toHaveBeenCalledWith(
         error,
-        'Error displaying application rejected page'
+        'Error displaying update and resubmit page'
       )
+    })
+  })
+
+  describe('#updateAndResubmitSubmitController', () => {
+    test('should do nothing', async () => {
+      const request = {
+        params: { marineLicenceId: mockLicence.id }
+      }
+      const h = { response: vi.fn() }
+
+      await updateAndResubmitSubmitController.handler(request, h)
+
+      expect(h.response).toHaveBeenCalled()
+      expect(getMarineLicenceService).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/server/marine-licence/update-and-resubmit/controller.test.js
+++ b/src/server/marine-licence/update-and-resubmit/controller.test.js
@@ -1,16 +1,24 @@
 import { vi } from 'vitest'
 import Boom from '@hapi/boom'
-import { marineLicenceRoutes } from '#src/server/common/constants/routes.js'
+import {
+  apiRoutes,
+  marineLicenceRoutes,
+  routes
+} from '#src/server/common/constants/routes.js'
 import {
   updateAndResubmitController,
   updateAndResubmitSubmitController,
   UPDATE_AND_RESUBMIT_VIEW_ROUTE
 } from '#src/server/marine-licence/update-and-resubmit/controller.js'
 import { getMarineLicenceService } from '#src/services/marine-licence-service/index.js'
+import { authenticatedPostRequest } from '#src/server/common/helpers/authenticated-requests.js'
+import { clearMarineLicenceCache } from '#src/server/common/helpers/marine-licence/session-cache/utils.js'
 import { mockRejectedMarineLicenceApplication } from '#src/server/test-helpers/mocks/marine-licence-mocks.js'
 import { PROJECT_STATUS } from '#src/server/common/constants/projects.js'
 
 vi.mock('#src/services/marine-licence-service/index.js')
+vi.mock('#src/server/common/helpers/authenticated-requests.js')
+vi.mock('#src/server/common/helpers/marine-licence/session-cache/utils.js')
 
 describe('#updateAndResubmit', () => {
   const mockLicence = {
@@ -94,16 +102,48 @@ describe('#updateAndResubmit', () => {
   })
 
   describe('#updateAndResubmitSubmitController', () => {
-    test('should do nothing', async () => {
+    test('should copy the marine licence, clear the cache and redirect to the new task list', async () => {
       const request = {
-        params: { marineLicenceId: mockLicence.id }
+        params: { marineLicenceId: mockLicence.id },
+        logger: { error: vi.fn() }
       }
-      const h = { response: vi.fn() }
+      const h = { redirect: vi.fn() }
+
+      vi.mocked(authenticatedPostRequest).mockResolvedValue({
+        payload: { value: { id: 'new-marine-licence-id' } }
+      })
 
       await updateAndResubmitSubmitController.handler(request, h)
 
-      expect(h.response).toHaveBeenCalled()
-      expect(getMarineLicenceService).not.toHaveBeenCalled()
+      expect(authenticatedPostRequest).toHaveBeenCalledWith(
+        request,
+        apiRoutes.COPY_MARINE_LICENCE,
+        { id: mockLicence.id }
+      )
+      expect(clearMarineLicenceCache).toHaveBeenCalledWith(request, h)
+      expect(h.redirect).toHaveBeenCalledWith(
+        `${marineLicenceRoutes.MARINE_LICENCE_TASK_LIST}/new-marine-licence-id`
+      )
+    })
+
+    test('should redirect to the dashboard if the copy request fails', async () => {
+      const request = {
+        params: { marineLicenceId: mockLicence.id },
+        logger: { error: vi.fn() }
+      }
+      const h = { redirect: vi.fn() }
+      const error = new Error('Copy failed')
+
+      vi.mocked(authenticatedPostRequest).mockRejectedValue(error)
+
+      await updateAndResubmitSubmitController.handler(request, h)
+
+      expect(request.logger.error).toHaveBeenCalledWith(
+        error,
+        'Error copying marine licence'
+      )
+      expect(clearMarineLicenceCache).not.toHaveBeenCalled()
+      expect(h.redirect).toHaveBeenCalledWith(routes.DASHBOARD)
     })
   })
 })

--- a/src/server/marine-licence/update-and-resubmit/index.js
+++ b/src/server/marine-licence/update-and-resubmit/index.js
@@ -1,0 +1,18 @@
+import {
+  updateAndResubmitController,
+  updateAndResubmitSubmitController
+} from '#src/server/marine-licence/update-and-resubmit/controller.js'
+import { marineLicenceRoutes } from '#src/server/common/constants/routes.js'
+
+export const updateAndResubmitRoutes = [
+  {
+    method: 'GET',
+    path: `${marineLicenceRoutes.MARINE_LICENCE_UPDATE_AND_RESUBMIT}/{marineLicenceId}`,
+    ...updateAndResubmitController
+  },
+  {
+    method: 'POST',
+    path: `${marineLicenceRoutes.MARINE_LICENCE_UPDATE_AND_RESUBMIT}/{marineLicenceId}`,
+    ...updateAndResubmitSubmitController
+  }
+]

--- a/src/server/marine-licence/update-and-resubmit/index.njk
+++ b/src/server/marine-licence/update-and-resubmit/index.njk
@@ -1,0 +1,49 @@
+{% extends 'layouts/page.njk' %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "cancel-button/macro.njk" import appCancelButton %}
+
+{% block beforeContent %}
+  {{ super() }}
+  <nav>
+    {{ govukBackLink({
+      text: "Back",
+      href: backLink
+    }) }}
+  </nav>
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <span class="govuk-caption-l">{{ projectName }}</span>
+      <h1 class="govuk-heading-l">{{ heading }}</h1>
+
+      <p class="govuk-body">To support you with this, we will copy all of the information from your original application (<strong>{{ applicationReference }}</strong>) into a new draft application.</p>
+
+      <p class="govuk-body">Fix the issues we've identified before you submit. You can also change anything else.</p>
+
+      <p class="govuk-body">Your original application will stay 'Unable to progress'. You can still view it in your projects.</p>
+
+      <form method="POST">
+        <input type="hidden" name="csrfToken" value="{{ csrfToken }}" />
+
+        <div class="govuk-button-group">
+          {{ govukButton({
+            text: "Create new draft and fix issues",
+            preventDoubleClick: true,
+            attributes: {
+              "data-module": "govuk-button"
+            }
+          }) }}
+
+          {{ appCancelButton({
+            cancelLink: cancelLink
+          }) }}
+        </div>
+      </form>
+
+    </div>
+  </div>
+{% endblock %}

--- a/src/server/marine-licence/view-details/controller.js
+++ b/src/server/marine-licence/view-details/controller.js
@@ -24,6 +24,10 @@ const getApplicantBackLink = (status, marineLicenceId) => {
     return `${marineLicenceRoutes.MARINE_LICENCE_APPLICATION_TRANSFERRED}/${marineLicenceId}`
   }
 
+  if (status === PROJECT_STATUS.REJECTED) {
+    return `${marineLicenceRoutes.MARINE_LICENCE_APPLICATION_REJECTED}/${marineLicenceId}`
+  }
+
   return routes.DASHBOARD
 }
 

--- a/src/server/marine-licence/view-details/index.njk
+++ b/src/server/marine-licence/view-details/index.njk
@@ -32,10 +32,13 @@
       {% endif %}
       <h1 class="govuk-heading-l" id="view-details-heading">{{ pageTitle }}</h1>
 
-      {% if isTransferred %}
+      {% if showApplicationDetailsCard %}
         {{ appMarineLicenceApplicationDetailsCard({
           statusTag: statusTag,
+          isTransferred: isTransferred,
+          isRejected: isRejected,
           applicationReference: applicationReference,
+          rejectedDate: rejectedDate,
           transferredDate: transferredDate,
           submittedAt: submittedAt
         }) }}

--- a/src/server/marine-licence/view-details/index.njk
+++ b/src/server/marine-licence/view-details/index.njk
@@ -23,6 +23,22 @@
   {% endif %}
 {% endblock %}
 
+{% set rejectedReasonsOutput %}
+
+  {% if rejectedReasons %}
+    <ul class="govuk-list govuk-list--bullet">
+    {% for reason in rejectedReasons %}
+      <li>{{reason}}</li>
+    {% endfor %}
+  </ul>
+  {% endif %}
+
+  {% if rejectedInformation %}
+    <p class="govuk-body">{{ rejectedInformation }}</p>
+  {% endif %}
+
+{% endset %}
+
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
@@ -39,6 +55,7 @@
           isRejected: isRejected,
           applicationReference: applicationReference,
           rejectedDate: rejectedDate,
+          rejectedReasons: rejectedReasonsOutput,
           transferredDate: transferredDate,
           submittedAt: submittedAt
         }) }}

--- a/src/server/marine-licence/view-details/utils.js
+++ b/src/server/marine-licence/view-details/utils.js
@@ -19,7 +19,9 @@ export const buildApplicationDetailsCardData = (marineLicence) => {
     submittedAt: formatDate(submittedAt, 'd MMM yyyy'),
     transferredDate: formatDate(transferredDate, 'd MMM yyyy'),
     rejectedDate: formatDate(rejectedDate, 'd MMM yyyy'),
-    rejectedReasons: rejectedReasons ? rejectedReasons.split(',') : rejectedReasons,
+    rejectedReasons: rejectedReasons
+      ? rejectedReasons.split(',')
+      : rejectedReasons,
     rejectedInformation,
     isTransferred: status === PROJECT_STATUS.TRANSFERRED,
     isRejected: status === PROJECT_STATUS.REJECTED,

--- a/src/server/marine-licence/view-details/utils.js
+++ b/src/server/marine-licence/view-details/utils.js
@@ -4,14 +4,25 @@ import { PROJECT_STATUS } from '#src/server/common/constants/projects.js'
 import escapeHtml from 'lodash/escape.js'
 
 export const buildApplicationDetailsCardData = (marineLicence) => {
-  const { applicationReference, status, submittedAt, transferredDate } =
-    marineLicence
+  const {
+    applicationReference,
+    status,
+    submittedAt,
+    rejectedDate,
+    rejectedReasons,
+    rejectedInformation,
+    transferredDate
+  } = marineLicence
 
   return {
     applicationReference,
     submittedAt: formatDate(submittedAt, 'd MMM yyyy'),
     transferredDate: formatDate(transferredDate, 'd MMM yyyy'),
+    rejectedDate: formatDate(rejectedDate, 'd MMM yyyy'),
+    rejectedReasons: rejectedReasons ? rejectedReasons.split(',') : rejectedReasons,
+    rejectedInformation,
     isTransferred: status === PROJECT_STATUS.TRANSFERRED,
+    isRejected: status === PROJECT_STATUS.REJECTED,
     statusTag: `<strong class="govuk-tag ${getTagStyle(status)}">${escapeHtml(status)}</strong>`
   }
 }

--- a/src/server/marine-licence/view-details/utils.js
+++ b/src/server/marine-licence/view-details/utils.js
@@ -1,7 +1,9 @@
 import { formatDate } from '#src/config/nunjucks/filters/format-date.js'
 import { getTagStyle } from '#src/server/common/helpers/ui/get-tag-style.js'
 import { PROJECT_STATUS } from '#src/server/common/constants/projects.js'
-import escapeHtml from 'lodash/escape.js'
+import { getStatusLabelText } from '#src/server/dashboard/utils.js'
+
+const APPLICATION_DATE_FORMAT = 'd MMM yyyy'
 
 export const buildApplicationDetailsCardData = (marineLicence) => {
   const {
@@ -14,17 +16,22 @@ export const buildApplicationDetailsCardData = (marineLicence) => {
     transferredDate
   } = marineLicence
 
+  const isTransferred = status === PROJECT_STATUS.TRANSFERRED
+  const isRejected = status === PROJECT_STATUS.REJECTED
+
   return {
     applicationReference,
-    submittedAt: formatDate(submittedAt, 'd MMM yyyy'),
-    transferredDate: formatDate(transferredDate, 'd MMM yyyy'),
-    rejectedDate: formatDate(rejectedDate, 'd MMM yyyy'),
+    submittedAt: formatDate(submittedAt, APPLICATION_DATE_FORMAT),
+    transferredDate: formatDate(transferredDate, APPLICATION_DATE_FORMAT),
+    rejectedDate: formatDate(rejectedDate, APPLICATION_DATE_FORMAT),
     rejectedReasons: rejectedReasons
       ? rejectedReasons.split(',')
       : rejectedReasons,
     rejectedInformation,
-    isTransferred: status === PROJECT_STATUS.TRANSFERRED,
-    isRejected: status === PROJECT_STATUS.REJECTED,
-    statusTag: `<strong class="govuk-tag ${getTagStyle(status)}">${escapeHtml(status)}</strong>`
+    isTransferred,
+    isRejected,
+    showApplicationDetailsCard: isTransferred || isRejected,
+    status,
+    statusTag: `<strong class="govuk-tag ${getTagStyle(status)}">${getStatusLabelText(status)}</strong>`
   }
 }

--- a/src/server/marine-licence/view-details/utils.test.js
+++ b/src/server/marine-licence/view-details/utils.test.js
@@ -1,5 +1,8 @@
 import { buildApplicationDetailsCardData } from '#src/server/marine-licence/view-details/utils.js'
-import { PROJECT_STATUS } from '#src/server/common/constants/projects.js'
+import {
+  PROJECT_STATUS,
+  UNABLE_TO_PROGRESS
+} from '#src/server/common/constants/projects.js'
 import { expect } from 'vitest'
 
 describe('#buildApplicationDetailsCardData', () => {
@@ -39,7 +42,7 @@ describe('#buildApplicationDetailsCardData', () => {
     expect(result.rejectedDate).toBe('20 Mar 2026')
     expect(result.rejectedReasons).toEqual(['Reason 1', 'Reason 2'])
     expect(result.statusTag).toContain('govuk-tag--orange')
-    expect(result.statusTag).toContain(PROJECT_STATUS.REJECTED)
+    expect(result.statusTag).toContain(UNABLE_TO_PROGRESS)
   })
 
   test('leaves rejectedReasons unset when not present', () => {

--- a/src/server/marine-licence/view-details/utils.test.js
+++ b/src/server/marine-licence/view-details/utils.test.js
@@ -1,5 +1,6 @@
 import { buildApplicationDetailsCardData } from '#src/server/marine-licence/view-details/utils.js'
 import { PROJECT_STATUS } from '#src/server/common/constants/projects.js'
+import { expect } from 'vitest'
 
 describe('#buildApplicationDetailsCardData', () => {
   test('returns the application details fields and a rendered status tag', () => {
@@ -18,6 +19,35 @@ describe('#buildApplicationDetailsCardData', () => {
     expect(result.transferredDate).toBe('20 Feb 2026')
     expect(result.statusTag).toContain('govuk-tag--magenta')
     expect(result.statusTag).toContain(PROJECT_STATUS.TRANSFERRED)
+  })
+
+  test('returns the application details fields and a rendered rejected status tag', () => {
+    const marineLicence = {
+      applicationReference: 'ML-2026-001',
+      status: PROJECT_STATUS.REJECTED,
+      submittedAt: '2026-01-15',
+      rejectedDate: '2026-03-20',
+      rejectedReasons: 'Reason 1,Reason 2',
+      rejectedInformation: 'Test text'
+    }
+
+    const result = buildApplicationDetailsCardData(marineLicence)
+
+    expect(result.applicationReference).toBe('ML-2026-001')
+    expect(result.isRejected).toBe(true)
+    expect(result.submittedAt).toBe('15 Jan 2026')
+    expect(result.rejectedDate).toBe('20 Mar 2026')
+    expect(result.rejectedReasons).toEqual(['Reason 1', 'Reason 2'])
+    expect(result.statusTag).toContain('govuk-tag--orange')
+    expect(result.statusTag).toContain(PROJECT_STATUS.REJECTED)
+  })
+
+  test('leaves rejectedReasons unset when not present', () => {
+    const result = buildApplicationDetailsCardData({
+      status: PROJECT_STATUS.SUBMITTED
+    })
+
+    expect(result.rejectedReasons).toBeUndefined()
   })
 
   test('sets isTransferred to false when status is not transferred', () => {

--- a/src/server/test-helpers/mocks/marine-licence-mocks.js
+++ b/src/server/test-helpers/mocks/marine-licence-mocks.js
@@ -180,7 +180,7 @@ export const mockRejectedMarineLicenceApplication = {
   status: PROJECT_STATUS.REJECTED,
   applicationReference: 'MLA/2026/10264',
   submittedAt: '2026-05-26T10:00:00Z',
-  rejectedDate: '2026-06-26T10:00:00Z',
+  rejectedDate: '2026-07-26T10:00:00Z',
   rejectedReasons: 'Site location,Water Framework Directive',
   rejectedInformation:
     'The site location entered indicated that it was within 1 nautical mile of the coast but no Water Framework Directive assessment was uploaded. Check the site location and if it meets the requirements for a WFD assessment.'

--- a/src/server/test-helpers/mocks/marine-licence-mocks.js
+++ b/src/server/test-helpers/mocks/marine-licence-mocks.js
@@ -175,6 +175,17 @@ export const mockTransferredMarineLicenceApplication = {
   transferredDate: '2026-06-26T10:00:00Z'
 }
 
+export const mockRejectedMarineLicenceApplication = {
+  ...mockSubmittedMarineLicenceApplication,
+  status: PROJECT_STATUS.REJECTED,
+  applicationReference: 'MLA/2026/10264',
+  submittedAt: '2026-05-26T10:00:00Z',
+  rejectedDate: '2026-06-26T10:00:00Z',
+  rejectedReasons: 'Site location,Water Framework Directive',
+  rejectedInformation:
+    'The site location entered indicated that it was within 1 nautical mile of the coast but no Water Framework Directive assessment was uploaded. Check the site location and if it meets the requirements for a WFD assessment.'
+}
+
 export const mockMarineLicenceWithMarinePlanPolicies = {
   ...mockMarineLicenceApplication,
   marinePlanPolicyJob: 'ready',

--- a/tests/integration/accessibility/marine-licence-page-accessibility.test.js
+++ b/tests/integration/accessibility/marine-licence-page-accessibility.test.js
@@ -5,7 +5,9 @@ import {
   mockManualCoordinatesMarineLicence,
   mockMarineLicenceApplication,
   mockMarineLicenceWithMarinePlanPolicies,
-  mockSubmittedMarineLicenceApplication
+  mockSubmittedMarineLicenceApplication,
+  mockTransferredMarineLicenceApplication,
+  mockRejectedMarineLicenceApplication
 } from '~/src/server/test-helpers/mocks/marine-licence-mocks.js'
 import {
   mockMarineLicence,
@@ -15,7 +17,6 @@ import { agentSession } from '../shared/session-fixtures.js'
 import { selectActivityVariants } from '~/src/server/common/constants/activity-variants.js'
 import { getMarinePlanPolicyLink } from '~/src/server/common/helpers/marine-licence/marine-plan-policy-link.js'
 import { runPageAccessibilityTests } from './page-accessibility-tests.js'
-import { mockTransferredMarineLicenceApplication } from '#src/server/test-helpers/mocks/marine-licence-mocks.js'
 
 vi.mock('~/src/server/common/helpers/authenticated-requests.js')
 vi.mock('~/src/server/common/helpers/defraid-login/session-cache.js')
@@ -257,6 +258,11 @@ const marineLicencePages = [
     url: `${marineLicenceRoutes.MARINE_LICENCE_APPLICATION_TRANSFERRED}/${mockSubmittedMarineLicenceApplication.id}`,
     title: 'Your application has been transferred',
     marineLicence: mockTransferredMarineLicenceApplication
+  },
+  {
+    url: `${marineLicenceRoutes.MARINE_LICENCE_APPLICATION_REJECTED}/${mockRejectedMarineLicenceApplication.id}`,
+    title: 'We are unable to progress your application',
+    marineLicence: mockRejectedMarineLicenceApplication
   }
   // TODO: Uncomment when meta refresh a11y issue is resolved (same issue as upload-and-wait)
   // {

--- a/tests/integration/accessibility/marine-licence-page-accessibility.test.js
+++ b/tests/integration/accessibility/marine-licence-page-accessibility.test.js
@@ -263,6 +263,11 @@ const marineLicencePages = [
     url: `${marineLicenceRoutes.MARINE_LICENCE_APPLICATION_REJECTED}/${mockRejectedMarineLicenceApplication.id}`,
     title: 'We are unable to progress your application',
     marineLicence: mockRejectedMarineLicenceApplication
+  },
+  {
+    url: `${marineLicenceRoutes.MARINE_LICENCE_UPDATE_AND_RESUBMIT}/${mockRejectedMarineLicenceApplication.id}`,
+    title: 'Apply again for this project',
+    marineLicence: mockRejectedMarineLicenceApplication
   }
   // TODO: Uncomment when meta refresh a11y issue is resolved (same issue as upload-and-wait)
   // {

--- a/tests/integration/marine-licence/application-rejected.test.js
+++ b/tests/integration/marine-licence/application-rejected.test.js
@@ -1,0 +1,118 @@
+import { getByRole, getByText } from '@testing-library/dom'
+import {
+  marineLicenceRoutes,
+  routes
+} from '~/src/server/common/constants/routes.js'
+import {
+  mockMarineLicence,
+  setupTestServer
+} from '~/tests/integration/shared/test-setup-helpers.js'
+import { loadPage } from '~/tests/integration/shared/app-server.js'
+import {
+  mockRejectedMarineLicenceApplication,
+  mockSubmittedMarineLicenceApplication
+} from '#src/server/test-helpers/mocks/marine-licence-mocks.js'
+import { statusCodes } from '~/src/server/common/constants/status-codes.js'
+import {
+  makeGetRequest,
+  makePostRequest
+} from '~/src/server/test-helpers/server-requests.js'
+
+describe('Application rejected', () => {
+  const getServer = setupTestServer()
+  const marineLicence = mockRejectedMarineLicenceApplication
+
+  test('page elements', async () => {
+    mockMarineLicence(mockRejectedMarineLicenceApplication)
+
+    const document = await loadPage({
+      requestUrl: `${marineLicenceRoutes.MARINE_LICENCE_APPLICATION_REJECTED}/${marineLicence.id}`,
+      server: getServer()
+    })
+
+    expect(getByText(document, marineLicence.projectName)).toBeInTheDocument()
+    expect(getByRole(document, 'heading', { level: 1 })).toHaveTextContent(
+      'We are unable to progress your application'
+    )
+    expect(
+      getByText(document, (content) =>
+        content.includes(
+          `We have reviewed your application (${marineLicence.applicationReference}) and we are unable to progress it as submitted.`
+        )
+      )
+    ).toBeInTheDocument()
+    expect(
+      getByRole(document, 'heading', {
+        level: 2,
+        name: 'Why we are unable to progress your application'
+      })
+    ).toBeInTheDocument()
+    expect(getByText(document, 'Site location')).toBeInTheDocument()
+    expect(getByText(document, 'Water Framework Directive')).toBeInTheDocument()
+    expect(
+      getByText(document, marineLicence.rejectedInformation)
+    ).toBeInTheDocument()
+    expect(
+      getByRole(document, 'heading', {
+        level: 2,
+        name: 'Charges for reviewing your application'
+      })
+    ).toBeInTheDocument()
+    expect(
+      getByRole(document, 'heading', {
+        level: 2,
+        name: 'What you can do'
+      })
+    ).toBeInTheDocument()
+    expect(
+      getByText(document, 'you will get a new fee estimate')
+    ).toBeInTheDocument()
+    expect(
+      getByText(
+        document,
+        'your new application will have a new reference number'
+      )
+    ).toBeInTheDocument()
+    expect(
+      getByRole(document, 'button', { name: 'Apply again' })
+    ).toBeInTheDocument()
+    expect(
+      getByRole(document, 'link', {
+        name: 'View your original application'
+      })
+    ).toHaveAttribute(
+      'href',
+      `${marineLicenceRoutes.MARINE_LICENCE_VIEW_DETAILS}/${marineLicence.id}`
+    )
+  })
+
+  test('should redirect if marine licence is not rejected', async () => {
+    mockMarineLicence(mockSubmittedMarineLicenceApplication)
+
+    const response = await makeGetRequest({
+      url: `${marineLicenceRoutes.MARINE_LICENCE_APPLICATION_REJECTED}/${marineLicence.id}`,
+      server: getServer()
+    })
+
+    expect(response.statusCode).toBe(statusCodes.redirect)
+    expect(response.headers.location).toBe(routes.DASHBOARD)
+  })
+
+  test('should submit apply again without error', async () => {
+    const response = await makePostRequest({
+      url: `${marineLicenceRoutes.MARINE_LICENCE_APPLICATION_REJECTED}/${marineLicence.id}`,
+      server: getServer()
+    })
+
+    expect(response.statusCode).toBe(statusCodes.noContent)
+  })
+
+  test('should return bad request for an invalid marine licence id', async () => {
+    const response = await makeGetRequest({
+      url: `${marineLicenceRoutes.MARINE_LICENCE_APPLICATION_REJECTED}/not-a-valid-id`,
+      server: getServer()
+    })
+
+    expect(response.statusCode).toBe(statusCodes.badRequest)
+  })
+})

--- a/tests/integration/marine-licence/application-rejected.test.js
+++ b/tests/integration/marine-licence/application-rejected.test.js
@@ -13,10 +13,7 @@ import {
   mockSubmittedMarineLicenceApplication
 } from '#src/server/test-helpers/mocks/marine-licence-mocks.js'
 import { statusCodes } from '~/src/server/common/constants/status-codes.js'
-import {
-  makeGetRequest,
-  makePostRequest
-} from '~/src/server/test-helpers/server-requests.js'
+import { makeGetRequest } from '~/src/server/test-helpers/server-requests.js'
 
 describe('Application rejected', () => {
   const getServer = setupTestServer()
@@ -75,7 +72,11 @@ describe('Application rejected', () => {
     ).toBeInTheDocument()
     expect(
       getByRole(document, 'button', { name: 'Apply again' })
-    ).toBeInTheDocument()
+    ).toHaveAttribute(
+      'href',
+      `${marineLicenceRoutes.MARINE_LICENCE_UPDATE_AND_RESUBMIT}/${marineLicence.id}`
+    )
+
     expect(
       getByRole(document, 'link', {
         name: 'View your original application'
@@ -96,15 +97,6 @@ describe('Application rejected', () => {
 
     expect(response.statusCode).toBe(statusCodes.redirect)
     expect(response.headers.location).toBe(routes.DASHBOARD)
-  })
-
-  test('should submit apply again without error', async () => {
-    const response = await makePostRequest({
-      url: `${marineLicenceRoutes.MARINE_LICENCE_APPLICATION_REJECTED}/${marineLicence.id}`,
-      server: getServer()
-    })
-
-    expect(response.statusCode).toBe(statusCodes.noContent)
   })
 
   test('should return bad request for an invalid marine licence id', async () => {

--- a/tests/integration/marine-licence/application-transferred.test.js
+++ b/tests/integration/marine-licence/application-transferred.test.js
@@ -83,4 +83,13 @@ describe('Application transferred', () => {
     expect(response.statusCode).toBe(statusCodes.redirect)
     expect(response.headers.location).toBe(routes.DASHBOARD)
   })
+
+  test('should return bad request for an invalid marine licence id', async () => {
+    const response = await makeGetRequest({
+      url: `${marineLicenceRoutes.MARINE_LICENCE_APPLICATION_TRANSFERRED}/not-a-valid-id`,
+      server: getServer()
+    })
+
+    expect(response.statusCode).toBe(statusCodes.badRequest)
+  })
 })

--- a/tests/integration/marine-licence/update-and-resubmit.test.js
+++ b/tests/integration/marine-licence/update-and-resubmit.test.js
@@ -1,0 +1,98 @@
+import { getByRole, getByText } from '@testing-library/dom'
+import {
+  marineLicenceRoutes,
+  routes
+} from '~/src/server/common/constants/routes.js'
+import {
+  mockMarineLicence,
+  setupTestServer
+} from '~/tests/integration/shared/test-setup-helpers.js'
+import { loadPage } from '~/tests/integration/shared/app-server.js'
+import {
+  mockRejectedMarineLicenceApplication,
+  mockSubmittedMarineLicenceApplication
+} from '#src/server/test-helpers/mocks/marine-licence-mocks.js'
+import { statusCodes } from '~/src/server/common/constants/status-codes.js'
+import {
+  makeGetRequest,
+  makePostRequest
+} from '~/src/server/test-helpers/server-requests.js'
+
+describe('Update and resubmit', () => {
+  const getServer = setupTestServer()
+  const marineLicence = mockRejectedMarineLicenceApplication
+
+  test('page elements', async () => {
+    mockMarineLicence(mockRejectedMarineLicenceApplication)
+
+    const document = await loadPage({
+      requestUrl: `${marineLicenceRoutes.MARINE_LICENCE_UPDATE_AND_RESUBMIT}/${marineLicence.id}`,
+      server: getServer()
+    })
+
+    expect(getByText(document, marineLicence.projectName)).toBeInTheDocument()
+    expect(getByRole(document, 'link', { name: 'Back' })).toHaveAttribute(
+      'href',
+      `${marineLicenceRoutes.MARINE_LICENCE_APPLICATION_REJECTED}/${marineLicence.id}`
+    )
+    expect(getByRole(document, 'heading', { level: 1 })).toHaveTextContent(
+      'Apply again for this project'
+    )
+    expect(
+      document.body.textContent.includes(
+        `To support you with this, we will copy all of the information from your original application (${marineLicence.applicationReference}) into a new draft application.`
+      )
+    ).toBe(true)
+    expect(
+      getByText(
+        document,
+        "Fix the issues we've identified before you submit. You can also change anything else."
+      )
+    ).toBeInTheDocument()
+    expect(
+      getByText(
+        document,
+        "Your original application will stay 'Unable to progress'. You can still view it in your projects."
+      )
+    ).toBeInTheDocument()
+    expect(
+      getByRole(document, 'button', {
+        name: 'Create new draft and fix issues'
+      })
+    ).toBeInTheDocument()
+    expect(getByRole(document, 'link', { name: 'Cancel' })).toHaveAttribute(
+      'href',
+      `${marineLicenceRoutes.MARINE_LICENCE_APPLICATION_REJECTED}/${marineLicence.id}`
+    )
+  })
+
+  test('should redirect if marine licence is not rejected', async () => {
+    mockMarineLicence(mockSubmittedMarineLicenceApplication)
+
+    const response = await makeGetRequest({
+      url: `${marineLicenceRoutes.MARINE_LICENCE_UPDATE_AND_RESUBMIT}/${marineLicence.id}`,
+      server: getServer()
+    })
+
+    expect(response.statusCode).toBe(statusCodes.redirect)
+    expect(response.headers.location).toBe(routes.DASHBOARD)
+  })
+
+  test('should submit without error', async () => {
+    const response = await makePostRequest({
+      url: `${marineLicenceRoutes.MARINE_LICENCE_UPDATE_AND_RESUBMIT}/${marineLicence.id}`,
+      server: getServer()
+    })
+
+    expect(response.statusCode).toBe(statusCodes.noContent)
+  })
+
+  test('should return bad request for an invalid marine licence id', async () => {
+    const response = await makeGetRequest({
+      url: `${marineLicenceRoutes.MARINE_LICENCE_UPDATE_AND_RESUBMIT}/not-a-valid-id`,
+      server: getServer()
+    })
+
+    expect(response.statusCode).toBe(statusCodes.badRequest)
+  })
+})

--- a/tests/integration/marine-licence/update-and-resubmit.test.js
+++ b/tests/integration/marine-licence/update-and-resubmit.test.js
@@ -1,5 +1,7 @@
+import { vi } from 'vitest'
 import { getByRole, getByText } from '@testing-library/dom'
 import {
+  apiRoutes,
   marineLicenceRoutes,
   routes
 } from '~/src/server/common/constants/routes.js'
@@ -17,6 +19,7 @@ import {
   makeGetRequest,
   makePostRequest
 } from '~/src/server/test-helpers/server-requests.js'
+import { authenticatedPostRequest } from '~/src/server/common/helpers/authenticated-requests.js'
 
 describe('Update and resubmit', () => {
   const getServer = setupTestServer()
@@ -78,13 +81,41 @@ describe('Update and resubmit', () => {
     expect(response.headers.location).toBe(routes.DASHBOARD)
   })
 
-  test('should submit without error', async () => {
+  test('should copy the marine licence and redirect to the new task list', async () => {
+    mockMarineLicence(mockRejectedMarineLicenceApplication)
+    vi.mocked(authenticatedPostRequest).mockResolvedValue({
+      payload: { value: { id: 'new-marine-licence-id' } }
+    })
+
     const response = await makePostRequest({
       url: `${marineLicenceRoutes.MARINE_LICENCE_UPDATE_AND_RESUBMIT}/${marineLicence.id}`,
       server: getServer()
     })
 
-    expect(response.statusCode).toBe(statusCodes.noContent)
+    expect(authenticatedPostRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      apiRoutes.COPY_MARINE_LICENCE,
+      { id: marineLicence.id }
+    )
+    expect(response.statusCode).toBe(statusCodes.redirect)
+    expect(response.headers.location).toBe(
+      `${marineLicenceRoutes.MARINE_LICENCE_TASK_LIST}/new-marine-licence-id`
+    )
+  })
+
+  test('should redirect to the dashboard if copying the marine licence fails', async () => {
+    mockMarineLicence(mockRejectedMarineLicenceApplication)
+    vi.mocked(authenticatedPostRequest).mockRejectedValue(
+      new Error('Copy failed')
+    )
+
+    const response = await makePostRequest({
+      url: `${marineLicenceRoutes.MARINE_LICENCE_UPDATE_AND_RESUBMIT}/${marineLicence.id}`,
+      server: getServer()
+    })
+
+    expect(response.statusCode).toBe(statusCodes.redirect)
+    expect(response.headers.location).toBe(routes.DASHBOARD)
   })
 
   test('should return bad request for an invalid marine licence id', async () => {

--- a/tests/integration/marine-licence/view-details/fixtures.js
+++ b/tests/integration/marine-licence/view-details/fixtures.js
@@ -25,20 +25,42 @@ export const expectedApplicationDetailsCard = {
       value: 'Marine licence application'
     },
     {
-      key: 'Status',
-      value: 'Transferred'
-    },
-    {
       key: 'Reference number',
       value: mockTransferredMarineLicenceApplication.applicationReference
     },
     {
       key: 'Date submitted',
       value: '26 May 2026'
+    }
+  ]
+}
+
+export const expectedTransferredApplicationDetailsCard = {
+  ...expectedApplicationDetailsCard,
+  rows: [
+    ...expectedApplicationDetailsCard.rows,
+    {
+      key: 'Status',
+      value: 'Transferred'
     },
     {
       key: 'Date of transfer',
       value: '26 Jun 2026'
+    }
+  ]
+}
+
+export const expectedRejectedApplicationDetailsCard = {
+  ...expectedApplicationDetailsCard,
+  rows: [
+    ...expectedApplicationDetailsCard.rows,
+    {
+      key: 'Status',
+      value: 'Unable to progress'
+    },
+    {
+      key: 'Date rejected',
+      value: '26 Jul 2026'
     }
   ]
 }

--- a/tests/integration/marine-licence/view-details/fixtures.js
+++ b/tests/integration/marine-licence/view-details/fixtures.js
@@ -59,8 +59,13 @@ export const expectedRejectedApplicationDetailsCard = {
       value: 'Unable to progress'
     },
     {
-      key: 'Date rejected',
+      key: 'Date marked as unable to progress',
       value: '26 Jul 2026'
+    },
+    {
+      key: 'Reasons marked as unable to progress',
+      value:
+        'Site location Water Framework Directive The site location entered indicated that it was within 1 nautical mile of the coast but no Water Framework Directive assessment was uploaded. Check the site location and if it meets the requirements for a WFD assessment.'
     }
   ]
 }

--- a/tests/integration/marine-licence/view-details/view-details.test.js
+++ b/tests/integration/marine-licence/view-details/view-details.test.js
@@ -148,7 +148,10 @@ describe('Marine Licence View Details', () => {
 
         expect(row).toBeTruthy()
         expect(
-          row.querySelector('.govuk-summary-list__value').textContent.trim()
+          row
+            .querySelector('.govuk-summary-list__value')
+            .textContent.replace(/\s+/g, ' ')
+            .trim()
         ).toBe(value)
       }
     )

--- a/tests/integration/marine-licence/view-details/view-details.test.js
+++ b/tests/integration/marine-licence/view-details/view-details.test.js
@@ -10,7 +10,8 @@ import {
 import { loadPage } from '~/tests/integration/shared/app-server.js'
 import {
   mockSubmittedMarineLicenceApplication,
-  mockTransferredMarineLicenceApplication
+  mockTransferredMarineLicenceApplication,
+  mockRejectedMarineLicenceApplication
 } from '~/src/server/test-helpers/mocks/marine-licence-mocks.js'
 import {
   expectedProjectDetailsCard,
@@ -65,6 +66,18 @@ describe('Marine Licence View Details', () => {
     expect(getByRole(document, 'link', { name: 'Back' })).toHaveAttribute(
       'href',
       `${marineLicenceRoutes.MARINE_LICENCE_APPLICATION_TRANSFERRED}/${mockTransferredMarineLicenceApplication.id}`
+    )
+  })
+
+  test('back link goes to application rejected page for rejected applications', async () => {
+    const document = await loadViewDetailsPage(
+      getServer(),
+      mockRejectedMarineLicenceApplication
+    )
+
+    expect(getByRole(document, 'link', { name: 'Back' })).toHaveAttribute(
+      'href',
+      `${marineLicenceRoutes.MARINE_LICENCE_APPLICATION_REJECTED}/${mockRejectedMarineLicenceApplication.id}`
     )
   })
 

--- a/tests/integration/marine-licence/view-details/view-details.test.js
+++ b/tests/integration/marine-licence/view-details/view-details.test.js
@@ -19,7 +19,8 @@ import {
   expectedWaterFrameworkDirectiveCard,
   expectedInvocingCardIndividualUser,
   expectedInvocingCardOrgUser,
-  expectedApplicationDetailsCard
+  expectedTransferredApplicationDetailsCard,
+  expectedRejectedApplicationDetailsCard
 } from './fixtures.js'
 import { getCardRow } from './utils.js'
 import {
@@ -81,7 +82,7 @@ describe('Marine Licence View Details', () => {
     )
   })
 
-  describe('application details card', () => {
+  describe('application details card (transferred)', () => {
     let document
 
     beforeEach(async () => {
@@ -103,7 +104,43 @@ describe('Marine Licence View Details', () => {
       ).toBeInTheDocument()
     })
 
-    test.each(expectedApplicationDetailsCard.rows)(
+    test.each(expectedTransferredApplicationDetailsCard.rows)(
+      'renders "$key" row with correct value',
+      ({ key, value }) => {
+        const card = document.querySelector('#application-details-card')
+        const row = getCardRow(card, key)
+
+        expect(row).toBeTruthy()
+        expect(
+          row.querySelector('.govuk-summary-list__value').textContent.trim()
+        ).toBe(value)
+      }
+    )
+  })
+
+  describe('application details card (rejected)', () => {
+    let document
+
+    beforeEach(async () => {
+      document = await loadViewDetailsPage(
+        getServer(),
+        mockRejectedMarineLicenceApplication
+      )
+    })
+
+    test('does not render for submitted applications', async () => {
+      document = await loadViewDetailsPage(getServer())
+
+      expect(document.querySelector('#application-details-card')).toBeNull()
+    })
+
+    test('renders for rejected applications', async () => {
+      expect(
+        document.querySelector('#application-details-card')
+      ).toBeInTheDocument()
+    })
+
+    test.each(expectedRejectedApplicationDetailsCard.rows)(
       'renders "$key" row with correct value',
       ({ key, value }) => {
         const card = document.querySelector('#application-details-card')


### PR DESCRIPTION
### Description

View a rejected application and create new draft from this rejected licence

### Changes

- 2 new pages: `application-rejected` and `update-and-resubmit`
-  New status: 
<img width="188" height="41" alt="Screenshot 2026-08-07 at 10 26 53" src="https://github.com/user-attachments/assets/c33b4562-a868-4085-a093-765855524140" />

- If a user decides to copy marine licence into a new application, clear the cache and direct to the task-list. This page already takes care of the new cache and loading from the server.
- [validate-marine-licence-id-params.js](https://github.com/DEFRA/marine-licensing-frontend/pull/853/changes#diff-13e514905983c9daf85a60f4d78e64452255947a341ecdc79278cb0e41db1837) : Some extra protection on the URL params.

<img width="2052" height="3090" alt="We-are-unable-to-progress-your-application-Get-permission-for-marine-work-08-07-2026_10_25_AM" src="https://github.com/user-attachments/assets/3df75fe4-b970-4e56-b151-b1bad1fd423e" />

