### PR TITLE
ML-1074 - LCML - withdraw a marine licence application

### DIFF
--- a/src/server/common/components/marine-licence/application-details-card/template.njk
+++ b/src/server/common/components/marine-licence/application-details-card/template.njk
@@ -1,61 +1,5 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 
-{% set rows = [] %}
-
-{% set rows = (rows.push({
-  key: {
-    text: "Application type"
-  },
-  value: {
-    text: 'Marine licence application'
-  }
-},{
-  key: {
-    text: "Status"
-  },
-  value: {
-    html: params.statusTag
-  }
-},{
-  key: {
-    text: "Reference number"
-  },
-  value: {
-    text: params.applicationReference
-  }
-}, {
-  key: {
-    text: "Date submitted"
-  },
-  value: {
-    text: params.submittedAt
-  }
-},{
-  key: {
-    text: "Date marked as unable to progress"
-  },
-  value: {
-    text: params.rejectedDate
-  }
-} if params.isRejected, 
-{
-  key: {
-    text: "Date of transfer"
-  },
-  value: {
-    text: params.transferredDate
-  }
-} if params.isTransferred,
-{
-  key: {
-    text: "Reasons marked as unable to progress"
-  },
-  value: {
-    html: params.rejectedReasons
-  }
-} if params.isRejected), rows) %}
-
-
 {{ govukSummaryList({
   card: {
     title: {
@@ -113,6 +57,22 @@
       value: {
         text: params.withdrawnAt
       }
-    } if params.withdrawnAt else none
+    } if params.withdrawnAt else none,
+    {
+      key: {
+        text: "Date marked as unable to progress"
+      },
+      value: {
+        text: params.rejectedDate
+      }
+    } if params.isRejected else none,
+    {
+      key: {
+        text: "Reasons marked as unable to progress"
+      },
+      value: {
+        html: params.rejectedReasons
+      }
+    } if params.isRejected else none
   ]
 }) }}

--- a/src/server/common/components/marine-licence/application-details-card/template.njk
+++ b/src/server/common/components/marine-licence/application-details-card/template.njk
@@ -49,7 +49,7 @@
       value: {
         text: params.transferredDate
       }
-    } if params.transferredDate else undefined,
+    } if params.transferredDate else none,
     {
       key: {
         text: "Date withdrawn"
@@ -57,6 +57,6 @@
       value: {
         text: params.withdrawnAt
       }
-    } if params.withdrawnAt else undefined
+    } if params.withdrawnAt else none
   ]
 }) }}

--- a/src/server/common/components/marine-licence/application-details-card/template.njk
+++ b/src/server/common/components/marine-licence/application-details-card/template.njk
@@ -1,45 +1,5 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 
-{% set rows = [] %}
-
-{% set rows = (rows.push({
-  key: {
-    text: "Application type"
-  },
-  value: {
-    text: 'Marine licence application'
-  }
-},{
-  key: {
-    text: "Status"
-  },
-  value: {
-    html: params.statusTag
-  }
-},{
-  key: {
-    text: "Reference number"
-  },
-  value: {
-    text: params.applicationReference
-  }
-}, {
-  key: {
-    text: "Date submitted"
-  },
-  value: {
-    text: params.submittedAt
-  }
-},{
-  key: {
-    text: "Date of transfer"
-  },
-  value: {
-    text: params.transferredDate
-  }
-}), rows) %}
-
-
 {{ govukSummaryList({
   card: {
     title: {
@@ -49,5 +9,54 @@
       id: "application-details-card"
     }
   },
-  rows: rows
+  rows: [
+    {
+      key: {
+        text: "Application type"
+      },
+      value: {
+        text: 'Marine licence application'
+      }
+    },
+    {
+      key: {
+        text: "Status"
+      },
+      value: {
+        html: params.statusTag
+      }
+    },
+    {
+      key: {
+        text: "Reference number"
+      },
+      value: {
+        text: params.applicationReference
+      }
+    },
+    {
+      key: {
+        text: "Date submitted"
+      },
+      value: {
+        text: params.submittedAt
+      }
+    },
+    {
+      key: {
+        text: "Date of transfer"
+      },
+      value: {
+        text: params.transferredDate
+      }
+    } if params.transferredDate else undefined,
+    {
+      key: {
+        text: "Date withdrawn"
+      },
+      value: {
+        text: params.withdrawnAt
+      }
+    } if params.withdrawnAt else undefined
+  ]
 }) }}

--- a/src/server/common/components/marine-licence/application-details-card/template.test.js
+++ b/src/server/common/components/marine-licence/application-details-card/template.test.js
@@ -36,5 +36,28 @@ describe('Marine Licence Application Details Card Component', () => {
 
     expect(htmlContent).toContain('Date of transfer')
     expect(htmlContent).toContain('02 01 2026')
+
+    expect(htmlContent).not.toContain('Date withdrawn')
+  })
+
+  test('Should render the date withdrawn row and omit the transfer row for a withdrawn application', () => {
+    const $withdrawn = renderComponent(
+      'marine-licence/application-details-card',
+      {
+        statusTag:
+          '<strong class="govuk-tag govuk-tag--grey">Withdrawn</strong>',
+        applicationReference: 'MLA/2025/10018',
+        submittedAt: '15 Dec 2025',
+        withdrawnAt: '19 Jan 2026'
+      }
+    )
+
+    const htmlContent = $withdrawn.html()
+
+    expect(htmlContent).toContain('Date withdrawn')
+    expect(htmlContent).toContain('19 Jan 2026')
+    expect(htmlContent).toContain('Withdrawn')
+
+    expect(htmlContent).not.toContain('Date of transfer')
   })
 })

--- a/src/server/common/constants/routes.js
+++ b/src/server/common/constants/routes.js
@@ -65,6 +65,7 @@ export const marineLicenceRoutes = {
   MARINE_LICENCE_PROJECT_NAME: '/marine-licence/project-name',
   MARINE_LICENCE_TASK_LIST: '/marine-licence/task-list',
   MARINE_LICENCE_DELETE: '/marine-licence/delete',
+  MARINE_LICENCE_WITHDRAW: '/marine-licence/withdraw',
   MARINE_LICENCE_SPECIAL_LEGAL_POWERS: '/marine-licence/special-legal-powers',
   MARINE_LICENCE_OTHER_AUTHORITIES: '/marine-licence/other-authorities',
   MARINE_LICENCE_HARBOUR_AUTHORITY: '/marine-licence/harbour-authority',

--- a/src/server/dashboard/utils.js
+++ b/src/server/dashboard/utils.js
@@ -40,11 +40,9 @@ const getViewDetailsRoute = (projectType, status) => {
 }
 
 const getActiveActions = (id, escapedProjectName, viewRoute, withdrawRoute) => {
-  const marginClass = withdrawRoute
-    ? 'govuk-link govuk-!-margin-right-4 '
-    : 'govuk-link '
+  const marginClass = withdrawRoute ? ' govuk-!-margin-right-4' : ''
 
-  let buttons = `<a href="${viewRoute}/${id}" class="${marginClass}govuk-link--no-visited-state" aria-label="View details of ${escapedProjectName}">View details</a>`
+  let buttons = `<a href="${viewRoute}/${id}" class="govuk-link${marginClass} govuk-link--no-visited-state" aria-label="View details of ${escapedProjectName}">View details</a>`
 
   if (withdrawRoute) {
     buttons += `<a href="${withdrawRoute}/${id}" class="govuk-link govuk-link--no-visited-state" aria-label="Withdraw ${escapedProjectName}">Withdraw</a>`
@@ -52,13 +50,13 @@ const getActiveActions = (id, escapedProjectName, viewRoute, withdrawRoute) => {
   return buttons
 }
 
-const getMarineLicenceActions = (
+const getMarineLicenceActions = ({
   id,
   escapedProjectName,
   viewRoute,
   status,
   isOwnProject
-) => {
+}) => {
   if (status === PROJECT_STATUS.DRAFT && isOwnProject) {
     return getDraftActions(id, escapedProjectName, MARINE_LICENCE_KEY)
   }
@@ -90,16 +88,16 @@ export const getActionButtons = (project) => {
   const viewRoute = getViewDetailsRoute(projectType, status)
 
   if (projectType === MARINE_LICENCE_KEY) {
-    return getMarineLicenceActions(
+    return getMarineLicenceActions({
       id,
       escapedProjectName,
       viewRoute,
       status,
-      !!isOwnProject
-    )
+      isOwnProject
+    })
   }
 
-  const canWithdraw = status === PROJECT_STATUS.ACTIVE && !!isOwnProject
+  const canWithdraw = status === PROJECT_STATUS.ACTIVE && isOwnProject
   const withdrawRoute = canWithdraw ? routes.WITHDRAW_EXEMPTION : null
 
   if (isOwnProject) {

--- a/src/server/dashboard/utils.js
+++ b/src/server/dashboard/utils.js
@@ -100,16 +100,12 @@ export const getActionButtons = (project) => {
   }
 
   const canWithdraw = status === PROJECT_STATUS.ACTIVE && !!isOwnProject
+  const withdrawRoute = canWithdraw ? routes.WITHDRAW_EXEMPTION : null
 
   if (isOwnProject) {
     return status === PROJECT_STATUS.DRAFT
       ? getDraftActions(id, escapedProjectName, projectType)
-      : getActiveActions(
-          id,
-          escapedProjectName,
-          viewRoute,
-          canWithdraw ? routes.WITHDRAW_EXEMPTION : null
-        )
+      : getActiveActions(id, escapedProjectName, viewRoute, withdrawRoute)
   }
 
   return project.status === PROJECT_STATUS.DRAFT

--- a/src/server/dashboard/utils.js
+++ b/src/server/dashboard/utils.js
@@ -39,17 +39,38 @@ const getViewDetailsRoute = (projectType, status) => {
     : routes.VIEW_DETAILS
 }
 
-const getActiveActions = (id, escapedProjectName, viewRoute, canWithdraw) => {
-  const marginClass = canWithdraw
+const getActiveActions = (id, escapedProjectName, viewRoute, withdrawRoute) => {
+  const marginClass = withdrawRoute
     ? 'govuk-link govuk-!-margin-right-4 '
     : 'govuk-link '
 
   let buttons = `<a href="${viewRoute}/${id}" class="${marginClass}govuk-link--no-visited-state" aria-label="View details of ${escapedProjectName}">View details</a>`
 
-  if (canWithdraw) {
-    buttons += `<a href="${routes.WITHDRAW_EXEMPTION}/${id}" class="govuk-link govuk-link--no-visited-state" aria-label="Withdraw ${escapedProjectName}">Withdraw</a>`
+  if (withdrawRoute) {
+    buttons += `<a href="${withdrawRoute}/${id}" class="govuk-link govuk-link--no-visited-state" aria-label="Withdraw ${escapedProjectName}">Withdraw</a>`
   }
   return buttons
+}
+
+const getMarineLicenceActions = (
+  id,
+  escapedProjectName,
+  viewRoute,
+  status,
+  isOwnProject
+) => {
+  if (status === PROJECT_STATUS.DRAFT && isOwnProject) {
+    return getDraftActions(id, escapedProjectName, MARINE_LICENCE_KEY)
+  }
+
+  const canWithdraw = status === PROJECT_STATUS.SUBMITTED && isOwnProject
+
+  return getActiveActions(
+    id,
+    escapedProjectName,
+    viewRoute,
+    canWithdraw ? marineLicenceRoutes.MARINE_LICENCE_WITHDRAW : null
+  )
 }
 
 export const sortProjectsByStatus = (projects) => {
@@ -69,9 +90,13 @@ export const getActionButtons = (project) => {
   const viewRoute = getViewDetailsRoute(projectType, status)
 
   if (projectType === MARINE_LICENCE_KEY) {
-    return status === PROJECT_STATUS.DRAFT && isOwnProject
-      ? getDraftActions(id, escapedProjectName, projectType)
-      : getActiveActions(id, escapedProjectName, viewRoute)
+    return getMarineLicenceActions(
+      id,
+      escapedProjectName,
+      viewRoute,
+      status,
+      !!isOwnProject
+    )
   }
 
   const canWithdraw = status === PROJECT_STATUS.ACTIVE && !!isOwnProject
@@ -79,7 +104,12 @@ export const getActionButtons = (project) => {
   if (isOwnProject) {
     return status === PROJECT_STATUS.DRAFT
       ? getDraftActions(id, escapedProjectName, projectType)
-      : getActiveActions(id, escapedProjectName, viewRoute, canWithdraw)
+      : getActiveActions(
+          id,
+          escapedProjectName,
+          viewRoute,
+          canWithdraw ? routes.WITHDRAW_EXEMPTION : null
+        )
   }
 
   return project.status === PROJECT_STATUS.DRAFT

--- a/src/server/dashboard/utils.test.js
+++ b/src/server/dashboard/utils.test.js
@@ -386,7 +386,7 @@ describe('getActionButtons', () => {
     )
   })
 
-  it.each(['Draft', 'Transferred', 'Withdrawn', 'Active'])(
+  it.each(['Transferred', 'Withdrawn', 'Active'])(
     'does not return a Withdraw link for a marine licence with status %s',
     (status) => {
       const result = getActionButtons({

--- a/src/server/dashboard/utils.test.js
+++ b/src/server/dashboard/utils.test.js
@@ -358,6 +358,64 @@ describe('getActionButtons', () => {
     )
   })
 
+  it('returns View details and Withdraw links for a submitted marine licence owned by the user', () => {
+    const submittedMarineLicence = {
+      id: 'ml123',
+      projectName: 'Groyne construction, Bournemouth seafront, Dorset',
+      projectType: 'MARINE_LICENCE',
+      status: 'Submitted',
+      isOwnProject: true
+    }
+    const result = getActionButtons(submittedMarineLicence)
+    expect(result).toBe(
+      `<a href="${marineLicenceRoutes.MARINE_LICENCE_VIEW_DETAILS}/ml123" class="govuk-link govuk-!-margin-right-4 govuk-link--no-visited-state" aria-label="View details of Groyne construction, Bournemouth seafront, Dorset">View details</a><a href="${marineLicenceRoutes.MARINE_LICENCE_WITHDRAW}/ml123" class="govuk-link govuk-link--no-visited-state" aria-label="Withdraw Groyne construction, Bournemouth seafront, Dorset">Withdraw</a>`
+    )
+  })
+
+  it('does not return a Withdraw link for a submitted marine licence owned by another user', () => {
+    const submittedMarineLicence = {
+      id: 'ml123',
+      projectName: 'Marine Licence Project',
+      projectType: 'MARINE_LICENCE',
+      status: 'Submitted',
+      isOwnProject: false
+    }
+    const result = getActionButtons(submittedMarineLicence)
+    expect(result).toBe(
+      `<a href="${marineLicenceRoutes.MARINE_LICENCE_VIEW_DETAILS}/ml123" class="govuk-link govuk-link--no-visited-state" aria-label="View details of Marine Licence Project">View details</a>`
+    )
+  })
+
+  it.each(['Draft', 'Transferred', 'Withdrawn', 'Active'])(
+    'does not return a Withdraw link for a marine licence with status %s',
+    (status) => {
+      const result = getActionButtons({
+        id: 'ml123',
+        projectName: 'Marine Licence Project',
+        projectType: 'MARINE_LICENCE',
+        status,
+        isOwnProject: true
+      })
+
+      expect(result).not.toContain('Withdraw</a>')
+      expect(result).not.toContain(marineLicenceRoutes.MARINE_LICENCE_WITHDRAW)
+    }
+  )
+
+  it('returns only a View details link for a withdrawn marine licence', () => {
+    const withdrawn = {
+      id: 'ml123',
+      projectName: 'Marine Licence Project',
+      projectType: 'MARINE_LICENCE',
+      status: 'Withdrawn',
+      isOwnProject: true
+    }
+    const result = getActionButtons(withdrawn)
+    expect(result).toBe(
+      `<a href="${marineLicenceRoutes.MARINE_LICENCE_VIEW_DETAILS}/ml123" class="govuk-link govuk-link--no-visited-state" aria-label="View details of Marine Licence Project">View details</a>`
+    )
+  })
+
   it('returns transferred page link for transferred marine licence', () => {
     const transferred = {
       id: 'ml123',

--- a/src/server/marine-licence/index.js
+++ b/src/server/marine-licence/index.js
@@ -3,6 +3,7 @@ import { confirmationRoutes } from '#src/server/marine-licence/confirmation/inde
 import { projectNameRoutes } from '#src/server/marine-licence/project-name/index.js'
 import { taskListRoutes } from '#src/server/marine-licence/task-list/index.js'
 import { deleteMarineLicenceRoutes } from '#src/server/marine-licence/delete/index.js'
+import { withdrawMarineLicenceRoutes } from '#src/server/marine-licence/withdraw/index.js'
 import { specialLegalPowersRoutes } from '#src/server/marine-licence/special-legal-powers/index.js'
 import { publicRegisterRoutes } from '#src/server/marine-licence/public-register/index.js'
 import { publicConsultationRoutes } from '#src/server/marine-licence/public-consultation/index.js'
@@ -33,6 +34,7 @@ export const marineLicence = {
         ...projectNameRoutes,
         ...taskListRoutes,
         ...deleteMarineLicenceRoutes,
+        ...withdrawMarineLicenceRoutes,
         ...specialLegalPowersRoutes,
         ...publicRegisterRoutes,
         ...publicConsultationRoutes,

--- a/src/server/marine-licence/view-details/index.njk
+++ b/src/server/marine-licence/view-details/index.njk
@@ -48,7 +48,6 @@
       {% endif %}
       <h1 class="govuk-heading-l" id="view-details-heading">{{ pageTitle }}</h1>
 
-      {% if isTransferred or isWithdrawn %}
       {% if showApplicationDetailsCard %}
         {{ appMarineLicenceApplicationDetailsCard({
           statusTag: statusTag,

--- a/src/server/marine-licence/view-details/index.njk
+++ b/src/server/marine-licence/view-details/index.njk
@@ -32,11 +32,12 @@
       {% endif %}
       <h1 class="govuk-heading-l" id="view-details-heading">{{ pageTitle }}</h1>
 
-      {% if isTransferred %}
+      {% if isTransferred or isWithdrawn %}
         {{ appMarineLicenceApplicationDetailsCard({
           statusTag: statusTag,
           applicationReference: applicationReference,
           transferredDate: transferredDate,
+          withdrawnAt: withdrawnAt,
           submittedAt: submittedAt
         }) }}
       {% endif %}

--- a/src/server/marine-licence/view-details/utils.js
+++ b/src/server/marine-licence/view-details/utils.js
@@ -4,14 +4,21 @@ import { PROJECT_STATUS } from '#src/server/common/constants/projects.js'
 import escapeHtml from 'lodash/escape.js'
 
 export const buildApplicationDetailsCardData = (marineLicence) => {
-  const { applicationReference, status, submittedAt, transferredDate } =
-    marineLicence
+  const {
+    applicationReference,
+    status,
+    submittedAt,
+    transferredDate,
+    withdrawnAt
+  } = marineLicence
 
   return {
     applicationReference,
     submittedAt: formatDate(submittedAt, 'd MMM yyyy'),
     transferredDate: formatDate(transferredDate, 'd MMM yyyy'),
+    withdrawnAt: formatDate(withdrawnAt, 'd MMM yyyy'),
     isTransferred: status === PROJECT_STATUS.TRANSFERRED,
+    isWithdrawn: status === PROJECT_STATUS.WITHDRAWN,
     statusTag: `<strong class="govuk-tag ${getTagStyle(status)}">${escapeHtml(status)}</strong>`
   }
 }

--- a/src/server/marine-licence/view-details/utils.js
+++ b/src/server/marine-licence/view-details/utils.js
@@ -5,38 +5,27 @@ import { getStatusLabelText } from '#src/server/dashboard/utils.js'
 
 const APPLICATION_DATE_FORMAT = 'd MMM yyyy'
 
-const DATE_FORMAT = 'd MMM yyyy'
-
 export const buildApplicationDetailsCardData = (marineLicence) => {
   const {
     applicationReference,
     status,
     submittedAt,
+    rejectedDate,
+    rejectedReasons,
+    rejectedInformation,
     transferredDate,
     withdrawnAt
   } = marineLicence
 
-  return {
-    applicationReference,
-    submittedAt: formatDate(submittedAt, DATE_FORMAT),
-    transferredDate: formatDate(transferredDate, DATE_FORMAT),
-    withdrawnAt: formatDate(withdrawnAt, DATE_FORMAT),
-    isTransferred: status === PROJECT_STATUS.TRANSFERRED,
-    isWithdrawn: status === PROJECT_STATUS.WITHDRAWN,
-    statusTag: `<strong class="govuk-tag ${getTagStyle(status)}">${escapeHtml(status)}</strong>`
-    rejectedDate,
-    rejectedReasons,
-    rejectedInformation,
-    transferredDate
-  } = marineLicence
-
   const isTransferred = status === PROJECT_STATUS.TRANSFERRED
   const isRejected = status === PROJECT_STATUS.REJECTED
+  const isWithdrawn = status === PROJECT_STATUS.WITHDRAWN
 
   return {
     applicationReference,
     submittedAt: formatDate(submittedAt, APPLICATION_DATE_FORMAT),
     transferredDate: formatDate(transferredDate, APPLICATION_DATE_FORMAT),
+    withdrawnAt: formatDate(withdrawnAt, APPLICATION_DATE_FORMAT),
     rejectedDate: formatDate(rejectedDate, APPLICATION_DATE_FORMAT),
     rejectedReasons: rejectedReasons
       ? rejectedReasons.split(',')
@@ -44,7 +33,8 @@ export const buildApplicationDetailsCardData = (marineLicence) => {
     rejectedInformation,
     isTransferred,
     isRejected,
-    showApplicationDetailsCard: isTransferred || isRejected,
+    isWithdrawn,
+    showApplicationDetailsCard: isTransferred || isRejected || isWithdrawn,
     status,
     statusTag: `<strong class="govuk-tag ${getTagStyle(status)}">${getStatusLabelText(status)}</strong>`
   }

--- a/src/server/marine-licence/view-details/utils.js
+++ b/src/server/marine-licence/view-details/utils.js
@@ -3,6 +3,8 @@ import { getTagStyle } from '#src/server/common/helpers/ui/get-tag-style.js'
 import { PROJECT_STATUS } from '#src/server/common/constants/projects.js'
 import escapeHtml from 'lodash/escape.js'
 
+const DATE_FORMAT = 'd MMM yyyy'
+
 export const buildApplicationDetailsCardData = (marineLicence) => {
   const {
     applicationReference,
@@ -14,9 +16,9 @@ export const buildApplicationDetailsCardData = (marineLicence) => {
 
   return {
     applicationReference,
-    submittedAt: formatDate(submittedAt, 'd MMM yyyy'),
-    transferredDate: formatDate(transferredDate, 'd MMM yyyy'),
-    withdrawnAt: formatDate(withdrawnAt, 'd MMM yyyy'),
+    submittedAt: formatDate(submittedAt, DATE_FORMAT),
+    transferredDate: formatDate(transferredDate, DATE_FORMAT),
+    withdrawnAt: formatDate(withdrawnAt, DATE_FORMAT),
     isTransferred: status === PROJECT_STATUS.TRANSFERRED,
     isWithdrawn: status === PROJECT_STATUS.WITHDRAWN,
     statusTag: `<strong class="govuk-tag ${getTagStyle(status)}">${escapeHtml(status)}</strong>`

--- a/src/server/marine-licence/view-details/utils.test.js
+++ b/src/server/marine-licence/view-details/utils.test.js
@@ -28,6 +28,32 @@ describe('#buildApplicationDetailsCardData', () => {
     expect(result.isTransferred).toBe(false)
   })
 
+  test('returns the withdrawal fields when the application is withdrawn', () => {
+    const result = buildApplicationDetailsCardData({
+      applicationReference: 'MLA/2025/10018',
+      status: PROJECT_STATUS.WITHDRAWN,
+      submittedAt: '2025-12-15',
+      withdrawnAt: '2026-01-19'
+    })
+
+    expect(result.isWithdrawn).toBe(true)
+    expect(result.isTransferred).toBe(false)
+    expect(result.submittedAt).toBe('15 Dec 2025')
+    expect(result.withdrawnAt).toBe('19 Jan 2026')
+    expect(result.transferredDate).toBe('')
+    expect(result.statusTag).toContain('govuk-tag--grey')
+    expect(result.statusTag).toContain(PROJECT_STATUS.WITHDRAWN)
+  })
+
+  test('sets isWithdrawn to false when status is not withdrawn', () => {
+    const result = buildApplicationDetailsCardData({
+      status: PROJECT_STATUS.SUBMITTED
+    })
+
+    expect(result.isWithdrawn).toBe(false)
+    expect(result.withdrawnAt).toBe('')
+  })
+
   test('escapes html in the status', () => {
     const marineLicence = { status: '<script>alert(1)</script>' }
 

--- a/src/server/marine-licence/withdraw/controller.js
+++ b/src/server/marine-licence/withdraw/controller.js
@@ -8,13 +8,11 @@ import {
   setMarineLicenceCache,
   clearMarineLicenceCache
 } from '#src/server/common/helpers/marine-licence/session-cache/utils.js'
-import Boom from '@hapi/boom'
 import { MARINE_LICENCE_TYPE } from '#src/server/common/constants/marine-licence.js'
 import { PROJECT_STATUS } from '#src/server/common/constants/projects.js'
 import { getMarineLicenceService } from '#src/services/marine-licence-service/index.js'
 
-export const WITHDRAW_MARINE_LICENCE_VIEW_ROUTE =
-  'marine-licence/withdraw/index'
+const WITHDRAW_MARINE_LICENCE_VIEW_ROUTE = 'marine-licence/withdraw/index'
 
 const WITHDRAW_MARINE_LICENCE_PAGE_TITLE =
   'Are you sure you want to withdraw this application?'
@@ -22,21 +20,32 @@ const WITHDRAW_MARINE_LICENCE_PAGE_TITLE =
 export const TERMS_AND_CONDITIONS_LINK =
   'https://assets.publishing.service.gov.uk/media/6938145b6a12691d48491c56/Terms_and_Conditions_for_carrying_out_chargeable_activities_for_marine_licensing.pdf'
 
-export const withdrawMarineLicenceController = {
+export const withdrawMarineLicenceConfirmController = {
   handler: async (request, h) => {
     const { id: marineLicenceId } = getMarineLicenceCache(request)
 
     if (!marineLicenceId) {
-      throw Boom.notFound('Marine licence not found')
+      request.logger.warn(
+        'No marine licence selected to withdraw, redirecting to dashboard'
+      )
+      return h.redirect(routes.DASHBOARD)
     }
 
     try {
       const service = getMarineLicenceService(request)
       const marineLicence = await service.getMarineLicenceById(marineLicenceId)
 
-      if (marineLicence?.status !== PROJECT_STATUS.SUBMITTED) {
-        request.logger.error(
-          { marineLicenceId, status: marineLicence?.status },
+      if (!marineLicence) {
+        request.logger.warn(
+          { marineLicenceId },
+          'Marine licence to withdraw not found'
+        )
+        return h.redirect(routes.DASHBOARD)
+      }
+
+      if (marineLicence.status !== PROJECT_STATUS.SUBMITTED) {
+        request.logger.warn(
+          { marineLicenceId, status: marineLicence.status },
           'Marine licence cannot be withdrawn'
         )
         return h.redirect(routes.DASHBOARD)
@@ -50,8 +59,7 @@ export const withdrawMarineLicenceController = {
         marineLicenceId,
         termsAndConditionsLink: TERMS_AND_CONDITIONS_LINK,
         backLink: routes.DASHBOARD,
-        cancelLink: routes.DASHBOARD,
-        routes
+        cancelLink: routes.DASHBOARD
       })
     } catch (error) {
       request.logger.error(
@@ -67,7 +75,6 @@ export const withdrawMarineLicenceController = {
 export const withdrawMarineLicenceSelectController = {
   async handler(request, h) {
     const { marineLicenceId } = request.params
-    await clearMarineLicenceCache(request, h)
     await setMarineLicenceCache(request, h, { id: marineLicenceId })
     return h.redirect(marineLicenceRoutes.MARINE_LICENCE_WITHDRAW)
   }
@@ -80,7 +87,7 @@ export const withdrawMarineLicenceSubmitController = {
       const { id: cachedMarineLicenceId } = getMarineLicenceCache(request)
 
       if (!marineLicenceId || marineLicenceId !== cachedMarineLicenceId) {
-        request.logger.error(
+        request.logger.warn(
           {
             formMarineLicenceId: marineLicenceId,
             cachedMarineLicenceId

--- a/src/server/marine-licence/withdraw/controller.js
+++ b/src/server/marine-licence/withdraw/controller.js
@@ -1,0 +1,112 @@
+import { authenticatedPostRequest } from '#src/server/common/helpers/authenticated-requests.js'
+import {
+  routes,
+  marineLicenceRoutes
+} from '#src/server/common/constants/routes.js'
+import {
+  getMarineLicenceCache,
+  setMarineLicenceCache,
+  clearMarineLicenceCache
+} from '#src/server/common/helpers/marine-licence/session-cache/utils.js'
+import Boom from '@hapi/boom'
+import { MARINE_LICENCE_TYPE } from '#src/server/common/constants/marine-licence.js'
+import { PROJECT_STATUS } from '#src/server/common/constants/projects.js'
+import { getMarineLicenceService } from '#src/services/marine-licence-service/index.js'
+
+export const WITHDRAW_MARINE_LICENCE_VIEW_ROUTE =
+  'marine-licence/withdraw/index'
+
+const WITHDRAW_MARINE_LICENCE_PAGE_TITLE =
+  'Are you sure you want to withdraw this application?'
+
+export const TERMS_AND_CONDITIONS_LINK =
+  'https://assets.publishing.service.gov.uk/media/6938145b6a12691d48491c56/Terms_and_Conditions_for_carrying_out_chargeable_activities_for_marine_licensing.pdf'
+
+export const withdrawMarineLicenceController = {
+  handler: async (request, h) => {
+    const { id: marineLicenceId } = getMarineLicenceCache(request)
+
+    if (!marineLicenceId) {
+      throw Boom.notFound('Marine licence not found')
+    }
+
+    try {
+      const service = getMarineLicenceService(request)
+      const marineLicence = await service.getMarineLicenceById(marineLicenceId)
+
+      if (!marineLicence || marineLicence.status !== PROJECT_STATUS.SUBMITTED) {
+        request.logger.error(
+          { marineLicenceId, status: marineLicence?.status },
+          'Marine licence cannot be withdrawn'
+        )
+        return h.redirect(routes.DASHBOARD)
+      }
+
+      return h.view(WITHDRAW_MARINE_LICENCE_VIEW_ROUTE, {
+        pageTitle: WITHDRAW_MARINE_LICENCE_PAGE_TITLE,
+        heading: WITHDRAW_MARINE_LICENCE_PAGE_TITLE,
+        projectName: marineLicence.projectName,
+        marineLicenceType: MARINE_LICENCE_TYPE,
+        marineLicenceId,
+        termsAndConditionsLink: TERMS_AND_CONDITIONS_LINK,
+        backLink: routes.DASHBOARD,
+        cancelLink: routes.DASHBOARD,
+        routes
+      })
+    } catch (error) {
+      request.logger.error(
+        { err: error },
+        'Error fetching project for withdraw'
+      )
+
+      return h.redirect(routes.DASHBOARD)
+    }
+  }
+}
+
+export const withdrawMarineLicenceSelectController = {
+  async handler(request, h) {
+    const { marineLicenceId } = request.params
+    await clearMarineLicenceCache(request, h)
+    await setMarineLicenceCache(request, h, { id: marineLicenceId })
+    return h.redirect(marineLicenceRoutes.MARINE_LICENCE_WITHDRAW)
+  }
+}
+
+export const withdrawMarineLicenceSubmitController = {
+  handler: async (request, h) => {
+    try {
+      const { marineLicenceId } = request.payload
+      const { id: cachedMarineLicenceId } = getMarineLicenceCache(request)
+
+      if (!marineLicenceId || marineLicenceId !== cachedMarineLicenceId) {
+        request.logger.error(
+          {
+            formMarineLicenceId: marineLicenceId,
+            cachedMarineLicenceId
+          },
+          'Marine licence ID mismatch or missing'
+        )
+        return h.redirect(routes.DASHBOARD)
+      }
+
+      await authenticatedPostRequest(
+        request,
+        `/marine-licence/${marineLicenceId}/withdraw`,
+        {}
+      )
+
+      request.logger.info(
+        { marineLicenceId },
+        `Withdrawn marine licence ${marineLicenceId}`
+      )
+
+      await clearMarineLicenceCache(request, h)
+
+      return h.redirect(routes.DASHBOARD)
+    } catch (error) {
+      request.logger.error({ err: error }, 'Error withdrawing marine licence')
+      return h.redirect(routes.DASHBOARD)
+    }
+  }
+}

--- a/src/server/marine-licence/withdraw/controller.js
+++ b/src/server/marine-licence/withdraw/controller.js
@@ -34,7 +34,7 @@ export const withdrawMarineLicenceController = {
       const service = getMarineLicenceService(request)
       const marineLicence = await service.getMarineLicenceById(marineLicenceId)
 
-      if (!marineLicence || marineLicence.status !== PROJECT_STATUS.SUBMITTED) {
+      if (marineLicence?.status !== PROJECT_STATUS.SUBMITTED) {
         request.logger.error(
           { marineLicenceId, status: marineLicence?.status },
           'Marine licence cannot be withdrawn'

--- a/src/server/marine-licence/withdraw/controller.test.js
+++ b/src/server/marine-licence/withdraw/controller.test.js
@@ -1,0 +1,236 @@
+import { vi } from 'vitest'
+
+import { authenticatedPostRequest } from '#src/server/common/helpers/authenticated-requests.js'
+import {
+  getMarineLicenceCache,
+  setMarineLicenceCache,
+  clearMarineLicenceCache
+} from '#src/server/common/helpers/marine-licence/session-cache/utils.js'
+import {
+  routes,
+  marineLicenceRoutes
+} from '#src/server/common/constants/routes.js'
+import { MARINE_LICENCE_TYPE } from '#src/server/common/constants/marine-licence.js'
+import { PROJECT_STATUS } from '#src/server/common/constants/projects.js'
+import * as marineLicenceServiceModule from '#src/services/marine-licence-service/index.js'
+
+import {
+  withdrawMarineLicenceController,
+  withdrawMarineLicenceSelectController,
+  withdrawMarineLicenceSubmitController,
+  TERMS_AND_CONDITIONS_LINK
+} from './controller.js'
+
+vi.mock('~/src/server/common/helpers/authenticated-requests.js')
+vi.mock('~/src/server/common/helpers/marine-licence/session-cache/utils.js')
+
+describe('#withdrawMarineLicence', () => {
+  let mockRequest
+  let mockH
+  let mockGetMarineLicenceById
+
+  const mockedAuthenticatedPostRequest = vi.mocked(authenticatedPostRequest)
+  const mockedGetMarineLicenceCache = vi.mocked(getMarineLicenceCache)
+  const mockedSetMarineLicenceCache = vi.mocked(setMarineLicenceCache)
+  const mockedClearMarineLicenceCache = vi.mocked(clearMarineLicenceCache)
+
+  const marineLicenceId = 'test-project-id'
+
+  const submittedMarineLicence = {
+    id: marineLicenceId,
+    projectName: 'Worthing pier repairs',
+    status: PROJECT_STATUS.SUBMITTED
+  }
+
+  beforeEach(() => {
+    mockRequest = {
+      logger: { error: vi.fn(), info: vi.fn() },
+      state: {}
+    }
+
+    mockH = {
+      view: vi.fn().mockReturnValue('view-response'),
+      redirect: vi.fn().mockReturnValue('redirect-response')
+    }
+
+    mockGetMarineLicenceById = vi.fn()
+    vi.spyOn(
+      marineLicenceServiceModule,
+      'getMarineLicenceService'
+    ).mockReturnValue({ getMarineLicenceById: mockGetMarineLicenceById })
+  })
+
+  describe('withdrawMarineLicenceController', () => {
+    it('should render the withdraw confirmation page with project details', async () => {
+      mockedGetMarineLicenceCache.mockReturnValue({ id: marineLicenceId })
+      mockGetMarineLicenceById.mockResolvedValue(submittedMarineLicence)
+
+      const result = await withdrawMarineLicenceController.handler(
+        mockRequest,
+        mockH
+      )
+
+      expect(mockGetMarineLicenceById).toHaveBeenCalledWith(marineLicenceId)
+      expect(mockH.view).toHaveBeenCalledWith('marine-licence/withdraw/index', {
+        pageTitle: 'Are you sure you want to withdraw this application?',
+        heading: 'Are you sure you want to withdraw this application?',
+        projectName: 'Worthing pier repairs',
+        marineLicenceType: MARINE_LICENCE_TYPE,
+        marineLicenceId,
+        termsAndConditionsLink: TERMS_AND_CONDITIONS_LINK,
+        backLink: routes.DASHBOARD,
+        cancelLink: routes.DASHBOARD,
+        routes
+      })
+      expect(result).toBe('view-response')
+    })
+
+    it('should throw 404 if marine licence is not found in cache', async () => {
+      mockedGetMarineLicenceCache.mockReturnValue({ id: undefined })
+
+      await expect(
+        withdrawMarineLicenceController.handler(mockRequest, mockH)
+      ).rejects.toThrow('Marine licence not found')
+    })
+
+    it.each([
+      PROJECT_STATUS.DRAFT,
+      PROJECT_STATUS.TRANSFERRED,
+      PROJECT_STATUS.WITHDRAWN
+    ])('should redirect to dashboard when status is %s', async (status) => {
+      mockedGetMarineLicenceCache.mockReturnValue({ id: marineLicenceId })
+      mockGetMarineLicenceById.mockResolvedValue({
+        ...submittedMarineLicence,
+        status
+      })
+
+      const result = await withdrawMarineLicenceController.handler(
+        mockRequest,
+        mockH
+      )
+
+      expect(mockH.view).not.toHaveBeenCalled()
+      expect(mockH.redirect).toHaveBeenCalledWith(routes.DASHBOARD)
+      expect(result).toBe('redirect-response')
+    })
+
+    it('should redirect to dashboard if the project is not found', async () => {
+      mockedGetMarineLicenceCache.mockReturnValue({ id: marineLicenceId })
+      mockGetMarineLicenceById.mockResolvedValue(null)
+
+      const result = await withdrawMarineLicenceController.handler(
+        mockRequest,
+        mockH
+      )
+
+      expect(mockH.redirect).toHaveBeenCalledWith(routes.DASHBOARD)
+      expect(result).toBe('redirect-response')
+    })
+
+    it('should redirect to dashboard if the API call fails', async () => {
+      mockedGetMarineLicenceCache.mockReturnValue({ id: marineLicenceId })
+      mockGetMarineLicenceById.mockRejectedValue(new Error('API Error'))
+
+      const result = await withdrawMarineLicenceController.handler(
+        mockRequest,
+        mockH
+      )
+
+      expect(mockRequest.logger.error).toHaveBeenCalled()
+      expect(mockH.redirect).toHaveBeenCalledWith(routes.DASHBOARD)
+      expect(result).toBe('redirect-response')
+    })
+  })
+
+  describe('withdrawMarineLicenceSelectController', () => {
+    it('should clear cache, set marine licence ID in cache, and redirect to withdraw page', async () => {
+      mockRequest.params = { marineLicenceId }
+
+      const result = await withdrawMarineLicenceSelectController.handler(
+        mockRequest,
+        mockH
+      )
+
+      expect(mockedClearMarineLicenceCache).toHaveBeenCalledWith(
+        mockRequest,
+        mockH
+      )
+      expect(mockedSetMarineLicenceCache).toHaveBeenCalledWith(
+        mockRequest,
+        mockH,
+        { id: marineLicenceId }
+      )
+      expect(mockH.redirect).toHaveBeenCalledWith(
+        marineLicenceRoutes.MARINE_LICENCE_WITHDRAW
+      )
+      expect(result).toBe('redirect-response')
+    })
+  })
+
+  describe('withdrawMarineLicenceSubmitController', () => {
+    it('should withdraw the marine licence and redirect to dashboard when IDs match', async () => {
+      mockRequest.payload = { marineLicenceId }
+      mockedGetMarineLicenceCache.mockReturnValue({ id: marineLicenceId })
+
+      const result = await withdrawMarineLicenceSubmitController.handler(
+        mockRequest,
+        mockH
+      )
+
+      expect(mockedAuthenticatedPostRequest).toHaveBeenCalledWith(
+        mockRequest,
+        `/marine-licence/${marineLicenceId}/withdraw`,
+        {}
+      )
+      expect(mockedClearMarineLicenceCache).toHaveBeenCalledWith(
+        mockRequest,
+        mockH
+      )
+      expect(mockH.redirect).toHaveBeenCalledWith(routes.DASHBOARD)
+      expect(result).toBe('redirect-response')
+    })
+
+    it('should redirect to dashboard when marine licence ID is missing', async () => {
+      mockRequest.payload = {}
+      mockedGetMarineLicenceCache.mockReturnValue({ id: marineLicenceId })
+
+      const result = await withdrawMarineLicenceSubmitController.handler(
+        mockRequest,
+        mockH
+      )
+
+      expect(mockedAuthenticatedPostRequest).not.toHaveBeenCalled()
+      expect(mockH.redirect).toHaveBeenCalledWith(routes.DASHBOARD)
+      expect(result).toBe('redirect-response')
+    })
+
+    it('should redirect to dashboard when marine licence IDs do not match', async () => {
+      mockRequest.payload = { marineLicenceId: 'different-id' }
+      mockedGetMarineLicenceCache.mockReturnValue({ id: marineLicenceId })
+
+      const result = await withdrawMarineLicenceSubmitController.handler(
+        mockRequest,
+        mockH
+      )
+
+      expect(mockedAuthenticatedPostRequest).not.toHaveBeenCalled()
+      expect(mockH.redirect).toHaveBeenCalledWith(routes.DASHBOARD)
+      expect(result).toBe('redirect-response')
+    })
+
+    it('should redirect to dashboard when an exception occurs', async () => {
+      mockRequest.payload = { marineLicenceId }
+      mockedGetMarineLicenceCache.mockReturnValue({ id: marineLicenceId })
+      mockedAuthenticatedPostRequest.mockRejectedValue(new Error('Test error'))
+
+      const result = await withdrawMarineLicenceSubmitController.handler(
+        mockRequest,
+        mockH
+      )
+
+      expect(mockRequest.logger.error).toHaveBeenCalled()
+      expect(mockH.redirect).toHaveBeenCalledWith(routes.DASHBOARD)
+      expect(result).toBe('redirect-response')
+    })
+  })
+})

--- a/src/server/marine-licence/withdraw/controller.test.js
+++ b/src/server/marine-licence/withdraw/controller.test.js
@@ -3,26 +3,21 @@ import { vi } from 'vitest'
 import { authenticatedPostRequest } from '#src/server/common/helpers/authenticated-requests.js'
 import {
   getMarineLicenceCache,
-  setMarineLicenceCache,
   clearMarineLicenceCache
 } from '#src/server/common/helpers/marine-licence/session-cache/utils.js'
-import {
-  routes,
-  marineLicenceRoutes
-} from '#src/server/common/constants/routes.js'
+import { routes } from '#src/server/common/constants/routes.js'
 import { MARINE_LICENCE_TYPE } from '#src/server/common/constants/marine-licence.js'
 import { PROJECT_STATUS } from '#src/server/common/constants/projects.js'
 import * as marineLicenceServiceModule from '#src/services/marine-licence-service/index.js'
 
 import {
-  withdrawMarineLicenceController,
-  withdrawMarineLicenceSelectController,
+  withdrawMarineLicenceConfirmController,
   withdrawMarineLicenceSubmitController,
   TERMS_AND_CONDITIONS_LINK
 } from './controller.js'
 
-vi.mock('~/src/server/common/helpers/authenticated-requests.js')
-vi.mock('~/src/server/common/helpers/marine-licence/session-cache/utils.js')
+vi.mock('#src/server/common/helpers/authenticated-requests.js')
+vi.mock('#src/server/common/helpers/marine-licence/session-cache/utils.js')
 
 describe('#withdrawMarineLicence', () => {
   let mockRequest
@@ -31,7 +26,6 @@ describe('#withdrawMarineLicence', () => {
 
   const mockedAuthenticatedPostRequest = vi.mocked(authenticatedPostRequest)
   const mockedGetMarineLicenceCache = vi.mocked(getMarineLicenceCache)
-  const mockedSetMarineLicenceCache = vi.mocked(setMarineLicenceCache)
   const mockedClearMarineLicenceCache = vi.mocked(clearMarineLicenceCache)
 
   const marineLicenceId = 'test-project-id'
@@ -44,7 +38,7 @@ describe('#withdrawMarineLicence', () => {
 
   beforeEach(() => {
     mockRequest = {
-      logger: { error: vi.fn(), info: vi.fn() },
+      logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
       state: {}
     }
 
@@ -60,12 +54,12 @@ describe('#withdrawMarineLicence', () => {
     ).mockReturnValue({ getMarineLicenceById: mockGetMarineLicenceById })
   })
 
-  describe('withdrawMarineLicenceController', () => {
+  describe('withdrawMarineLicenceConfirmController', () => {
     it('should render the withdraw confirmation page with project details', async () => {
       mockedGetMarineLicenceCache.mockReturnValue({ id: marineLicenceId })
       mockGetMarineLicenceById.mockResolvedValue(submittedMarineLicence)
 
-      const result = await withdrawMarineLicenceController.handler(
+      const result = await withdrawMarineLicenceConfirmController.handler(
         mockRequest,
         mockH
       )
@@ -79,18 +73,23 @@ describe('#withdrawMarineLicence', () => {
         marineLicenceId,
         termsAndConditionsLink: TERMS_AND_CONDITIONS_LINK,
         backLink: routes.DASHBOARD,
-        cancelLink: routes.DASHBOARD,
-        routes
+        cancelLink: routes.DASHBOARD
       })
       expect(result).toBe('view-response')
     })
 
-    it('should throw 404 if marine licence is not found in cache', async () => {
+    it('should redirect to dashboard if no marine licence is selected in the cache', async () => {
       mockedGetMarineLicenceCache.mockReturnValue({ id: undefined })
 
-      await expect(
-        withdrawMarineLicenceController.handler(mockRequest, mockH)
-      ).rejects.toThrow('Marine licence not found')
+      const result = await withdrawMarineLicenceConfirmController.handler(
+        mockRequest,
+        mockH
+      )
+
+      expect(mockGetMarineLicenceById).not.toHaveBeenCalled()
+      expect(mockH.view).not.toHaveBeenCalled()
+      expect(mockH.redirect).toHaveBeenCalledWith(routes.DASHBOARD)
+      expect(result).toBe('redirect-response')
     })
 
     it.each([
@@ -104,7 +103,7 @@ describe('#withdrawMarineLicence', () => {
         status
       })
 
-      const result = await withdrawMarineLicenceController.handler(
+      const result = await withdrawMarineLicenceConfirmController.handler(
         mockRequest,
         mockH
       )
@@ -118,7 +117,7 @@ describe('#withdrawMarineLicence', () => {
       mockedGetMarineLicenceCache.mockReturnValue({ id: marineLicenceId })
       mockGetMarineLicenceById.mockResolvedValue(null)
 
-      const result = await withdrawMarineLicenceController.handler(
+      const result = await withdrawMarineLicenceConfirmController.handler(
         mockRequest,
         mockH
       )
@@ -131,38 +130,13 @@ describe('#withdrawMarineLicence', () => {
       mockedGetMarineLicenceCache.mockReturnValue({ id: marineLicenceId })
       mockGetMarineLicenceById.mockRejectedValue(new Error('API Error'))
 
-      const result = await withdrawMarineLicenceController.handler(
+      const result = await withdrawMarineLicenceConfirmController.handler(
         mockRequest,
         mockH
       )
 
       expect(mockRequest.logger.error).toHaveBeenCalled()
       expect(mockH.redirect).toHaveBeenCalledWith(routes.DASHBOARD)
-      expect(result).toBe('redirect-response')
-    })
-  })
-
-  describe('withdrawMarineLicenceSelectController', () => {
-    it('should clear cache, set marine licence ID in cache, and redirect to withdraw page', async () => {
-      mockRequest.params = { marineLicenceId }
-
-      const result = await withdrawMarineLicenceSelectController.handler(
-        mockRequest,
-        mockH
-      )
-
-      expect(mockedClearMarineLicenceCache).toHaveBeenCalledWith(
-        mockRequest,
-        mockH
-      )
-      expect(mockedSetMarineLicenceCache).toHaveBeenCalledWith(
-        mockRequest,
-        mockH,
-        { id: marineLicenceId }
-      )
-      expect(mockH.redirect).toHaveBeenCalledWith(
-        marineLicenceRoutes.MARINE_LICENCE_WITHDRAW
-      )
       expect(result).toBe('redirect-response')
     })
   })

--- a/src/server/marine-licence/withdraw/index.js
+++ b/src/server/marine-licence/withdraw/index.js
@@ -1,0 +1,24 @@
+import {
+  withdrawMarineLicenceController,
+  withdrawMarineLicenceSelectController,
+  withdrawMarineLicenceSubmitController
+} from '#src/server/marine-licence/withdraw/controller.js'
+import { marineLicenceRoutes } from '#src/server/common/constants/routes.js'
+
+export const withdrawMarineLicenceRoutes = [
+  {
+    method: 'GET',
+    path: marineLicenceRoutes.MARINE_LICENCE_WITHDRAW,
+    ...withdrawMarineLicenceController
+  },
+  {
+    method: 'GET',
+    path: `${marineLicenceRoutes.MARINE_LICENCE_WITHDRAW}/{marineLicenceId}`,
+    ...withdrawMarineLicenceSelectController
+  },
+  {
+    method: 'POST',
+    path: marineLicenceRoutes.MARINE_LICENCE_WITHDRAW,
+    ...withdrawMarineLicenceSubmitController
+  }
+]

--- a/src/server/marine-licence/withdraw/index.js
+++ b/src/server/marine-licence/withdraw/index.js
@@ -1,5 +1,5 @@
 import {
-  withdrawMarineLicenceController,
+  withdrawMarineLicenceConfirmController,
   withdrawMarineLicenceSelectController,
   withdrawMarineLicenceSubmitController
 } from '#src/server/marine-licence/withdraw/controller.js'
@@ -9,7 +9,7 @@ export const withdrawMarineLicenceRoutes = [
   {
     method: 'GET',
     path: marineLicenceRoutes.MARINE_LICENCE_WITHDRAW,
-    ...withdrawMarineLicenceController
+    ...withdrawMarineLicenceConfirmController
   },
   {
     method: 'GET',

--- a/src/server/marine-licence/withdraw/index.njk
+++ b/src/server/marine-licence/withdraw/index.njk
@@ -1,0 +1,58 @@
+{% extends 'layouts/page.njk' %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "cancel-button/macro.njk" import appCancelButton %}
+
+{% block beforeContent %}
+  {{ super() }}
+  <nav>
+    {{ govukBackLink({
+      text: "Back",
+      href: backLink
+    }) }}
+  </nav>
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">Are you sure you want to withdraw this application?</h1>
+
+      {{ govukInsetText({
+        text: marineLicenceType + ": " + projectName
+      }) }}
+
+      <p class="govuk-body">
+        If you withdraw this marine licence application, we will not progress it any further. You must not carry out the proposed works unless a valid marine licence is in place.
+      </p>
+
+      <p class="govuk-body govuk-!-margin-bottom-6">
+        We will charge you for the time spent processing your application up to the date of withdrawal, in accordance with our <a href="{{ termsAndConditionsLink }}" class="govuk-link" target="_blank" rel="noreferrer noopener">terms and conditions (opens in new tab)</a>.
+      </p>
+
+      <form method="POST">
+        <input type="hidden" name="csrfToken" value="{{csrfToken}}">
+        <input type="hidden" name="marineLicenceId" value="{{ marineLicenceId }}">
+
+        <div class="govuk-button-group">
+          {{ govukButton({
+            text: "Yes, withdraw application",
+            classes: "govuk-button--warning",
+            type: "submit",
+            preventDoubleClick: true,
+            attributes: {
+              "data-module": "govuk-button"
+            }
+          }) }}
+
+          {{ appCancelButton({
+            cancelLink: cancelLink
+          }) }}
+        </div>
+      </form>
+
+    </div>
+  </div>
+{% endblock %}

--- a/src/server/marine-licence/withdraw/index.njk
+++ b/src/server/marine-licence/withdraw/index.njk
@@ -18,7 +18,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      <h1 class="govuk-heading-l">Are you sure you want to withdraw this application?</h1>
+      <h1 class="govuk-heading-l">{{ heading }}</h1>
 
       {{ govukInsetText({
         text: marineLicenceType + ": " + projectName

--- a/src/server/marine-licence/withdraw/index.test.js
+++ b/src/server/marine-licence/withdraw/index.test.js
@@ -1,0 +1,20 @@
+import { withdrawMarineLicenceRoutes } from '#src/server/marine-licence/withdraw/index.js'
+
+describe('withdrawMarineLicence routes', () => {
+  test('routes are formatted correctly', () => {
+    expect(withdrawMarineLicenceRoutes).toEqual([
+      expect.objectContaining({
+        method: 'GET',
+        path: '/marine-licence/withdraw'
+      }),
+      expect.objectContaining({
+        method: 'GET',
+        path: '/marine-licence/withdraw/{marineLicenceId}'
+      }),
+      expect.objectContaining({
+        method: 'POST',
+        path: '/marine-licence/withdraw'
+      })
+    ])
+  })
+})

--- a/src/server/test-helpers/mocks/marine-licence-mocks.js
+++ b/src/server/test-helpers/mocks/marine-licence-mocks.js
@@ -175,6 +175,13 @@ export const mockTransferredMarineLicenceApplication = {
   transferredDate: '2026-06-26T10:00:00Z'
 }
 
+export const mockWithdrawnMarineLicenceApplication = {
+  ...mockSubmittedMarineLicenceApplication,
+  status: PROJECT_STATUS.WITHDRAWN,
+  submittedAt: '2026-05-26T10:00:00Z',
+  withdrawnAt: '2026-06-26T10:00:00Z'
+}
+
 export const mockMarineLicenceWithMarinePlanPolicies = {
   ...mockMarineLicenceApplication,
   marinePlanPolicyJob: 'ready',

--- a/src/server/test-helpers/mocks/marine-licence-mocks.js
+++ b/src/server/test-helpers/mocks/marine-licence-mocks.js
@@ -180,6 +180,8 @@ export const mockWithdrawnMarineLicenceApplication = {
   status: PROJECT_STATUS.WITHDRAWN,
   submittedAt: '2026-05-26T10:00:00Z',
   withdrawnAt: '2026-06-26T10:00:00Z'
+}
+
 export const mockRejectedMarineLicenceApplication = {
   ...mockSubmittedMarineLicenceApplication,
   status: PROJECT_STATUS.REJECTED,

--- a/tests/integration/accessibility/marine-licence-page-accessibility.test.js
+++ b/tests/integration/accessibility/marine-licence-page-accessibility.test.js
@@ -5,7 +5,8 @@ import {
   mockManualCoordinatesMarineLicence,
   mockMarineLicenceApplication,
   mockMarineLicenceWithMarinePlanPolicies,
-  mockSubmittedMarineLicenceApplication
+  mockSubmittedMarineLicenceApplication,
+  mockWithdrawnMarineLicenceApplication
 } from '~/src/server/test-helpers/mocks/marine-licence-mocks.js'
 import {
   mockMarineLicence,
@@ -238,6 +239,16 @@ const marineLicencePages = [
   {
     url: marineLicenceRoutes.MARINE_LICENCE_DELETE,
     title: 'Are you sure you want to delete this project?'
+  },
+  {
+    url: marineLicenceRoutes.MARINE_LICENCE_WITHDRAW,
+    title: 'Are you sure you want to withdraw this application?',
+    marineLicence: mockSubmittedMarineLicenceApplication
+  },
+  {
+    url: `${marineLicenceRoutes.MARINE_LICENCE_VIEW_DETAILS}/${mockWithdrawnMarineLicenceApplication.id}`,
+    title: mockWithdrawnMarineLicenceApplication.projectName,
+    marineLicence: mockWithdrawnMarineLicenceApplication
   },
   {
     url: `${marineLicenceRoutes.MARINE_LICENCE_VIEW_DETAILS}/${mockSubmittedMarineLicenceApplication.id}`,

--- a/tests/integration/accessibility/marine-licence-page-accessibility.test.js
+++ b/tests/integration/accessibility/marine-licence-page-accessibility.test.js
@@ -6,7 +6,7 @@ import {
   mockMarineLicenceApplication,
   mockMarineLicenceWithMarinePlanPolicies,
   mockSubmittedMarineLicenceApplication,
-  mockWithdrawnMarineLicenceApplication
+  mockWithdrawnMarineLicenceApplication,
   mockTransferredMarineLicenceApplication,
   mockRejectedMarineLicenceApplication
 } from '~/src/server/test-helpers/mocks/marine-licence-mocks.js'

--- a/tests/integration/dashboard/dashboard.test.js
+++ b/tests/integration/dashboard/dashboard.test.js
@@ -126,6 +126,65 @@ describe('Dashboard', () => {
       'href',
       `/marine-licence/view-details/${mockMarineLicenceApplication.id}`
     )
+    expect(
+      getByRole(actionsCell, 'link', { name: 'Withdraw Test Project' })
+    ).toHaveAttribute(
+      'href',
+      `/marine-licence/withdraw/${mockMarineLicenceApplication.id}`
+    )
+  })
+
+  it('should not offer Withdraw for a submitted marine licence owned by another user', async () => {
+    mockMarineLicence([{ ...marineLicences[0], isOwnProject: false }])
+    const doc = await loadDashboardPage()
+
+    const cells = getProjectsTableRow({
+      document: doc,
+      name: mockMarineLicenceApplication.projectName
+    })
+    const actionsCell = cells.pop()
+
+    expect(
+      getByRole(actionsCell, 'link', { name: 'View details of Test Project' })
+    ).toBeInTheDocument()
+    expect(
+      queryByRole(actionsCell, 'link', { name: 'Withdraw Test Project' })
+    ).not.toBeInTheDocument()
+  })
+
+  it('should render a withdrawn marine licence with View details only', async () => {
+    mockMarineLicence([
+      {
+        ...marineLicences[0],
+        status: 'Withdrawn',
+        applicationReference: 'MLA/2025/10018'
+      }
+    ])
+    const doc = await loadDashboardPage()
+
+    const cells = getProjectsTableRow({
+      document: doc,
+      name: mockMarineLicenceApplication.projectName
+    })
+    const actionsCell = cells.pop()
+    const cellContents = cells.map((cell) => cell.textContent.trim())
+    expect(cellContents).toEqual([
+      'Test Project',
+      'Marine licence application',
+      'MLA/2025/10018',
+      'Withdrawn',
+      '23 Oct 2025'
+    ])
+
+    expect(
+      getByRole(actionsCell, 'link', { name: 'View details of Test Project' })
+    ).toHaveAttribute(
+      'href',
+      `/marine-licence/view-details/${mockMarineLicenceApplication.id}`
+    )
+    expect(
+      queryByRole(actionsCell, 'link', { name: 'Withdraw Test Project' })
+    ).not.toBeInTheDocument()
   })
 
   it('should render a message if there are no projects', async () => {

--- a/tests/integration/marine-licence/withdraw.test.js
+++ b/tests/integration/marine-licence/withdraw.test.js
@@ -1,0 +1,139 @@
+import { vi } from 'vitest'
+import {
+  mockMarineLicence,
+  setupTestServer
+} from '~/tests/integration/shared/test-setup-helpers.js'
+import { loadPage } from '~/tests/integration/shared/app-server.js'
+import { within } from '@testing-library/dom'
+import {
+  marineLicenceRoutes,
+  routes
+} from '#src/server/common/constants/routes.js'
+import { PROJECT_STATUS } from '#src/server/common/constants/projects.js'
+import {
+  makeGetRequest,
+  makePostRequest
+} from '#src/server/test-helpers/server-requests.js'
+import { authenticatedPostRequest } from '#src/server/common/helpers/authenticated-requests.js'
+import { TERMS_AND_CONDITIONS_LINK } from '#src/server/marine-licence/withdraw/controller.js'
+
+vi.mock('#src/server/common/helpers/authenticated-requests.js')
+
+const marineLicenceId = '68b1b8f4c1a2b3d4e5f60001'
+
+const submittedMarineLicence = {
+  id: marineLicenceId,
+  projectName: 'Groyne construction, Bournemouth seafront, Dorset',
+  applicationReference: 'MLA/2025/10018',
+  status: PROJECT_STATUS.SUBMITTED
+}
+
+describe('Withdraw marine licence application', () => {
+  const getServer = setupTestServer()
+
+  beforeEach(() => {
+    mockMarineLicence(submittedMarineLicence)
+  })
+
+  describe('confirmation page', () => {
+    test('should display the withdraw confirmation page', async () => {
+      const document = await loadPage({
+        requestUrl: marineLicenceRoutes.MARINE_LICENCE_WITHDRAW,
+        server: getServer()
+      })
+
+      const pageHeading = within(document).getByRole('heading', {
+        level: 1,
+        name: 'Are you sure you want to withdraw this application?'
+      })
+      expect(pageHeading).toBeInTheDocument()
+
+      const inset = document.querySelector('.govuk-inset-text')
+      expect(inset).toHaveTextContent(
+        'Marine licence application: Groyne construction, Bournemouth seafront, Dorset'
+      )
+
+      expect(
+        within(document).getByText(
+          /we will not progress it any further. You must not carry out the proposed works unless a valid marine licence is in place/
+        )
+      ).toBeInTheDocument()
+
+      const termsLink = within(document).getByRole('link', {
+        name: 'terms and conditions (opens in new tab)'
+      })
+      expect(termsLink).toHaveAttribute('href', TERMS_AND_CONDITIONS_LINK)
+      expect(termsLink).toHaveAttribute('target', '_blank')
+
+      within(document).getByRole('button', {
+        name: 'Yes, withdraw application'
+      })
+
+      const backLink = within(document).getByRole('link', { name: 'Back' })
+      expect(backLink).toHaveAttribute('href', routes.DASHBOARD)
+
+      const cancelLink = within(document).getByRole('link', { name: 'Cancel' })
+      expect(cancelLink).toHaveAttribute('href', routes.DASHBOARD)
+    })
+
+    test('should redirect to the withdraw page when selecting an application to withdraw', async () => {
+      const response = await makeGetRequest({
+        url: `${marineLicenceRoutes.MARINE_LICENCE_WITHDRAW}/${marineLicenceId}`,
+        server: getServer()
+      })
+
+      expect(response.statusCode).toBe(302)
+      expect(response.headers.location).toBe(
+        marineLicenceRoutes.MARINE_LICENCE_WITHDRAW
+      )
+    })
+
+    test('should withdraw the application and redirect to the dashboard', async () => {
+      const response = await makePostRequest({
+        url: marineLicenceRoutes.MARINE_LICENCE_WITHDRAW,
+        server: getServer(),
+        formData: { marineLicenceId }
+      })
+
+      expect(vi.mocked(authenticatedPostRequest)).toHaveBeenCalledWith(
+        expect.anything(),
+        `/marine-licence/${marineLicenceId}/withdraw`,
+        {}
+      )
+      expect(response.statusCode).toBe(302)
+      expect(response.headers.location).toBe(routes.DASHBOARD)
+    })
+
+    test('should not call the API when the submitted id does not match the cached one', async () => {
+      vi.mocked(authenticatedPostRequest).mockClear()
+
+      const response = await makePostRequest({
+        url: marineLicenceRoutes.MARINE_LICENCE_WITHDRAW,
+        server: getServer(),
+        formData: { marineLicenceId: '68b1b8f4c1a2b3d4e5f60002' }
+      })
+
+      expect(vi.mocked(authenticatedPostRequest)).not.toHaveBeenCalled()
+      expect(response.statusCode).toBe(302)
+      expect(response.headers.location).toBe(routes.DASHBOARD)
+    })
+  })
+
+  describe('when the application is not submitted', () => {
+    test.each([
+      PROJECT_STATUS.DRAFT,
+      PROJECT_STATUS.TRANSFERRED,
+      PROJECT_STATUS.WITHDRAWN
+    ])('should redirect to the dashboard when status is %s', async (status) => {
+      mockMarineLicence({ ...submittedMarineLicence, status })
+
+      const response = await makeGetRequest({
+        url: marineLicenceRoutes.MARINE_LICENCE_WITHDRAW,
+        server: getServer()
+      })
+
+      expect(response.statusCode).toBe(302)
+      expect(response.headers.location).toBe(routes.DASHBOARD)
+    })
+  })
+})


### PR DESCRIPTION
## ML-1074: Withdraw a marine licence application

Lets an applicant withdraw a submitted marine licence application from the dashboard, and shows the withdrawn state on the view details page.

Requires the corresponding backend endpoint `POST /marine-licence/{id}/withdraw`.

### Changes

**New withdraw journey** (`src/server/marine-licence/withdraw/`)

- `GET /marine-licence/withdraw/{marineLicenceId}` — selects the application and redirects to the confirmation page.
- `GET /marine-licence/withdraw` — renders "Are you sure you want to withdraw this application?", showing the project name, the consequences of withdrawing, and a link to the marine licensing terms and conditions (opens in new tab). Only renders when the application is `Submitted`; anything else redirects to the dashboard.
- `POST /marine-licence/withdraw` — verifies the submitted ID matches the one in the session, calls the backend, clears the session cache and returns to the dashboard.

**Dashboard** (`src/server/dashboard/utils.js`)

- Marine licence rows now show a **Withdraw** link alongside **View details**, gated on status `Submitted` and the application belonging to the current user.
- `getActiveActions` now takes the withdraw route rather than a boolean, so marine licence and exemption rows share one code path.

**View details** (`src/server/marine-licence/view-details/`, `application-details-card`)

- The application details card is shown for withdrawn applications and includes a **Date withdrawn** row.
- The **Date of transfer** and **Date withdrawn** rows are now conditional, so neither renders as an empty row on the other's journey.

### Testing

Unit tests for the three controllers, the dashboard action buttons and the card data builder; component tests for the details card; integration tests for the withdraw journey and the dashboard rows; the withdraw page and the withdrawn view details page added to the accessibility suite.

### Known limitation

If the backend call fails, the user is redirected to the dashboard with no error shown — indistinguishable from a successful withdrawal. This matches the existing exemption withdraw behaviour; worth addressing for both journeys separately.