### PR TITLE
ML-1434 D365 - "Sites and activities" tab

### DIFF
--- a/src/server/common/helpers/activity-details/snapshot-activity-labels.js
+++ b/src/server/common/helpers/activity-details/snapshot-activity-labels.js
@@ -71,13 +71,7 @@ export const snapshotActivityLabels = (activity = {}) => {
   return next
 }
 
-export const snapshotSiteActivityLabels = (site = {}) => {
-  if (!Array.isArray(site?.activityDetails)) {
-    return site
-  }
-
-  return {
-    ...site,
-    activityDetails: site.activityDetails.map(snapshotActivityLabels)
-  }
-}
+export const snapshotActivityDetails = (activityDetails) =>
+  Array.isArray(activityDetails)
+    ? activityDetails.map(snapshotActivityLabels)
+    : activityDetails

--- a/src/server/common/helpers/activity-details/snapshot-activity-labels.js
+++ b/src/server/common/helpers/activity-details/snapshot-activity-labels.js
@@ -72,7 +72,7 @@ export const snapshotActivityLabels = (activity = {}) => {
 }
 
 export const snapshotSiteActivityLabels = (site = {}) => {
-  if (!site?.activityDetails) {
+  if (!Array.isArray(site?.activityDetails)) {
     return site
   }
 

--- a/src/server/common/helpers/activity-details/snapshot-activity-labels.js
+++ b/src/server/common/helpers/activity-details/snapshot-activity-labels.js
@@ -1,0 +1,83 @@
+import { ACTIVITY_LABELS } from '#src/server/common/constants/activities.js'
+import {
+  formatActivitySubTypeLabel,
+  getOtherActivityLabel
+} from '#src/server/common/helpers/review-site-details/activity-details.js'
+
+export const ACTIVITY_TYPE_LABELS = {
+  construction: 'Construction, alteration or improvement of any works',
+  deposit: 'Deposit of any substance or object',
+  removal: 'Removal of any substance or object'
+}
+
+export const resolveActivityTypeLabel = (activityType) =>
+  ACTIVITY_TYPE_LABELS[activityType] ?? null
+
+export const resolveSelectionLabel = (
+  selection,
+  activityType,
+  otherActivity
+) => {
+  if (selection === 'other') {
+    return getOtherActivityLabel(activityType, otherActivity)
+  }
+
+  return ACTIVITY_LABELS[selection] ?? selection ?? null
+}
+
+/**
+ * Adds snapshot labels so Mongo (and Dynamics) keep applicant-era wording.
+ * Keys remain the source of form logic; labels are display text at save time.
+ */
+export const snapshotActivityLabels = (activity = {}) => {
+  if (!activity || typeof activity !== 'object') {
+    return activity
+  }
+
+  const {
+    activityType,
+    activitySubType,
+    activityTypeLabel,
+    activitySubTypeLabel,
+    activities
+  } = activity
+
+  const next = { ...activity }
+
+  if (activityType) {
+    next.activityTypeLabel =
+      activityTypeLabel || resolveActivityTypeLabel(activityType)
+  }
+
+  if (activitySubType) {
+    next.activitySubTypeLabel =
+      activitySubTypeLabel || formatActivitySubTypeLabel(activitySubType)
+  }
+
+  if (activities && typeof activities === 'object') {
+    const selections = Array.isArray(activities.selections)
+      ? activities.selections
+      : [activities.selections].filter(Boolean)
+
+    next.activities = {
+      ...activities,
+      selections,
+      selectionLabels: selections.map((selection) =>
+        resolveSelectionLabel(selection, activityType, activities.otherActivity)
+      )
+    }
+  }
+
+  return next
+}
+
+export const snapshotSiteActivityLabels = (site = {}) => {
+  if (!site?.activityDetails) {
+    return site
+  }
+
+  return {
+    ...site,
+    activityDetails: site.activityDetails.map(snapshotActivityLabels)
+  }
+}

--- a/src/server/common/helpers/activity-details/snapshot-activity-labels.js
+++ b/src/server/common/helpers/activity-details/snapshot-activity-labels.js
@@ -34,24 +34,16 @@ export const snapshotActivityLabels = (activity = {}) => {
     return activity
   }
 
-  const {
-    activityType,
-    activitySubType,
-    activityTypeLabel,
-    activitySubTypeLabel,
-    activities
-  } = activity
+  const { activityType, activitySubType, activities } = activity
 
   const next = { ...activity }
 
   if (activityType) {
-    next.activityTypeLabel =
-      activityTypeLabel || resolveActivityTypeLabel(activityType)
+    next.activityTypeLabel = resolveActivityTypeLabel(activityType)
   }
 
   if (activitySubType) {
-    next.activitySubTypeLabel =
-      activitySubTypeLabel || formatActivitySubTypeLabel(activitySubType)
+    next.activitySubTypeLabel = formatActivitySubTypeLabel(activitySubType)
   }
 
   if (activities && typeof activities === 'object') {

--- a/src/server/common/helpers/activity-details/snapshot-activity-labels.test.js
+++ b/src/server/common/helpers/activity-details/snapshot-activity-labels.test.js
@@ -1,0 +1,56 @@
+import {
+  ACTIVITY_TYPE_LABELS,
+  resolveActivityTypeLabel,
+  resolveSelectionLabel,
+  snapshotActivityLabels,
+  snapshotSiteActivityLabels
+} from '#src/server/common/helpers/activity-details/snapshot-activity-labels.js'
+
+describe('snapshotActivityLabels', () => {
+  test('adds activity type, subtype and selection labels', () => {
+    const result = snapshotActivityLabels({
+      activityType: 'construction',
+      activitySubType: 'construction-type-1',
+      activities: {
+        selections: ['CON14', 'CON12']
+      }
+    })
+
+    expect(result.activityTypeLabel).toBe(ACTIVITY_TYPE_LABELS.construction)
+    expect(result.activitySubTypeLabel).toBe('Construction of new marine works')
+    expect(result.activities.selectionLabels).toEqual([
+      'Pontoons or floating walkways',
+      'Slipway or boat ramp'
+    ])
+  })
+
+  test('formats other selection with free text', () => {
+    expect(
+      resolveSelectionLabel('other', 'construction', 'Custom structure')
+    ).toBe('Other structures: Custom structure')
+  })
+
+  test('resolveActivityTypeLabel returns null for unknown type', () => {
+    expect(resolveActivityTypeLabel('unknown')).toBeNull()
+  })
+
+  test('snapshotSiteActivityLabels maps all activities', () => {
+    const site = snapshotSiteActivityLabels({
+      siteName: 'Site 1',
+      activityDetails: [
+        {
+          activityType: 'deposit',
+          activitySubType: 'deposit-type-2',
+          activities: { selections: ['DEP11'] }
+        }
+      ]
+    })
+
+    expect(site.activityDetails[0].activityTypeLabel).toBe(
+      ACTIVITY_TYPE_LABELS.deposit
+    )
+    expect(site.activityDetails[0].activities.selectionLabels).toEqual([
+      'Pontoons'
+    ])
+  })
+})

--- a/src/server/common/helpers/activity-details/snapshot-activity-labels.test.js
+++ b/src/server/common/helpers/activity-details/snapshot-activity-labels.test.js
@@ -33,16 +33,18 @@ describe('snapshotActivityLabels', () => {
     expect(snapshotActivityLabels()).toEqual({})
   })
 
-  test('keeps existing type and subtype labels', () => {
+  test('re-resolves type and subtype labels when keys change via change link', () => {
     const result = snapshotActivityLabels({
-      activityType: 'construction',
-      activitySubType: 'construction-type-1',
-      activityTypeLabel: 'Existing type label',
-      activitySubTypeLabel: 'Existing subtype label'
+      activityType: 'removal',
+      activitySubType: 'removal-type-2',
+      activityTypeLabel: 'Construction, alteration or improvement of any works',
+      activitySubTypeLabel: 'Construction of new marine works'
     })
 
-    expect(result.activityTypeLabel).toBe('Existing type label')
-    expect(result.activitySubTypeLabel).toBe('Existing subtype label')
+    expect(result.activityTypeLabel).toBe(ACTIVITY_TYPE_LABELS.removal)
+    expect(result.activitySubTypeLabel).toBe(
+      'Removal as part of an ongoing or routine activity'
+    )
   })
 
   test('normalises a single selection string and skips empty selections', () => {

--- a/src/server/common/helpers/activity-details/snapshot-activity-labels.test.js
+++ b/src/server/common/helpers/activity-details/snapshot-activity-labels.test.js
@@ -3,7 +3,7 @@ import {
   resolveActivityTypeLabel,
   resolveSelectionLabel,
   snapshotActivityLabels,
-  snapshotSiteActivityLabels
+  snapshotActivityDetails
 } from '#src/server/common/helpers/activity-details/snapshot-activity-labels.js'
 
 describe('snapshotActivityLabels', () => {
@@ -105,39 +105,28 @@ describe('snapshotActivityLabels', () => {
     expect(resolveActivityTypeLabel('unknown')).toBeNull()
   })
 
-  test('snapshotSiteActivityLabels maps all activities', () => {
-    const site = snapshotSiteActivityLabels({
-      siteName: 'Site 1',
-      activityDetails: [
-        {
-          activityType: 'deposit',
-          activitySubType: 'deposit-type-2',
-          activities: { selections: ['DEP11'] }
-        }
-      ]
-    })
+  test('snapshotActivityDetails maps all activities', () => {
+    const activityDetails = snapshotActivityDetails([
+      {
+        activityType: 'deposit',
+        activitySubType: 'deposit-type-2',
+        activities: { selections: ['DEP11'] }
+      }
+    ])
 
-    expect(site.activityDetails[0].activityTypeLabel).toBe(
+    expect(activityDetails[0].activityTypeLabel).toBe(
       ACTIVITY_TYPE_LABELS.deposit
     )
-    expect(site.activityDetails[0].activities.selectionLabels).toEqual([
-      'Pontoons'
-    ])
+    expect(activityDetails[0].activities.selectionLabels).toEqual(['Pontoons'])
   })
 
-  test('snapshotSiteActivityLabels leaves non-array activityDetails unchanged', () => {
-    const site = {
-      siteName: 'Site 1',
-      activityDetails: { description: 'Test activity' }
-    }
+  test('snapshotActivityDetails leaves non-array activityDetails unchanged', () => {
+    const activityDetails = { description: 'Test activity' }
 
-    expect(snapshotSiteActivityLabels(site)).toEqual(site)
+    expect(snapshotActivityDetails(activityDetails)).toEqual(activityDetails)
   })
 
-  test('snapshotSiteActivityLabels returns site when activityDetails is missing', () => {
-    const site = { siteName: 'Site 1' }
-
-    expect(snapshotSiteActivityLabels(site)).toEqual(site)
-    expect(snapshotSiteActivityLabels()).toEqual({})
+  test('snapshotActivityDetails returns value when activityDetails is missing', () => {
+    expect(snapshotActivityDetails(undefined)).toBeUndefined()
   })
 })

--- a/src/server/common/helpers/activity-details/snapshot-activity-labels.test.js
+++ b/src/server/common/helpers/activity-details/snapshot-activity-labels.test.js
@@ -53,4 +53,13 @@ describe('snapshotActivityLabels', () => {
       'Pontoons'
     ])
   })
+
+  test('snapshotSiteActivityLabels leaves non-array activityDetails unchanged', () => {
+    const site = {
+      siteName: 'Site 1',
+      activityDetails: { description: 'Test activity' }
+    }
+
+    expect(snapshotSiteActivityLabels(site)).toEqual(site)
+  })
 })

--- a/src/server/common/helpers/activity-details/snapshot-activity-labels.test.js
+++ b/src/server/common/helpers/activity-details/snapshot-activity-labels.test.js
@@ -24,10 +24,81 @@ describe('snapshotActivityLabels', () => {
     ])
   })
 
+  test('returns non-object activity unchanged', () => {
+    expect(snapshotActivityLabels(null)).toBeNull()
+    expect(snapshotActivityLabels('not-an-object')).toBe('not-an-object')
+  })
+
+  test('returns empty object when called with no argument', () => {
+    expect(snapshotActivityLabels()).toEqual({})
+  })
+
+  test('keeps existing type and subtype labels', () => {
+    const result = snapshotActivityLabels({
+      activityType: 'construction',
+      activitySubType: 'construction-type-1',
+      activityTypeLabel: 'Existing type label',
+      activitySubTypeLabel: 'Existing subtype label'
+    })
+
+    expect(result.activityTypeLabel).toBe('Existing type label')
+    expect(result.activitySubTypeLabel).toBe('Existing subtype label')
+  })
+
+  test('normalises a single selection string and skips empty selections', () => {
+    const result = snapshotActivityLabels({
+      activityType: 'construction',
+      activities: {
+        selections: 'CON1'
+      }
+    })
+
+    expect(result.activities.selections).toEqual(['CON1'])
+    expect(result.activities.selectionLabels).toEqual([
+      'Aquaculture trestles or fixed walkways'
+    ])
+
+    const emptySelections = snapshotActivityLabels({
+      activities: { selections: undefined }
+    })
+
+    expect(emptySelections.activities.selections).toEqual([])
+    expect(emptySelections.activities.selectionLabels).toEqual([])
+  })
+
+  test('omits activity labels when type or subtype are missing', () => {
+    const result = snapshotActivityLabels({
+      activities: { selections: ['CON1'] }
+    })
+
+    expect(result.activityTypeLabel).toBeUndefined()
+    expect(result.activitySubTypeLabel).toBeUndefined()
+    expect(result.activities.selectionLabels).toEqual([
+      'Aquaculture trestles or fixed walkways'
+    ])
+  })
+
+  test('skips activities when not a plain object', () => {
+    const result = snapshotActivityLabels({
+      activityType: 'construction',
+      activities: 'invalid'
+    })
+
+    expect(result.activities).toBe('invalid')
+    expect(result.activityTypeLabel).toBe(ACTIVITY_TYPE_LABELS.construction)
+  })
+
   test('formats other selection with free text', () => {
     expect(
       resolveSelectionLabel('other', 'construction', 'Custom structure')
     ).toBe('Other structures: Custom structure')
+  })
+
+  test('resolveSelectionLabel falls back to selection key then null', () => {
+    expect(resolveSelectionLabel('UNKNOWN_CODE', 'construction')).toBe(
+      'UNKNOWN_CODE'
+    )
+    expect(resolveSelectionLabel(undefined, 'construction')).toBeNull()
   })
 
   test('resolveActivityTypeLabel returns null for unknown type', () => {
@@ -61,5 +132,12 @@ describe('snapshotActivityLabels', () => {
     }
 
     expect(snapshotSiteActivityLabels(site)).toEqual(site)
+  })
+
+  test('snapshotSiteActivityLabels returns site when activityDetails is missing', () => {
+    const site = { siteName: 'Site 1' }
+
+    expect(snapshotSiteActivityLabels(site)).toEqual(site)
+    expect(snapshotSiteActivityLabels()).toEqual({})
   })
 })

--- a/src/server/common/helpers/marine-licence/save-site-details.js
+++ b/src/server/common/helpers/marine-licence/save-site-details.js
@@ -4,7 +4,7 @@ import {
   setMarineLicenceCache
 } from '#src/server/common/helpers/marine-licence/session-cache/utils.js'
 import { transformCoordinatesForApi } from '#src/server/common/helpers/site-details/coordinate-transform.js'
-import { snapshotSiteActivityLabels } from '#src/server/common/helpers/activity-details/snapshot-activity-labels.js'
+import { snapshotActivityDetails } from '#src/server/common/helpers/activity-details/snapshot-activity-labels.js'
 import { routes, apiRoutes } from '#src/server/common/constants/routes.js'
 import Boom from '@hapi/boom'
 
@@ -16,7 +16,7 @@ export const prepareFileUploadDataForSave = (siteDetails, request) => {
     const geoJSON = site.geoJSON
     const featureCount = site.featureCount || 0
 
-    const siteToSave = snapshotSiteActivityLabels({
+    const siteToSave = {
       coordinatesType: 'file',
       fileUploadType: site.fileUploadType,
       geoJSON,
@@ -30,8 +30,8 @@ export const prepareFileUploadDataForSave = (siteDetails, request) => {
         checksumSha256: site.s3Location.checksumSha256
       },
       siteName: site.siteName,
-      activityDetails: site.activityDetails
-    })
+      activityDetails: snapshotActivityDetails(site.activityDetails)
+    }
 
     request.logger.info(
       {
@@ -52,14 +52,14 @@ export const prepareManualCoordinateDataForSave = (siteDetails) => {
   const dataToSave = []
 
   for (const site of siteDetails) {
-    const siteToSave = snapshotSiteActivityLabels({
+    const siteToSave = {
       coordinatesType: site.coordinatesType,
       coordinatesEntry: site.coordinatesEntry,
       coordinateSystem: site.coordinateSystem,
       coordinates: site.coordinates,
       siteName: site.siteName,
-      activityDetails: site.activityDetails
-    })
+      activityDetails: snapshotActivityDetails(site.activityDetails)
+    }
 
     if (site.coordinatesEntry === 'single') {
       siteToSave.circleWidth = site.circleWidth

--- a/src/server/common/helpers/marine-licence/save-site-details.js
+++ b/src/server/common/helpers/marine-licence/save-site-details.js
@@ -4,6 +4,7 @@ import {
   setMarineLicenceCache
 } from '#src/server/common/helpers/marine-licence/session-cache/utils.js'
 import { transformCoordinatesForApi } from '#src/server/common/helpers/site-details/coordinate-transform.js'
+import { snapshotSiteActivityLabels } from '#src/server/common/helpers/activity-details/snapshot-activity-labels.js'
 import { routes, apiRoutes } from '#src/server/common/constants/routes.js'
 import Boom from '@hapi/boom'
 
@@ -15,7 +16,7 @@ export const prepareFileUploadDataForSave = (siteDetails, request) => {
     const geoJSON = site.geoJSON
     const featureCount = site.featureCount || 0
 
-    const siteToSave = {
+    const siteToSave = snapshotSiteActivityLabels({
       coordinatesType: 'file',
       fileUploadType: site.fileUploadType,
       geoJSON,
@@ -30,7 +31,7 @@ export const prepareFileUploadDataForSave = (siteDetails, request) => {
       },
       siteName: site.siteName,
       activityDetails: site.activityDetails
-    }
+    })
 
     request.logger.info(
       {
@@ -51,14 +52,14 @@ export const prepareManualCoordinateDataForSave = (siteDetails) => {
   const dataToSave = []
 
   for (const site of siteDetails) {
-    const siteToSave = {
+    const siteToSave = snapshotSiteActivityLabels({
       coordinatesType: site.coordinatesType,
       coordinatesEntry: site.coordinatesEntry,
       coordinateSystem: site.coordinateSystem,
       coordinates: site.coordinates,
       siteName: site.siteName,
       activityDetails: site.activityDetails
-    }
+    })
 
     if (site.coordinatesEntry === 'single') {
       siteToSave.circleWidth = site.circleWidth

--- a/src/server/common/helpers/marine-licence/save-site-details.test.js
+++ b/src/server/common/helpers/marine-licence/save-site-details.test.js
@@ -17,6 +17,12 @@ import {
   mockManualCoordinatesMarineLicence
 } from '#src/server/test-helpers/mocks/marine-licence-mocks.js'
 import { apiRoutes } from '#src/server/common/constants/routes.js'
+import { snapshotActivityLabels } from '#src/server/common/helpers/activity-details/snapshot-activity-labels.js'
+
+const withActivityLabels = (activityDetails) =>
+  Array.isArray(activityDetails)
+    ? activityDetails.map(snapshotActivityLabels)
+    : activityDetails
 
 vi.mock('../authenticated-requests.js')
 vi.mock('./session-cache/utils.js')
@@ -41,8 +47,9 @@ describe('save-site-details', () => {
       expect(result[0]).toEqual({
         coordinatesType: 'file',
         fileUploadType: 'kml',
-        activityDetails:
-          mockMarineLicenceApplication.siteDetails[0].activityDetails,
+        activityDetails: withActivityLabels(
+          mockMarineLicenceApplication.siteDetails[0].activityDetails
+        ),
         geoJSON: mockMarineLicenceApplication.siteDetails[0].geoJSON,
         featureCount: mockMarineLicenceApplication.siteDetails[0].featureCount,
         siteName: 'test site name',
@@ -326,11 +333,15 @@ describe('save-site-details', () => {
 
       await saveSiteDetailsToBackend(mockRequest, mockH, { siteIndex: 0 })
 
+      const siteDetails = mockMarineLicenceApplication.siteDetails[0]
       expect(authenticatedPatchRequest).toHaveBeenCalledWith(
         mockRequest,
         apiRoutes.UPDATE_MARINE_LICENCE_SITE,
         {
-          siteDetails: mockMarineLicenceApplication.siteDetails[0],
+          siteDetails: {
+            ...siteDetails,
+            activityDetails: withActivityLabels(siteDetails.activityDetails)
+          },
           siteIndex: 0,
           id: mockMarineLicenceApplication.id
         }

--- a/src/server/common/helpers/marine-licence/save-site-details.test.js
+++ b/src/server/common/helpers/marine-licence/save-site-details.test.js
@@ -335,7 +335,9 @@ describe('save-site-details', () => {
         {
           siteDetails: {
             ...siteDetails,
-            activityDetails: snapshotActivityDetails(siteDetails.activityDetails)
+            activityDetails: snapshotActivityDetails(
+              siteDetails.activityDetails
+            )
           },
           siteIndex: 0,
           id: mockMarineLicenceApplication.id

--- a/src/server/common/helpers/marine-licence/save-site-details.test.js
+++ b/src/server/common/helpers/marine-licence/save-site-details.test.js
@@ -17,12 +17,7 @@ import {
   mockManualCoordinatesMarineLicence
 } from '#src/server/test-helpers/mocks/marine-licence-mocks.js'
 import { apiRoutes } from '#src/server/common/constants/routes.js'
-import { snapshotActivityLabels } from '#src/server/common/helpers/activity-details/snapshot-activity-labels.js'
-
-const withActivityLabels = (activityDetails) =>
-  Array.isArray(activityDetails)
-    ? activityDetails.map(snapshotActivityLabels)
-    : activityDetails
+import { snapshotActivityDetails } from '#src/server/common/helpers/activity-details/snapshot-activity-labels.js'
 
 vi.mock('../authenticated-requests.js')
 vi.mock('./session-cache/utils.js')
@@ -47,7 +42,7 @@ describe('save-site-details', () => {
       expect(result[0]).toEqual({
         coordinatesType: 'file',
         fileUploadType: 'kml',
-        activityDetails: withActivityLabels(
+        activityDetails: snapshotActivityDetails(
           mockMarineLicenceApplication.siteDetails[0].activityDetails
         ),
         geoJSON: mockMarineLicenceApplication.siteDetails[0].geoJSON,
@@ -340,7 +335,7 @@ describe('save-site-details', () => {
         {
           siteDetails: {
             ...siteDetails,
-            activityDetails: withActivityLabels(siteDetails.activityDetails)
+            activityDetails: snapshotActivityDetails(siteDetails.activityDetails)
           },
           siteIndex: 0,
           id: mockMarineLicenceApplication.id

--- a/src/server/common/helpers/marine-licence/session-cache/utils.js
+++ b/src/server/common/helpers/marine-licence/session-cache/utils.js
@@ -1,6 +1,7 @@
 import { clone } from '@hapi/hoek'
 import { getSiteDetailsBySite } from '#src/server/common/helpers/exemptions/session-cache/site-details-utils.js'
 import { getSiteDetailsBySite as getSiteByIndex } from '#src/server/common/helpers/marine-licence/session-cache/site-details-utils.js'
+import { snapshotActivityLabels } from '#src/server/common/helpers/activity-details/snapshot-activity-labels.js'
 import { SINGLE_SITE_MODE_KEY } from '#src/server/common/constants/cache.js'
 
 export const MARINE_LICENCE_CACHE_KEY = 'marineLicence'
@@ -68,10 +69,10 @@ export const updateMarineLicenceSiteActivityDetails = async (
     existingCache.siteDetails[siteIndex]?.activityDetails || []
 
   const updatedActivityDetails = [...existingActivityDetails]
-  updatedActivityDetails[activityDetailsIndex] = {
+  updatedActivityDetails[activityDetailsIndex] = snapshotActivityLabels({
     ...updatedActivityDetails[activityDetailsIndex],
     ...values
-  }
+  })
 
   return updateMarineLicenceSiteDetails(
     request,

--- a/src/server/common/helpers/marine-licence/session-cache/utils.test.js
+++ b/src/server/common/helpers/marine-licence/session-cache/utils.test.js
@@ -299,7 +299,10 @@ describe('#utils', () => {
                 { activityType: 'construction' },
                 {
                   activityType: 'removal',
-                  activitySubType: 'removal-type-2'
+                  activityTypeLabel: 'Removal of any substance or object',
+                  activitySubType: 'removal-type-2',
+                  activitySubTypeLabel:
+                    'Removal as part of an ongoing or routine activity'
                 }
               ]
             }
@@ -311,7 +314,10 @@ describe('#utils', () => {
           { activityType: 'construction' },
           {
             activityType: 'removal',
-            activitySubType: 'removal-type-2'
+            activityTypeLabel: 'Removal of any substance or object',
+            activitySubType: 'removal-type-2',
+            activitySubTypeLabel:
+              'Removal as part of an ongoing or routine activity'
           }
         ]
       })
@@ -339,7 +345,11 @@ describe('#utils', () => {
           siteDetails: [
             {
               activityDetails: [
-                { activityType: 'removal', activityDescription: 'Building' },
+                {
+                  activityType: 'removal',
+                  activityTypeLabel: 'Removal of any substance or object',
+                  activityDescription: 'Building'
+                },
                 { activityType: 'deposit', activityDescription: 'Dumping' }
               ]
             }
@@ -366,11 +376,27 @@ describe('#utils', () => {
       expect(mockRequest.yar.set).toHaveBeenCalledWith(
         MARINE_LICENCE_CACHE_KEY,
         {
-          siteDetails: [{ activityDetails: [{ activityType: 'construction' }] }]
+          siteDetails: [
+            {
+              activityDetails: [
+                {
+                  activityType: 'construction',
+                  activityTypeLabel:
+                    'Construction, alteration or improvement of any works'
+                }
+              ]
+            }
+          ]
         }
       )
       expect(result).toEqual({
-        activityDetails: [{ activityType: 'construction' }]
+        activityDetails: [
+          {
+            activityType: 'construction',
+            activityTypeLabel:
+              'Construction, alteration or improvement of any works'
+          }
+        ]
       })
     })
 
@@ -389,7 +415,14 @@ describe('#utils', () => {
         }
       )
 
-      expect(result).toEqual({ activityDetails: [{ activityType: 'deposit' }] })
+      expect(result).toEqual({
+        activityDetails: [
+          {
+            activityType: 'deposit',
+            activityTypeLabel: 'Deposit of any substance or object'
+          }
+        ]
+      })
     })
   })
 


### PR DESCRIPTION
Snapshots human-readable activity labels when saving marine licence site/activity details, so Mongo and Dynamics keep the wording the applicant saw even if form labels change later.

- Adds snapshot-activity-labels helper that resolves type, subtype, and selection labels from the activity keys
- Applies those labels when updating activity details in session and when preparing site details for the backend (file upload and manual coordinates)
- Activity keys stay the source of form logic; labels are display-only snapshots at save time
- Tests updated for the new fields and non-array activityDetails handling

Depends-On: https://github.com/DEFRA/marine-licensing-backend/pull/576