### PR TITLE
ML-1141 - LCML - link to satisfaction survey

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -113,6 +113,38 @@ export const config = convict({
       env: 'MCMS_PATH'
     }
   },
+  survey: {
+    exemption: {
+      midJourneyUrl: {
+        doc: 'Mid-journey feedback survey linked from the service banner on exemption screens',
+        format: String,
+        default:
+          'https://forms.office.com/pages/responsepage.aspx?id=UCQKdycCYkyQx044U38RAjXEiYXnHG1DvkWr_VjRfzZUNERIRURNOFNVT0tXSlo1NUdONUYxQjNKUy4u&route=shorturl',
+        env: 'SURVEY_EXEMPTION_MID_JOURNEY_URL'
+      },
+      confirmationUrl: {
+        doc: 'End-of-journey feedback survey linked from the exemption confirmation page',
+        format: String,
+        default:
+          'https://forms.office.com/pages/responsepage.aspx?id=UCQKdycCYkyQx044U38RAjXEiYXnHG1DvkWr_VjRfzZURFMxRkhCSzQyVlRKQzdZNDEyVDhSMFdSNy4u&route=shorturl',
+        env: 'SURVEY_EXEMPTION_CONFIRMATION_URL'
+      }
+    },
+    marineLicence: {
+      midJourneyUrl: {
+        doc: 'Mid-journey feedback survey linked from the service banner on marine licence screens',
+        format: String,
+        default: 'https://forms.cloud.microsoft/e/MHPbixhs4i',
+        env: 'SURVEY_MARINE_LICENCE_MID_JOURNEY_URL'
+      },
+      confirmationUrl: {
+        doc: 'End-of-journey feedback survey linked from the marine licence confirmation page',
+        format: String,
+        default: 'https://forms.cloud.microsoft/e/vUT96ZvAez',
+        env: 'SURVEY_MARINE_LICENCE_CONFIRMATION_URL'
+      }
+    }
+  },
   root: {
     doc: 'Project root',
     format: String,

--- a/src/config/config.test.js
+++ b/src/config/config.test.js
@@ -305,3 +305,33 @@ describe('config validation', () => {
     })
   })
 })
+
+describe('survey config', () => {
+  const surveyKeys = [
+    'survey.exemption.midJourneyUrl',
+    'survey.exemption.confirmationUrl',
+    'survey.marineLicence.midJourneyUrl',
+    'survey.marineLicence.confirmationUrl'
+  ]
+
+  test.each(surveyKeys)('should provide a default URL for %s', async (key) => {
+    const { config } = await import('./config.js')
+    expect(config.get(key)).toMatch(/^https:\/\//)
+  })
+
+  test('should use a distinct URL for every survey', async () => {
+    const { config } = await import('./config.js')
+    const urls = surveyKeys.map((key) => config.get(key))
+    expect(new Set(urls).size).toBe(surveyKeys.length)
+  })
+
+  test('should use the marine licence specific survey URLs', async () => {
+    const { config } = await import('./config.js')
+    expect(config.get('survey.marineLicence.midJourneyUrl')).toBe(
+      'https://forms.cloud.microsoft/e/MHPbixhs4i'
+    )
+    expect(config.get('survey.marineLicence.confirmationUrl')).toBe(
+      'https://forms.cloud.microsoft/e/vUT96ZvAez'
+    )
+  })
+})

--- a/src/config/nunjucks/context/context.js
+++ b/src/config/nunjucks/context/context.js
@@ -46,16 +46,13 @@ const isMarineLicencePath = (pagePath = '') => {
 }
 
 const getSurveyUrls = (request) => {
-  const midJourneyUrl = isMarineLicencePath(request?.path)
-    ? config.get('survey.marineLicence.midJourneyUrl')
-    : config.get('survey.exemption.midJourneyUrl')
+  const journey = isMarineLicencePath(request?.path)
+    ? 'marineLicence'
+    : 'exemption'
 
   return {
-    midJourney: midJourneyUrl,
-    exemptionConfirmation: config.get('survey.exemption.confirmationUrl'),
-    marineLicenceConfirmation: config.get(
-      'survey.marineLicence.confirmationUrl'
-    )
+    midJourney: config.get(`survey.${journey}.midJourneyUrl`),
+    confirmation: config.get(`survey.${journey}.confirmationUrl`)
   }
 }
 

--- a/src/config/nunjucks/context/context.js
+++ b/src/config/nunjucks/context/context.js
@@ -38,6 +38,27 @@ const hideNavigationRoutesMarineLicenceAlways = new Set([
 
 const hideNavigationRoutesExemptionAlways = new Set([routes.UPLOAD_AND_WAIT])
 
+const isMarineLicencePath = (pagePath = '') => {
+  return (
+    pagePath.startsWith('/marine-licence') ||
+    pagePath === marineLicenceRoutes.MARINE_LICENCE_VIEW_DETAILS_INTERNAL_USER
+  )
+}
+
+const getSurveyUrls = (request) => {
+  const midJourneyUrl = isMarineLicencePath(request?.path)
+    ? config.get('survey.marineLicence.midJourneyUrl')
+    : config.get('survey.exemption.midJourneyUrl')
+
+  return {
+    midJourney: midJourneyUrl,
+    exemptionConfirmation: config.get('survey.exemption.confirmationUrl'),
+    marineLicenceConfirmation: config.get(
+      'survey.marineLicence.confirmationUrl'
+    )
+  }
+}
+
 const isRouteNavigationHidden = (request) => {
   const { path: pagePath } = request
 
@@ -93,6 +114,7 @@ export function context(request) {
     navigation,
     isAuthenticated,
     analyticsEnabled,
+    surveyUrls: getSurveyUrls(request),
     clarityProjectId: config.get('clarityProjectId'),
     enableBrowserLogging: config.get('enableBrowserLogging'),
     getAssetPath(asset) {

--- a/src/config/nunjucks/context/context.test.js
+++ b/src/config/nunjucks/context/context.test.js
@@ -72,7 +72,12 @@ describe('#context', () => {
           }
         ],
         serviceName: 'Get permission for marine work',
-        serviceUrl: '/'
+        serviceUrl: '/',
+        surveyUrls: {
+          midJourney: expect.stringContaining('https://'),
+          exemptionConfirmation: expect.stringContaining('https://'),
+          marineLicenceConfirmation: expect.stringContaining('https://')
+        }
       })
     })
 
@@ -182,6 +187,58 @@ describe('#context', () => {
         serviceUrl: '/'
       })
     )
+  })
+
+  describe('survey URLs', () => {
+    const exemptionMidJourneyUrl =
+      'https://forms.office.com/pages/responsepage.aspx?id=UCQKdycCYkyQx044U38RAjXEiYXnHG1DvkWr_VjRfzZUNERIRURNOFNVT0tXSlo1NUdONUYxQjNKUy4u&route=shorturl'
+    const marineLicenceMidJourneyUrl =
+      'https://forms.cloud.microsoft/e/MHPbixhs4i'
+
+    it.each([
+      {
+        page: 'a marine licence journey page',
+        path: '/marine-licence/project-name',
+        expected: marineLicenceMidJourneyUrl
+      },
+      {
+        page: 'the internal user view details page',
+        path: '/view-marine-licence-details',
+        expected: marineLicenceMidJourneyUrl
+      },
+      {
+        page: 'an exemption journey page',
+        path: '/exemption/project-name',
+        expected: exemptionMidJourneyUrl
+      },
+      {
+        page: 'a page belonging to neither journey',
+        path: '/help/privacy',
+        expected: exemptionMidJourneyUrl
+      }
+    ])(
+      'When on $page, should use the matching mid journey survey URL',
+      ({ path, expected }) => {
+        const request = { path, logger: { error: vi.fn() } }
+        expect(context(request).surveyUrls.midJourney).toBe(expected)
+      }
+    )
+
+    it('Should provide both confirmation survey URLs regardless of journey', () => {
+      const request = {
+        path: '/exemption/project-name',
+        logger: { error: vi.fn() }
+      }
+      const { surveyUrls } = context(request)
+
+      expect(surveyUrls.marineLicenceConfirmation).toBe(
+        'https://forms.cloud.microsoft/e/vUT96ZvAez'
+      )
+      expect(surveyUrls.exemptionConfirmation).not.toBe(
+        surveyUrls.marineLicenceConfirmation
+      )
+      expect(surveyUrls.exemptionConfirmation).not.toBe(surveyUrls.midJourney)
+    })
   })
 
   it('When session cache throws, should show navigation', () => {

--- a/src/config/nunjucks/context/context.test.js
+++ b/src/config/nunjucks/context/context.test.js
@@ -75,8 +75,7 @@ describe('#context', () => {
         serviceUrl: '/',
         surveyUrls: {
           midJourney: expect.stringContaining('https://'),
-          exemptionConfirmation: expect.stringContaining('https://'),
-          marineLicenceConfirmation: expect.stringContaining('https://')
+          confirmation: expect.stringContaining('https://')
         }
       })
     })
@@ -224,20 +223,34 @@ describe('#context', () => {
       }
     )
 
-    it('Should provide both confirmation survey URLs regardless of journey', () => {
+    it.each([
+      {
+        page: 'a marine licence journey page',
+        path: '/marine-licence/confirmation',
+        expected: 'https://forms.cloud.microsoft/e/vUT96ZvAez'
+      },
+      {
+        page: 'an exemption journey page',
+        path: '/exemption/confirmation',
+        expected:
+          'https://forms.office.com/pages/responsepage.aspx?id=UCQKdycCYkyQx044U38RAjXEiYXnHG1DvkWr_VjRfzZURFMxRkhCSzQyVlRKQzdZNDEyVDhSMFdSNy4u&route=shorturl'
+      }
+    ])(
+      'When on $page, should use the matching confirmation survey URL',
+      ({ path, expected }) => {
+        const request = { path, logger: { error: vi.fn() } }
+        expect(context(request).surveyUrls.confirmation).toBe(expected)
+      }
+    )
+
+    it('Should use a different survey for the confirmation page and the banner', () => {
       const request = {
-        path: '/exemption/project-name',
+        path: '/marine-licence/confirmation',
         logger: { error: vi.fn() }
       }
       const { surveyUrls } = context(request)
 
-      expect(surveyUrls.marineLicenceConfirmation).toBe(
-        'https://forms.cloud.microsoft/e/vUT96ZvAez'
-      )
-      expect(surveyUrls.exemptionConfirmation).not.toBe(
-        surveyUrls.marineLicenceConfirmation
-      )
-      expect(surveyUrls.exemptionConfirmation).not.toBe(surveyUrls.midJourney)
+      expect(surveyUrls.confirmation).not.toBe(surveyUrls.midJourney)
     })
   })
 

--- a/src/server/common/components/survey-link/macro.njk
+++ b/src/server/common/components/survey-link/macro.njk
@@ -1,0 +1,3 @@
+{% macro appSurveyLink(params) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/src/server/common/components/survey-link/template.njk
+++ b/src/server/common/components/survey-link/template.njk
@@ -1,0 +1,3 @@
+<p class="govuk-body">
+  <a href="{{ params.href }}" class="govuk-link" rel="noopener noreferrer">What did you think of this service?</a> (takes 30 seconds)
+</p>

--- a/src/server/common/components/survey-link/template.test.js
+++ b/src/server/common/components/survey-link/template.test.js
@@ -1,0 +1,35 @@
+import { getByRole, getByText } from '@testing-library/dom'
+import { renderComponentJSDOM } from '#src/server/test-helpers/component-helpers.js'
+
+describe('Survey Link Component', () => {
+  let document
+
+  beforeEach(() => {
+    document = renderComponentJSDOM('survey-link', {
+      href: 'https://forms.cloud.microsoft/e/test-survey'
+    })
+  })
+
+  test('Should render the survey link with the supplied href', () => {
+    const surveyLink = getByRole(document, 'link', {
+      name: 'What did you think of this service?'
+    })
+    expect(surveyLink).toBeInTheDocument()
+    expect(surveyLink.getAttribute('href')).toBe(
+      'https://forms.cloud.microsoft/e/test-survey'
+    )
+    expect(surveyLink).toHaveClass('govuk-link')
+    expect(surveyLink.getAttribute('rel')).toBe('noopener noreferrer')
+  })
+
+  test('Should render the hint text outside the link', () => {
+    const paragraph = getByText(document, /\(takes 30 seconds\)/)
+    expect(paragraph).toBeInTheDocument()
+    expect(paragraph).toHaveClass('govuk-body')
+
+    const surveyLink = getByRole(document, 'link', {
+      name: 'What did you think of this service?'
+    })
+    expect(surveyLink.textContent).not.toContain('takes 30 seconds')
+  })
+})

--- a/src/server/common/templates/layouts/page.njk
+++ b/src/server/common/templates/layouts/page.njk
@@ -11,6 +11,7 @@
 {% from "back-link/macro.njk" import appBackLink %}
 {% from "organisation-heading/macro.njk" import appOrganisationHeading %}
 {% from "contact-details/macro.njk" import appContactDetails %}
+{% from "survey-link/macro.njk" import appSurveyLink %}
 
 {% set mainClasses = "app-main-wrapper" %}
 
@@ -74,7 +75,7 @@
     tag: {
       text: "Beta"
       },
-    html: 'This is a new service. Help us improve it and <a class="govuk-link govuk-link--no-visited-state" target="_blank" rel="noopener noreferrer" href="https://forms.office.com/pages/responsepage.aspx?id=UCQKdycCYkyQx044U38RAjXEiYXnHG1DvkWr_VjRfzZUNERIRURNOFNVT0tXSlo1NUdONUYxQjNKUy4u&route=shorturl">give your feedback (opens in new tab)</a>.'
+    html: 'This is a new service. Help us improve it and <a class="govuk-link govuk-link--no-visited-state" target="_blank" rel="noopener noreferrer" href="' + surveyUrls.midJourney + '">give your feedback (opens in new tab)</a>.'
   }) }}
   </div>
   {{ appOrganisationHeading({

--- a/src/server/exemption/confirmation/index.njk
+++ b/src/server/exemption/confirmation/index.njk
@@ -11,9 +11,7 @@
       <p class="govuk-body">We have sent you a confirmation email with your reference number.</p>
       <h2 class="govuk-heading-m">What happens next</h2>
       <p class="govuk-body">You can complete your activity within the dates you provided.</p>
-      <p class="govuk-body">
-        <a href="https://forms.office.com/pages/responsepage.aspx?id=UCQKdycCYkyQx044U38RAjXEiYXnHG1DvkWr_VjRfzZURFMxRkhCSzQyVlRKQzdZNDEyVDhSMFdSNy4u&route=shorturl" class="govuk-link" rel="noopener noreferrer">What did you think of this service? (takes 30 seconds)</a>
-      </p>
+      {{ appSurveyLink({ href: surveyUrls.exemptionConfirmation }) }}
     </div>
   </div>
 {% endblock %}

--- a/src/server/exemption/confirmation/index.njk
+++ b/src/server/exemption/confirmation/index.njk
@@ -11,7 +11,7 @@
       <p class="govuk-body">We have sent you a confirmation email with your reference number.</p>
       <h2 class="govuk-heading-m">What happens next</h2>
       <p class="govuk-body">You can complete your activity within the dates you provided.</p>
-      {{ appSurveyLink({ href: surveyUrls.exemptionConfirmation }) }}
+      {{ appSurveyLink({ href: surveyUrls.confirmation }) }}
     </div>
   </div>
 {% endblock %}

--- a/src/server/marine-licence/confirmation/index.njk
+++ b/src/server/marine-licence/confirmation/index.njk
@@ -15,7 +15,7 @@
         <a href="mailto:marine.consents@marinemanagement.org.uk" class="govuk-link">marine.consents@marinemanagement.org.uk</a>,
         quoting your reference number.
       </p>
-      {{ appSurveyLink({ href: surveyUrls.marineLicenceConfirmation }) }}
+      {{ appSurveyLink({ href: surveyUrls.confirmation }) }}
     </div>
   </div>
 {% endblock %}

--- a/src/server/marine-licence/confirmation/index.njk
+++ b/src/server/marine-licence/confirmation/index.njk
@@ -15,6 +15,7 @@
         <a href="mailto:marine.consents@marinemanagement.org.uk" class="govuk-link">marine.consents@marinemanagement.org.uk</a>,
         quoting your reference number.
       </p>
+      {{ appSurveyLink({ href: surveyUrls.marineLicenceConfirmation }) }}
     </div>
   </div>
 {% endblock %}

--- a/tests/integration/confirmation/confirmation.test.js
+++ b/tests/integration/confirmation/confirmation.test.js
@@ -50,6 +50,25 @@ describe('Confirmation page', () => {
     )
     expect(feedbackLink).toHaveAttribute('rel', 'noopener noreferrer')
     expect(feedbackLink).toHaveClass('govuk-link')
+    expect(feedbackLink.parentElement).toHaveTextContent(
+      'What did you think of this service? (takes 30 seconds)'
+    )
+  })
+
+  it('should keep the exemption mid journey survey URL in the banner', async () => {
+    const document = await loadPage({
+      requestUrl: `${routes.CONFIRMATION}?applicationReference=TEST-REF-123`,
+      server: getServer()
+    })
+
+    const phaseBanner = document.querySelector('.govuk-phase-banner')
+    const bannerLink = within(phaseBanner).getByRole('link', {
+      name: /give your feedback/i
+    })
+    expect(bannerLink).toHaveAttribute(
+      'href',
+      'https://forms.office.com/pages/responsepage.aspx?id=UCQKdycCYkyQx044U38RAjXEiYXnHG1DvkWr_VjRfzZUNERIRURNOFNVT0tXSlo1NUdONUYxQjNKUy4u&route=shorturl'
+    )
   })
 
   it('should return bad request when application reference is missing', async () => {

--- a/tests/integration/marine-licence/confirmation.test.js
+++ b/tests/integration/marine-licence/confirmation.test.js
@@ -58,6 +58,51 @@ describe('Marine licence confirmation page', () => {
     expect(contactEmail).toHaveClass('govuk-link')
   })
 
+  it('should display the survey link with the hint text and the marine licence survey URL', async () => {
+    const document = await loadPage({
+      requestUrl: `${marineLicenceRoutes.MARINE_LICENCE_CONFIRMATION}?applicationReference=ML-REF-123`,
+      server: getServer()
+    })
+
+    const surveyLink = within(document).getByRole('link', {
+      name: 'What did you think of this service?'
+    })
+    expect(surveyLink).toBeInTheDocument()
+    expect(surveyLink).toHaveAttribute(
+      'href',
+      'https://forms.cloud.microsoft/e/vUT96ZvAez'
+    )
+    expect(surveyLink).toHaveAttribute('rel', 'noopener noreferrer')
+    expect(surveyLink).toHaveClass('govuk-link')
+
+    expect(surveyLink.parentElement).toHaveTextContent(
+      'What did you think of this service? (takes 30 seconds)'
+    )
+  })
+
+  it('should display the banner feedback link using a different, mid journey survey URL', async () => {
+    const document = await loadPage({
+      requestUrl: `${marineLicenceRoutes.MARINE_LICENCE_CONFIRMATION}?applicationReference=ML-REF-123`,
+      server: getServer()
+    })
+
+    const phaseBanner = document.querySelector('.govuk-phase-banner')
+    const bannerLink = within(phaseBanner).getByRole('link', {
+      name: /give your feedback/i
+    })
+    expect(bannerLink).toHaveAttribute(
+      'href',
+      'https://forms.cloud.microsoft/e/MHPbixhs4i'
+    )
+
+    const surveyLink = within(document).getByRole('link', {
+      name: 'What did you think of this service?'
+    })
+    expect(bannerLink.getAttribute('href')).not.toBe(
+      surveyLink.getAttribute('href')
+    )
+  })
+
   it('should return bad request when application reference is missing', async () => {
     const response = await makeGetRequest({
       server: getServer(),

--- a/tests/integration/marine-licence/task-list.test.js
+++ b/tests/integration/marine-licence/task-list.test.js
@@ -185,7 +185,7 @@ describe('Task List', () => {
     expect(feedbackLink).toHaveAttribute('rel', 'noopener noreferrer')
     expect(feedbackLink).toHaveAttribute(
       'href',
-      'https://forms.office.com/pages/responsepage.aspx?id=UCQKdycCYkyQx044U38RAjXEiYXnHG1DvkWr_VjRfzZUNERIRURNOFNVT0tXSlo1NUdONUYxQjNKUy4u&route=shorturl'
+      'https://forms.cloud.microsoft/e/MHPbixhs4i'
     )
   })
 })


### PR DESCRIPTION
## ML-1141 — LCML: link to satisfaction survey

- Adds a satisfaction survey link to the marine licence confirmation page, pointing at the marine licence end-of-journey survey.
- Moves all four survey URLs into `config` (`survey.exemption.*`, `survey.marineLicence.*`), overridable per environment via `SURVEY_EXEMPTION_MID_JOURNEY_URL`, `SURVEY_EXEMPTION_CONFIRMATION_URL`, `SURVEY_MARINE_LICENCE_MID_JOURNEY_URL` and `SURVEY_MARINE_LICENCE_CONFIRMATION_URL`.
- `context()` now resolves the journey from the request path and exposes `surveyUrls.midJourney` and `surveyUrls.confirmation`, so each page automatically gets the right survey. Marine licence pages (including the internal-user `/view-marine-licence-details` view) get the marine licence surveys; everything else falls back to the exemption ones.
- The page banner feedback link in `page.njk` is now driven by `surveyUrls.midJourney` instead of a hardcoded URL — marine licence screens link to the marine licence mid-journey survey.
- Extracts the survey link into a shared `survey-link` component, replacing the inline markup on the exemption confirmation page. The `(takes 30 seconds)` hint now sits outside the anchor so the link's accessible name is just "What did you think of this service?". This last part was not in the ticket but confirmed with Chris

