### PR TITLE
ML-710 Extract "Site name" information from uploaded file

### DIFF
--- a/src/server/common/helpers/exemptions/session-cache/utils.js
+++ b/src/server/common/helpers/exemptions/session-cache/utils.js
@@ -1,5 +1,6 @@
 import { clone } from '@hapi/hoek'
 import { getSiteDetailsBySite } from '#src/server/common/helpers/exemptions/session-cache/site-details-utils.js'
+import { withExtractedSiteName } from '#src/server/common/helpers/file-upload/extract-site-name.js'
 
 export const EXEMPTION_CACHE_KEY = 'exemption'
 export const SAVED_SITE_DETAILS_CACHE_KEY = 'savedSiteDetails'
@@ -117,11 +118,15 @@ export const updateExemptionSiteDetailsBatch = (
   }
 
   if (!isMultipleSitesFile) {
-    const updatedSite = {
-      ...uploadSiteData,
-      extractedCoordinates: coordinateData.extractedCoordinates,
-      geoJSON: coordinateData.geoJSON
-    }
+    const updatedSite = withExtractedSiteName(
+      {
+        ...uploadSiteData,
+        extractedCoordinates: coordinateData.extractedCoordinates,
+        geoJSON: coordinateData.geoJSON
+      },
+      coordinateData.geoJSON.features[0],
+      fileUploadType
+    )
 
     request.yar.set(EXEMPTION_CACHE_KEY, {
       ...existingCache,
@@ -135,16 +140,21 @@ export const updateExemptionSiteDetailsBatch = (
 
   for (const [index] of coordinateData.geoJSON.features.entries()) {
     const existingSiteDetails = getSiteDetailsBySite(existingCache, index)
+    const feature = coordinateData.geoJSON.features[index]
 
-    const updatedSite = {
-      ...existingSiteDetails,
-      ...uploadSiteData,
-      extractedCoordinates: coordinateData.extractedCoordinates[index],
-      geoJSON: {
-        type: coordinateData.geoJSON.type,
-        features: [coordinateData.geoJSON.features[index]]
-      }
-    }
+    const updatedSite = withExtractedSiteName(
+      {
+        ...existingSiteDetails,
+        ...uploadSiteData,
+        extractedCoordinates: coordinateData.extractedCoordinates[index],
+        geoJSON: {
+          type: coordinateData.geoJSON.type,
+          features: [feature]
+        }
+      },
+      feature,
+      fileUploadType
+    )
 
     updatedSiteDetails.push(updatedSite)
   }

--- a/src/server/common/helpers/exemptions/session-cache/utils.js
+++ b/src/server/common/helpers/exemptions/session-cache/utils.js
@@ -124,8 +124,7 @@ export const updateExemptionSiteDetailsBatch = (
         extractedCoordinates: coordinateData.extractedCoordinates,
         geoJSON: coordinateData.geoJSON
       },
-      coordinateData.geoJSON.features[0],
-      fileUploadType
+      coordinateData.geoJSON.features[0]
     )
 
     request.yar.set(EXEMPTION_CACHE_KEY, {
@@ -152,8 +151,7 @@ export const updateExemptionSiteDetailsBatch = (
           features: [feature]
         }
       },
-      feature,
-      fileUploadType
+      feature
     )
 
     updatedSiteDetails.push(updatedSite)

--- a/src/server/common/helpers/exemptions/session-cache/utils.js
+++ b/src/server/common/helpers/exemptions/session-cache/utils.js
@@ -1,6 +1,6 @@
 import { clone } from '@hapi/hoek'
 import { getSiteDetailsBySite } from '#src/server/common/helpers/exemptions/session-cache/site-details-utils.js'
-import { withExtractedSiteName } from '#src/server/common/helpers/file-upload/extract-site-name.js'
+import { createSiteDetailsBatchUpdater } from '#src/server/common/helpers/file-upload/build-uploaded-site-details.js'
 
 export const EXEMPTION_CACHE_KEY = 'exemption'
 export const SAVED_SITE_DETAILS_CACHE_KEY = 'savedSiteDetails'
@@ -86,84 +86,12 @@ export const resetExemptionSiteDetails = async (request, h) => {
 
   return { siteDetails: null }
 }
-export const updateExemptionSiteDetailsBatch = (
-  request,
-  status,
-  coordinateData,
-  s3Location,
-  options
-) => {
-  const { isMultipleSitesFile } = options
-  const existingCache = getExemptionCache(request)
 
-  const firstSiteDetails = getSiteDetailsBySite(existingCache)
-
-  const { coordinatesType, fileUploadType } = firstSiteDetails
-
-  const uploadSiteData = {
-    coordinatesType,
-    fileUploadType,
-    uploadedFile: {
-      ...status
-    },
-    s3Location: {
-      s3Bucket: s3Location.s3Bucket,
-      s3Key: s3Location.s3Key,
-      fileId: status.s3Location.fileId,
-      s3Url: status.s3Location.s3Url,
-      checksumSha256: status.s3Location.checksumSha256
-    },
-    featureCount: 1,
-    uploadConfig: null
-  }
-
-  if (!isMultipleSitesFile) {
-    const updatedSite = withExtractedSiteName(
-      {
-        ...uploadSiteData,
-        extractedCoordinates: coordinateData.extractedCoordinates,
-        geoJSON: coordinateData.geoJSON
-      },
-      coordinateData.geoJSON.features[0]
-    )
-
-    request.yar.set(EXEMPTION_CACHE_KEY, {
-      ...existingCache,
-      siteDetails: [updatedSite]
-    })
-
-    return [updatedSite]
-  }
-
-  const updatedSiteDetails = []
-
-  for (const [index] of coordinateData.geoJSON.features.entries()) {
-    const existingSiteDetails = getSiteDetailsBySite(existingCache, index)
-    const feature = coordinateData.geoJSON.features[index]
-
-    const updatedSite = withExtractedSiteName(
-      {
-        ...existingSiteDetails,
-        ...uploadSiteData,
-        extractedCoordinates: coordinateData.extractedCoordinates[index],
-        geoJSON: {
-          type: coordinateData.geoJSON.type,
-          features: [feature]
-        }
-      },
-      feature
-    )
-
-    updatedSiteDetails.push(updatedSite)
-  }
-
-  request.yar.set(EXEMPTION_CACHE_KEY, {
-    ...existingCache,
-    siteDetails: updatedSiteDetails
-  })
-
-  return updatedSiteDetails
-}
+export const updateExemptionSiteDetailsBatch = createSiteDetailsBatchUpdater({
+  cacheKey: EXEMPTION_CACHE_KEY,
+  getCache: getExemptionCache,
+  getSiteDetails: getSiteDetailsBySite
+})
 
 export const clearSavedSiteDetails = async (request, h) => {
   request.yar.clear(SAVED_SITE_DETAILS_CACHE_KEY)

--- a/src/server/common/helpers/exemptions/session-cache/utils.test.js
+++ b/src/server/common/helpers/exemptions/session-cache/utils.test.js
@@ -629,6 +629,76 @@ describe('#utils', () => {
 
       expect(result).toEqual([expected])
     })
+
+    test('should populate siteName from KML feature properties', () => {
+      const existingCache = {
+        projectName: 'Test Project',
+        siteDetails: [{ coordinatesType: 'file', fileUploadType: 'kml' }]
+      }
+      mockRequest.yar.get.mockReturnValue(existingCache)
+
+      const mockCoordinateData = {
+        extractedCoordinates: [],
+        geoJSON: {
+          type: 'FeatureCollection',
+          features: [
+            {
+              type: 'Feature',
+              geometry: { type: 'Polygon', coordinates: [] },
+              properties: { name: 'North Harbour' }
+            }
+          ]
+        }
+      }
+
+      const result = updateExemptionSiteDetailsBatch(
+        mockRequest,
+        mockStatus,
+        mockCoordinateData,
+        mockS3Location,
+        { isMultipleSitesFile: false }
+      )
+
+      expect(result[0].siteName).toBe('North Harbour')
+    })
+
+    test('should populate site names from shapefile columns for multiple sites', () => {
+      const existingCache = {
+        projectName: 'Test Project',
+        siteDetails: [{ coordinatesType: 'file', fileUploadType: 'shapefile' }]
+      }
+      mockRequest.yar.get.mockReturnValue(existingCache)
+
+      const mockCoordinateData = {
+        extractedCoordinates: [[], []],
+        geoJSON: {
+          type: 'FeatureCollection',
+          features: [
+            {
+              type: 'Feature',
+              geometry: { type: 'Polygon', coordinates: [] },
+              properties: { Site_name: 'East Pier' }
+            },
+            {
+              type: 'Feature',
+              geometry: { type: 'Polygon', coordinates: [] },
+              properties: {}
+            }
+          ]
+        }
+      }
+
+      const result = updateExemptionSiteDetailsBatch(
+        mockRequest,
+        mockStatus,
+        mockCoordinateData,
+        mockS3Location,
+        { isMultipleSitesFile: true }
+      )
+
+      expect(result[0].siteName).toBe('East Pier')
+      expect(result[1].siteName).toBeUndefined()
+    })
   })
 
   describe('resetExemptionSiteDetails', () => {

--- a/src/server/common/helpers/exemptions/session-cache/utils.test.js
+++ b/src/server/common/helpers/exemptions/session-cache/utils.test.js
@@ -662,7 +662,7 @@ describe('#utils', () => {
       expect(result[0].siteName).toBe('North Harbour')
     })
 
-    test('should populate site names from shapefile columns for multiple sites', () => {
+    test('should populate site names from GeoJSON properties.name for multiple sites', () => {
       const existingCache = {
         projectName: 'Test Project',
         siteDetails: [{ coordinatesType: 'file', fileUploadType: 'shapefile' }]
@@ -677,7 +677,7 @@ describe('#utils', () => {
             {
               type: 'Feature',
               geometry: { type: 'Polygon', coordinates: [] },
-              properties: { Site_name: 'East Pier' }
+              properties: { name: 'East Pier' }
             },
             {
               type: 'Feature',

--- a/src/server/common/helpers/file-upload/build-uploaded-site-details.js
+++ b/src/server/common/helpers/file-upload/build-uploaded-site-details.js
@@ -1,0 +1,106 @@
+import { withExtractedSiteName } from '#src/server/common/helpers/file-upload/extract-site-name.js'
+
+export const buildUploadSiteData = ({ status, s3Location, siteDetails }) => ({
+  coordinatesType: siteDetails.coordinatesType,
+  fileUploadType: siteDetails.fileUploadType,
+  uploadedFile: {
+    ...status
+  },
+  s3Location: {
+    s3Bucket: s3Location.s3Bucket,
+    s3Key: s3Location.s3Key,
+    fileId: status.s3Location.fileId,
+    s3Url: status.s3Location.s3Url,
+    checksumSha256: status.s3Location.checksumSha256
+  },
+  featureCount: 1,
+  uploadConfig: null
+})
+
+const buildSingleUploadedSite = (uploadSiteData, coordinateData) =>
+  withExtractedSiteName(
+    {
+      ...uploadSiteData,
+      extractedCoordinates: coordinateData.extractedCoordinates,
+      geoJSON: coordinateData.geoJSON
+    },
+    coordinateData.geoJSON.features[0]
+  )
+
+const buildMultipleUploadedSites = (
+  existingCache,
+  uploadSiteData,
+  coordinateData,
+  getSiteDetails
+) =>
+  coordinateData.geoJSON.features.map((feature, index) =>
+    withExtractedSiteName(
+      {
+        ...getSiteDetails(existingCache, index),
+        ...uploadSiteData,
+        extractedCoordinates: coordinateData.extractedCoordinates[index],
+        geoJSON: {
+          type: coordinateData.geoJSON.type,
+          features: [feature]
+        }
+      },
+      feature
+    )
+  )
+
+export const buildUploadedSiteDetails = ({
+  existingCache,
+  uploadSiteData,
+  coordinateData,
+  isMultipleSitesFile,
+  getSiteDetails
+}) => {
+  if (!isMultipleSitesFile) {
+    return [buildSingleUploadedSite(uploadSiteData, coordinateData)]
+  }
+
+  return buildMultipleUploadedSites(
+    existingCache,
+    uploadSiteData,
+    coordinateData,
+    getSiteDetails
+  )
+}
+
+export const updateCachedSiteDetailsBatch = (
+  request,
+  status,
+  coordinateData,
+  s3Location,
+  { isMultipleSitesFile, cacheKey, getCache, getSiteDetails }
+) => {
+  const existingCache = getCache(request)
+  const updatedSiteDetails = buildUploadedSiteDetails({
+    existingCache,
+    uploadSiteData: buildUploadSiteData({
+      status,
+      s3Location,
+      siteDetails: getSiteDetails(existingCache)
+    }),
+    coordinateData,
+    isMultipleSitesFile,
+    getSiteDetails
+  })
+
+  request.yar.set(cacheKey, {
+    ...existingCache,
+    siteDetails: updatedSiteDetails
+  })
+
+  return updatedSiteDetails
+}
+
+export const createSiteDetailsBatchUpdater =
+  ({ cacheKey, getCache, getSiteDetails }) =>
+  (request, status, coordinateData, s3Location, options) =>
+    updateCachedSiteDetailsBatch(request, status, coordinateData, s3Location, {
+      ...options,
+      cacheKey,
+      getCache,
+      getSiteDetails
+    })

--- a/src/server/common/helpers/file-upload/build-uploaded-site-details.test.js
+++ b/src/server/common/helpers/file-upload/build-uploaded-site-details.test.js
@@ -1,0 +1,194 @@
+import { vi } from 'vitest'
+import {
+  buildUploadSiteData,
+  buildUploadedSiteDetails,
+  createSiteDetailsBatchUpdater,
+  updateCachedSiteDetailsBatch
+} from '#src/server/common/helpers/file-upload/build-uploaded-site-details.js'
+
+const mockStatus = {
+  filename: 'test-file',
+  status: 'ready',
+  s3Location: {
+    s3Bucket: 'status-bucket',
+    s3Key: 'status-key',
+    fileId: 'file-id',
+    s3Url: 'https://example.test/file',
+    checksumSha256: 'checksum'
+  }
+}
+
+const mockS3Location = {
+  s3Bucket: 'upload-bucket',
+  s3Key: 'upload-key'
+}
+
+const namedFeature = (name) => ({
+  type: 'Feature',
+  geometry: { type: 'Polygon', coordinates: [] },
+  properties: name ? { name } : {}
+})
+
+describe('#buildUploadSiteData', () => {
+  test('copies coordinates type, file type and S3 metadata from the upload', () => {
+    expect(
+      buildUploadSiteData({
+        status: mockStatus,
+        s3Location: mockS3Location,
+        siteDetails: { coordinatesType: 'file', fileUploadType: 'kml' }
+      })
+    ).toEqual({
+      coordinatesType: 'file',
+      fileUploadType: 'kml',
+      uploadedFile: mockStatus,
+      s3Location: {
+        s3Bucket: 'upload-bucket',
+        s3Key: 'upload-key',
+        fileId: 'file-id',
+        s3Url: 'https://example.test/file',
+        checksumSha256: 'checksum'
+      },
+      featureCount: 1,
+      uploadConfig: null
+    })
+  })
+})
+
+describe('#buildUploadedSiteDetails', () => {
+  const uploadSiteData = {
+    coordinatesType: 'file',
+    fileUploadType: 'kml',
+    featureCount: 1,
+    uploadConfig: null
+  }
+
+  test('builds a single site from the full GeoJSON and extracted site name', () => {
+    const geoJSON = {
+      type: 'FeatureCollection',
+      features: [namedFeature('North Harbour')]
+    }
+
+    const result = buildUploadedSiteDetails({
+      existingCache: {},
+      uploadSiteData,
+      coordinateData: { extractedCoordinates: [[0, 0]], geoJSON },
+      isMultipleSitesFile: false,
+      getSiteDetails: () => ({})
+    })
+
+    expect(result).toEqual([
+      {
+        ...uploadSiteData,
+        extractedCoordinates: [[0, 0]],
+        geoJSON,
+        siteName: 'North Harbour'
+      }
+    ])
+  })
+
+  test('builds one site per feature and looks up existing details by index', () => {
+    const features = [namedFeature('East Pier'), namedFeature()]
+    const getSiteDetails = (cache, index) => cache.siteDetails[index]
+    const existingCache = {
+      siteDetails: [{ siteName: 'Existing A' }, { siteName: 'Existing B' }]
+    }
+
+    const result = buildUploadedSiteDetails({
+      existingCache,
+      uploadSiteData,
+      coordinateData: {
+        extractedCoordinates: [[[1, 1]], [[2, 2]]],
+        geoJSON: { type: 'FeatureCollection', features }
+      },
+      isMultipleSitesFile: true,
+      getSiteDetails
+    })
+
+    expect(result).toEqual([
+      {
+        siteName: 'East Pier',
+        ...uploadSiteData,
+        extractedCoordinates: [[1, 1]],
+        geoJSON: { type: 'FeatureCollection', features: [features[0]] }
+      },
+      {
+        ...uploadSiteData,
+        extractedCoordinates: [[2, 2]],
+        geoJSON: { type: 'FeatureCollection', features: [features[1]] }
+      }
+    ])
+  })
+})
+
+describe('#updateCachedSiteDetailsBatch', () => {
+  test('writes built site details to the given cache key', () => {
+    const existingCache = {
+      projectName: 'Test Project',
+      siteDetails: [{ coordinatesType: 'file', fileUploadType: 'kml' }]
+    }
+    const mockRequest = {
+      yar: {
+        get: vi.fn().mockReturnValue(existingCache),
+        set: vi.fn()
+      }
+    }
+    const geoJSON = {
+      type: 'FeatureCollection',
+      features: [namedFeature('North Harbour')]
+    }
+
+    const result = updateCachedSiteDetailsBatch(
+      mockRequest,
+      mockStatus,
+      { extractedCoordinates: [[0, 0]], geoJSON },
+      mockS3Location,
+      {
+        isMultipleSitesFile: false,
+        cacheKey: 'exemption',
+        getCache: () => existingCache,
+        getSiteDetails: () => existingCache.siteDetails[0]
+      }
+    )
+
+    expect(result[0].siteName).toBe('North Harbour')
+    expect(mockRequest.yar.set).toHaveBeenCalledWith('exemption', {
+      projectName: 'Test Project',
+      siteDetails: result
+    })
+  })
+})
+
+describe('#createSiteDetailsBatchUpdater', () => {
+  test('returns a function that writes to the configured cache key', () => {
+    const existingCache = {
+      siteDetails: [{ coordinatesType: 'file', fileUploadType: 'kml' }]
+    }
+    const mockRequest = {
+      yar: { set: vi.fn() }
+    }
+    const updateSiteDetailsBatch = createSiteDetailsBatchUpdater({
+      cacheKey: 'marineLicence',
+      getCache: () => existingCache,
+      getSiteDetails: () => existingCache.siteDetails[0]
+    })
+
+    const result = updateSiteDetailsBatch(
+      mockRequest,
+      mockStatus,
+      {
+        extractedCoordinates: [[0, 0]],
+        geoJSON: {
+          type: 'FeatureCollection',
+          features: [namedFeature('Pier')]
+        }
+      },
+      mockS3Location,
+      { isMultipleSitesFile: false }
+    )
+
+    expect(result[0].siteName).toBe('Pier')
+    expect(mockRequest.yar.set).toHaveBeenCalledWith('marineLicence', {
+      siteDetails: result
+    })
+  })
+})

--- a/src/server/common/helpers/file-upload/extract-site-name.js
+++ b/src/server/common/helpers/file-upload/extract-site-name.js
@@ -1,0 +1,83 @@
+const SITE_NAME_MAX_LENGTH = 250
+
+const SITE_NAME_PROPERTY_KEYS_BY_FILE_TYPE = {
+  kml: ['name'],
+  shapefile: ['site_name', 'sitename', 'name']
+}
+
+const getSiteNamePropertyKeys = (fileType) =>
+  SITE_NAME_PROPERTY_KEYS_BY_FILE_TYPE[fileType] ??
+  SITE_NAME_PROPERTY_KEYS_BY_FILE_TYPE.shapefile
+
+const normaliseSiteName = (value) => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return String(value).slice(0, SITE_NAME_MAX_LENGTH)
+  }
+
+  if (typeof value !== 'string') {
+    return null
+  }
+
+  const trimmed = value.trim()
+
+  if (!trimmed) {
+    return null
+  }
+
+  return trimmed.slice(0, SITE_NAME_MAX_LENGTH)
+}
+
+const getLowercasedProperties = (properties) => {
+  const propertyMap = new Map()
+
+  for (const [key, value] of Object.entries(properties)) {
+    propertyMap.set(key.trim().toLowerCase(), value)
+  }
+
+  return propertyMap
+}
+
+export const extractSiteNameFromFeature = (feature, fileType) => {
+  const properties = feature?.properties
+
+  if (!properties || typeof properties !== 'object') {
+    return null
+  }
+
+  const propertyMap = getLowercasedProperties(properties)
+
+  for (const key of getSiteNamePropertyKeys(fileType)) {
+    if (!propertyMap.has(key)) {
+      continue
+    }
+
+    const siteName = normaliseSiteName(propertyMap.get(key))
+
+    if (siteName) {
+      return siteName
+    }
+  }
+
+  return null
+}
+
+export const withExtractedSiteName = (
+  site,
+  feature,
+  fileType,
+  { preserveExisting = false } = {}
+) => {
+  const extractedSiteName = extractSiteNameFromFeature(feature, fileType)
+
+  if (extractedSiteName) {
+    return { ...site, siteName: extractedSiteName }
+  }
+
+  if (preserveExisting) {
+    return site
+  }
+
+  const updatedSite = { ...site }
+  delete updatedSite.siteName
+  return updatedSite
+}

--- a/src/server/common/helpers/file-upload/extract-site-name.js
+++ b/src/server/common/helpers/file-upload/extract-site-name.js
@@ -1,73 +1,21 @@
-const SITE_NAME_MAX_LENGTH = 250
+export const extractSiteNameFromFeature = (feature) => {
+  const name = feature?.properties?.name
 
-const SITE_NAME_PROPERTY_KEYS_BY_FILE_TYPE = {
-  kml: ['name'],
-  shapefile: ['site_name', 'sitename', 'name']
-}
-
-const getSiteNamePropertyKeys = (fileType) =>
-  SITE_NAME_PROPERTY_KEYS_BY_FILE_TYPE[fileType] ??
-  SITE_NAME_PROPERTY_KEYS_BY_FILE_TYPE.shapefile
-
-const normaliseSiteName = (value) => {
-  if (typeof value === 'number' && Number.isFinite(value)) {
-    return String(value).slice(0, SITE_NAME_MAX_LENGTH)
-  }
-
-  if (typeof value !== 'string') {
+  if (typeof name !== 'string') {
     return null
   }
 
-  const trimmed = value.trim()
+  const trimmed = name.trim()
 
-  if (!trimmed) {
-    return null
-  }
-
-  return trimmed.slice(0, SITE_NAME_MAX_LENGTH)
-}
-
-const getLowercasedProperties = (properties) => {
-  const propertyMap = new Map()
-
-  for (const [key, value] of Object.entries(properties)) {
-    propertyMap.set(key.trim().toLowerCase(), value)
-  }
-
-  return propertyMap
-}
-
-export const extractSiteNameFromFeature = (feature, fileType) => {
-  const properties = feature?.properties
-
-  if (!properties || typeof properties !== 'object') {
-    return null
-  }
-
-  const propertyMap = getLowercasedProperties(properties)
-
-  for (const key of getSiteNamePropertyKeys(fileType)) {
-    if (!propertyMap.has(key)) {
-      continue
-    }
-
-    const siteName = normaliseSiteName(propertyMap.get(key))
-
-    if (siteName) {
-      return siteName
-    }
-  }
-
-  return null
+  return trimmed || null
 }
 
 export const withExtractedSiteName = (
   site,
   feature,
-  fileType,
   { preserveExisting = false } = {}
 ) => {
-  const extractedSiteName = extractSiteNameFromFeature(feature, fileType)
+  const extractedSiteName = extractSiteNameFromFeature(feature)
 
   if (extractedSiteName) {
     return { ...site, siteName: extractedSiteName }

--- a/src/server/common/helpers/file-upload/extract-site-name.test.js
+++ b/src/server/common/helpers/file-upload/extract-site-name.test.js
@@ -1,0 +1,134 @@
+import {
+  extractSiteNameFromFeature,
+  withExtractedSiteName
+} from '#src/server/common/helpers/file-upload/extract-site-name.js'
+
+const polygonFeature = (properties) => ({
+  type: 'Feature',
+  geometry: { type: 'Polygon', coordinates: [] },
+  properties
+})
+
+describe('#extractSiteNameFromFeature', () => {
+  describe('KML', () => {
+    test('extracts the name property', () => {
+      expect(
+        extractSiteNameFromFeature(
+          polygonFeature({ name: 'North Harbour' }),
+          'kml'
+        )
+      ).toBe('North Harbour')
+    })
+
+    test('returns null when name is missing', () => {
+      expect(extractSiteNameFromFeature(polygonFeature({}), 'kml')).toBeNull()
+    })
+
+    test('returns null when name is blank', () => {
+      expect(
+        extractSiteNameFromFeature(polygonFeature({ name: '   ' }), 'kml')
+      ).toBeNull()
+    })
+
+    test('does not use shapefile column names', () => {
+      expect(
+        extractSiteNameFromFeature(
+          polygonFeature({ Site_name: 'Should not use' }),
+          'kml'
+        )
+      ).toBeNull()
+    })
+  })
+
+  describe('shapefile', () => {
+    test.each([
+      [{ Site_name: 'North Harbour' }, 'North Harbour'],
+      [{ Sitename: 'East Pier' }, 'East Pier'],
+      [{ Name: 'West Dock' }, 'West Dock'],
+      [{ SITE_NAME: 'Uppercase column' }, 'Uppercase column']
+    ])('extracts from %j', (properties, expected) => {
+      expect(
+        extractSiteNameFromFeature(polygonFeature(properties), 'shapefile')
+      ).toBe(expected)
+    })
+
+    test('prefers Site_name over Name', () => {
+      expect(
+        extractSiteNameFromFeature(
+          polygonFeature({
+            Name: 'Name column',
+            Site_name: 'Site_name column'
+          }),
+          'shapefile'
+        )
+      ).toBe('Site_name column')
+    })
+
+    test('returns null when no recognised column has a value', () => {
+      expect(
+        extractSiteNameFromFeature(
+          polygonFeature({ other: 'ignored' }),
+          'shapefile'
+        )
+      ).toBeNull()
+    })
+  })
+
+  test('returns null when feature has no properties', () => {
+    expect(extractSiteNameFromFeature({ type: 'Feature' }, 'kml')).toBeNull()
+    expect(extractSiteNameFromFeature(null, 'shapefile')).toBeNull()
+  })
+
+  test('truncates names longer than 250 characters', () => {
+    expect(
+      extractSiteNameFromFeature(
+        polygonFeature({ name: 'a'.repeat(251) }),
+        'kml'
+      )
+    ).toBe('a'.repeat(250))
+  })
+})
+
+describe('#withExtractedSiteName', () => {
+  test('sets siteName from the feature when present', () => {
+    const result = withExtractedSiteName(
+      { coordinatesType: 'file' },
+      polygonFeature({ name: 'Harbour' }),
+      'kml'
+    )
+
+    expect(result.siteName).toBe('Harbour')
+  })
+
+  test('omits siteName when the feature has no name', () => {
+    const result = withExtractedSiteName(
+      { coordinatesType: 'file', siteName: 'Previous name' },
+      polygonFeature({}),
+      'kml'
+    )
+
+    expect(result.siteName).toBeUndefined()
+  })
+
+  test('keeps the existing siteName when preserveExisting is true and the feature has no name', () => {
+    const result = withExtractedSiteName(
+      { coordinatesType: 'file', siteName: 'Previous name' },
+      polygonFeature({}),
+      'kml',
+      { preserveExisting: true }
+    )
+
+    expect(result.siteName).toBe('Previous name')
+  })
+
+  test('overwrites the existing siteName when the feature has a name', () => {
+    const result = withExtractedSiteName(
+      { coordinatesType: 'file', siteName: 'Previous name' },
+      polygonFeature({ name: 'New name' }),
+      'kml',
+      { preserveExisting: true }
+    )
+
+    expect(result.siteName).toBe('New name')
+  })
+})

--- a/src/server/common/helpers/file-upload/extract-site-name.test.js
+++ b/src/server/common/helpers/file-upload/extract-site-name.test.js
@@ -79,6 +79,60 @@ describe('#extractSiteNameFromFeature', () => {
     expect(extractSiteNameFromFeature(null, 'shapefile')).toBeNull()
   })
 
+  test('returns null when properties is not an object', () => {
+    expect(
+      extractSiteNameFromFeature(
+        { type: 'Feature', properties: 'invalid' },
+        'kml'
+      )
+    ).toBeNull()
+  })
+
+  test('converts finite numeric names to strings', () => {
+    expect(
+      extractSiteNameFromFeature(polygonFeature({ name: 42 }), 'kml')
+    ).toBe('42')
+  })
+
+  test('returns null for non-string, non-numeric values', () => {
+    expect(
+      extractSiteNameFromFeature(polygonFeature({ name: true }), 'kml')
+    ).toBeNull()
+    expect(
+      extractSiteNameFromFeature(polygonFeature({ name: null }), 'kml')
+    ).toBeNull()
+  })
+
+  test('returns null for non-finite numbers', () => {
+    expect(
+      extractSiteNameFromFeature(polygonFeature({ name: Infinity }), 'kml')
+    ).toBeNull()
+    expect(
+      extractSiteNameFromFeature(polygonFeature({ name: NaN }), 'kml')
+    ).toBeNull()
+  })
+
+  test('uses shapefile column names for unknown file types', () => {
+    expect(
+      extractSiteNameFromFeature(
+        polygonFeature({ Site_name: 'Fallback site' }),
+        'geojson'
+      )
+    ).toBe('Fallback site')
+  })
+
+  test('skips a blank recognised column and uses the next one', () => {
+    expect(
+      extractSiteNameFromFeature(
+        polygonFeature({
+          Site_name: '  ',
+          Name: 'West Dock'
+        }),
+        'shapefile'
+      )
+    ).toBe('West Dock')
+  })
+
   test('truncates names longer than 250 characters', () => {
     expect(
       extractSiteNameFromFeature(

--- a/src/server/common/helpers/file-upload/extract-site-name.test.js
+++ b/src/server/common/helpers/file-upload/extract-site-name.test.js
@@ -10,136 +10,31 @@ const polygonFeature = (properties) => ({
 })
 
 describe('#extractSiteNameFromFeature', () => {
-  describe('KML', () => {
-    test('extracts the name property', () => {
-      expect(
-        extractSiteNameFromFeature(
-          polygonFeature({ name: 'North Harbour' }),
-          'kml'
-        )
-      ).toBe('North Harbour')
-    })
-
-    test('returns null when name is missing', () => {
-      expect(extractSiteNameFromFeature(polygonFeature({}), 'kml')).toBeNull()
-    })
-
-    test('returns null when name is blank', () => {
-      expect(
-        extractSiteNameFromFeature(polygonFeature({ name: '   ' }), 'kml')
-      ).toBeNull()
-    })
-
-    test('does not use shapefile column names', () => {
-      expect(
-        extractSiteNameFromFeature(
-          polygonFeature({ Site_name: 'Should not use' }),
-          'kml'
-        )
-      ).toBeNull()
-    })
+  test('reads properties.name from the backend GeoJSON', () => {
+    expect(
+      extractSiteNameFromFeature(polygonFeature({ name: 'North Harbour' }))
+    ).toBe('North Harbour')
   })
 
-  describe('shapefile', () => {
-    test.each([
-      [{ Site_name: 'North Harbour' }, 'North Harbour'],
-      [{ Sitename: 'East Pier' }, 'East Pier'],
-      [{ Name: 'West Dock' }, 'West Dock'],
-      [{ SITE_NAME: 'Uppercase column' }, 'Uppercase column']
-    ])('extracts from %j', (properties, expected) => {
-      expect(
-        extractSiteNameFromFeature(polygonFeature(properties), 'shapefile')
-      ).toBe(expected)
-    })
+  test('returns null when name is missing', () => {
+    expect(extractSiteNameFromFeature(polygonFeature({}))).toBeNull()
+  })
 
-    test('prefers Site_name over Name', () => {
-      expect(
-        extractSiteNameFromFeature(
-          polygonFeature({
-            Name: 'Name column',
-            Site_name: 'Site_name column'
-          }),
-          'shapefile'
-        )
-      ).toBe('Site_name column')
-    })
+  test('returns null when name is blank', () => {
+    expect(
+      extractSiteNameFromFeature(polygonFeature({ name: '   ' }))
+    ).toBeNull()
+  })
 
-    test('returns null when no recognised column has a value', () => {
-      expect(
-        extractSiteNameFromFeature(
-          polygonFeature({ other: 'ignored' }),
-          'shapefile'
-        )
-      ).toBeNull()
-    })
+  test('does not look up shapefile column names', () => {
+    expect(
+      extractSiteNameFromFeature(polygonFeature({ Site_name: 'East Pier' }))
+    ).toBeNull()
   })
 
   test('returns null when feature has no properties', () => {
-    expect(extractSiteNameFromFeature({ type: 'Feature' }, 'kml')).toBeNull()
-    expect(extractSiteNameFromFeature(null, 'shapefile')).toBeNull()
-  })
-
-  test('returns null when properties is not an object', () => {
-    expect(
-      extractSiteNameFromFeature(
-        { type: 'Feature', properties: 'invalid' },
-        'kml'
-      )
-    ).toBeNull()
-  })
-
-  test('converts finite numeric names to strings', () => {
-    expect(
-      extractSiteNameFromFeature(polygonFeature({ name: 42 }), 'kml')
-    ).toBe('42')
-  })
-
-  test('returns null for non-string, non-numeric values', () => {
-    expect(
-      extractSiteNameFromFeature(polygonFeature({ name: true }), 'kml')
-    ).toBeNull()
-    expect(
-      extractSiteNameFromFeature(polygonFeature({ name: null }), 'kml')
-    ).toBeNull()
-  })
-
-  test('returns null for non-finite numbers', () => {
-    expect(
-      extractSiteNameFromFeature(polygonFeature({ name: Infinity }), 'kml')
-    ).toBeNull()
-    expect(
-      extractSiteNameFromFeature(polygonFeature({ name: NaN }), 'kml')
-    ).toBeNull()
-  })
-
-  test('uses shapefile column names for unknown file types', () => {
-    expect(
-      extractSiteNameFromFeature(
-        polygonFeature({ Site_name: 'Fallback site' }),
-        'geojson'
-      )
-    ).toBe('Fallback site')
-  })
-
-  test('skips a blank recognised column and uses the next one', () => {
-    expect(
-      extractSiteNameFromFeature(
-        polygonFeature({
-          Site_name: '  ',
-          Name: 'West Dock'
-        }),
-        'shapefile'
-      )
-    ).toBe('West Dock')
-  })
-
-  test('truncates names longer than 250 characters', () => {
-    expect(
-      extractSiteNameFromFeature(
-        polygonFeature({ name: 'a'.repeat(251) }),
-        'kml'
-      )
-    ).toBe('a'.repeat(250))
+    expect(extractSiteNameFromFeature({ type: 'Feature' })).toBeNull()
+    expect(extractSiteNameFromFeature(null)).toBeNull()
   })
 })
 
@@ -147,8 +42,7 @@ describe('#withExtractedSiteName', () => {
   test('sets siteName from the feature when present', () => {
     const result = withExtractedSiteName(
       { coordinatesType: 'file' },
-      polygonFeature({ name: 'Harbour' }),
-      'kml'
+      polygonFeature({ name: 'Harbour' })
     )
 
     expect(result.siteName).toBe('Harbour')
@@ -157,8 +51,7 @@ describe('#withExtractedSiteName', () => {
   test('omits siteName when the feature has no name', () => {
     const result = withExtractedSiteName(
       { coordinatesType: 'file', siteName: 'Previous name' },
-      polygonFeature({}),
-      'kml'
+      polygonFeature({})
     )
 
     expect(result.siteName).toBeUndefined()
@@ -168,7 +61,6 @@ describe('#withExtractedSiteName', () => {
     const result = withExtractedSiteName(
       { coordinatesType: 'file', siteName: 'Previous name' },
       polygonFeature({}),
-      'kml',
       { preserveExisting: true }
     )
 
@@ -179,7 +71,6 @@ describe('#withExtractedSiteName', () => {
     const result = withExtractedSiteName(
       { coordinatesType: 'file', siteName: 'Previous name' },
       polygonFeature({ name: 'New name' }),
-      'kml',
       { preserveExisting: true }
     )
 

--- a/src/server/common/helpers/file-upload/file-upload.js
+++ b/src/server/common/helpers/file-upload/file-upload.js
@@ -16,16 +16,28 @@ import {
 export const CONSTRUCTION_DRAWING_ACCEPT_ATTRIBUTE =
   '.pdf,.bmp,.gif,.jpg,.jpeg,.png,.tif'
 
+export const KML_SITE_NAME_GUIDANCE = [
+  "We'll use a site name for each area in your file if one is included.",
+  'In a KML file, use the name of each place.'
+]
+
+export const SHAPEFILE_SITE_NAME_GUIDANCE = [
+  "We'll use a site name for each area in your file if one is included.",
+  'In a shapefile, put the name in a column such as Name or Site_name for each area.'
+]
+
 export const getFileTypeContent = (fileUploadType) => {
   if (fileUploadType === 'kml') {
     return {
       heading: 'Upload a KML file',
-      acceptAttribute: '.kml'
+      acceptAttribute: '.kml',
+      siteNameGuidance: KML_SITE_NAME_GUIDANCE
     }
   } else if (fileUploadType === 'shapefile') {
     return {
       heading: 'Upload a shapefile',
-      acceptAttribute: '.zip'
+      acceptAttribute: '.zip',
+      siteNameGuidance: SHAPEFILE_SITE_NAME_GUIDANCE
     }
   } else {
     return {

--- a/src/server/common/helpers/file-upload/file-upload.test.js
+++ b/src/server/common/helpers/file-upload/file-upload.test.js
@@ -1,7 +1,10 @@
 import {
   getAllowedExtensions,
   getCdpErrorMessageFromCode,
-  getGeoParserErrorMessage
+  getFileTypeContent,
+  getGeoParserErrorMessage,
+  KML_SITE_NAME_GUIDANCE,
+  SHAPEFILE_SITE_NAME_GUIDANCE
 } from '#src/server/common/helpers/file-upload/file-upload.js'
 import {
   CDP_ERROR_MESSAGES,
@@ -11,6 +14,32 @@ import {
   DEFAULT_GEO_PARSER_ERROR_MESSAGE,
   GEO_PARSER_ERROR_MESSAGES
 } from '#src/server/common/helpers/file-upload/error-messages.js'
+import { UPLOAD_A_FILE } from '#src/server/common/helpers/file-upload/constants.js'
+
+describe('#getFileTypeContent', () => {
+  test('should return KML heading, accept attribute and site name guidance', () => {
+    expect(getFileTypeContent('kml')).toEqual({
+      heading: 'Upload a KML file',
+      acceptAttribute: '.kml',
+      siteNameGuidance: KML_SITE_NAME_GUIDANCE
+    })
+  })
+
+  test('should return shapefile heading, accept attribute and site name guidance', () => {
+    expect(getFileTypeContent('shapefile')).toEqual({
+      heading: 'Upload a shapefile',
+      acceptAttribute: '.zip',
+      siteNameGuidance: SHAPEFILE_SITE_NAME_GUIDANCE
+    })
+  })
+
+  test('should return default content when file type is unknown', () => {
+    expect(getFileTypeContent('unknown')).toEqual({
+      heading: UPLOAD_A_FILE,
+      acceptAttribute: ''
+    })
+  })
+})
 
 describe('#getAllowedExtensions', () => {
   test.each([

--- a/src/server/common/helpers/marine-licence/session-cache/utils.js
+++ b/src/server/common/helpers/marine-licence/session-cache/utils.js
@@ -153,8 +153,7 @@ export const updateMarineLicenceSiteDetailsBatch = (
         extractedCoordinates: coordinateData.extractedCoordinates,
         geoJSON: coordinateData.geoJSON
       },
-      coordinateData.geoJSON.features[0],
-      uploadSiteData.fileUploadType
+      coordinateData.geoJSON.features[0]
     )
 
     request.yar.set(MARINE_LICENCE_CACHE_KEY, {
@@ -181,8 +180,7 @@ export const updateMarineLicenceSiteDetailsBatch = (
           features: [feature]
         }
       },
-      feature,
-      uploadSiteData.fileUploadType
+      feature
     )
 
     updatedSiteDetails.push(updatedSite)
@@ -219,7 +217,6 @@ export const updateSingleSiteLocation = (
       geoJSON: coordinateData.geoJSON
     },
     coordinateData.geoJSON.features[0],
-    uploadSiteData.fileUploadType,
     { preserveExisting: true }
   )
 

--- a/src/server/common/helpers/marine-licence/session-cache/utils.js
+++ b/src/server/common/helpers/marine-licence/session-cache/utils.js
@@ -121,13 +121,12 @@ export const updateMarineLicenceSiteDetailsMultiple = async (
   await request.yar.commit(h)
 }
 
-export const updateMarineLicenceSiteDetailsBatch = createSiteDetailsBatchUpdater(
-  {
+export const updateMarineLicenceSiteDetailsBatch =
+  createSiteDetailsBatchUpdater({
     cacheKey: MARINE_LICENCE_CACHE_KEY,
     getCache: getMarineLicenceCache,
     getSiteDetails: getSiteDetailsBySite
-  }
-)
+  })
 
 export const updateSingleSiteLocation = (
   request,

--- a/src/server/common/helpers/marine-licence/session-cache/utils.js
+++ b/src/server/common/helpers/marine-licence/session-cache/utils.js
@@ -3,6 +3,10 @@ import { getSiteDetailsBySite } from '#src/server/common/helpers/exemptions/sess
 import { getSiteDetailsBySite as getSiteByIndex } from '#src/server/common/helpers/marine-licence/session-cache/site-details-utils.js'
 import { snapshotActivityLabels } from '#src/server/common/helpers/activity-details/snapshot-activity-labels.js'
 import { SINGLE_SITE_MODE_KEY } from '#src/server/common/constants/cache.js'
+import {
+  buildUploadSiteData,
+  createSiteDetailsBatchUpdater
+} from '#src/server/common/helpers/file-upload/build-uploaded-site-details.js'
 import { withExtractedSiteName } from '#src/server/common/helpers/file-upload/extract-site-name.js'
 
 export const MARINE_LICENCE_CACHE_KEY = 'marineLicence'
@@ -24,6 +28,10 @@ export const getSavedSiteDetails = (request) =>
 export const setSavedSiteDetails = async (request, h, values) => {
   request.yar.set(SAVED_SITE_DETAILS_CACHE_KEY, values)
   await request.yar.commit(h)
+}
+
+export const getMarineLicenceCache = (request) => {
+  return clone(request.yar.get(MARINE_LICENCE_CACHE_KEY) || {})
 }
 
 export const updateMarineLicenceSiteDetails = async (
@@ -112,87 +120,14 @@ export const updateMarineLicenceSiteDetailsMultiple = async (
 
   await request.yar.commit(h)
 }
-const buildUploadSiteData = ({ status, s3Location, siteDetails }) => ({
-  coordinatesType: siteDetails.coordinatesType,
-  fileUploadType: siteDetails.fileUploadType,
-  uploadedFile: {
-    ...status
-  },
-  s3Location: {
-    s3Bucket: s3Location.s3Bucket,
-    s3Key: s3Location.s3Key,
-    fileId: status.s3Location.fileId,
-    s3Url: status.s3Location.s3Url,
-    checksumSha256: status.s3Location.checksumSha256
-  },
-  featureCount: 1,
-  uploadConfig: null
-})
 
-export const updateMarineLicenceSiteDetailsBatch = (
-  request,
-  status,
-  coordinateData,
-  s3Location,
-  options
-) => {
-  const { isMultipleSitesFile } = options
-  const existingCache = getMarineLicenceCache(request)
-
-  const firstSiteDetails = getSiteDetailsBySite(existingCache)
-  const uploadSiteData = buildUploadSiteData({
-    status,
-    s3Location,
-    siteDetails: firstSiteDetails
-  })
-
-  if (!isMultipleSitesFile) {
-    const updatedSite = withExtractedSiteName(
-      {
-        ...uploadSiteData,
-        extractedCoordinates: coordinateData.extractedCoordinates,
-        geoJSON: coordinateData.geoJSON
-      },
-      coordinateData.geoJSON.features[0]
-    )
-
-    request.yar.set(MARINE_LICENCE_CACHE_KEY, {
-      ...existingCache,
-      siteDetails: [updatedSite]
-    })
-
-    return [updatedSite]
+export const updateMarineLicenceSiteDetailsBatch = createSiteDetailsBatchUpdater(
+  {
+    cacheKey: MARINE_LICENCE_CACHE_KEY,
+    getCache: getMarineLicenceCache,
+    getSiteDetails: getSiteDetailsBySite
   }
-
-  const updatedSiteDetails = []
-
-  for (const [index] of coordinateData.geoJSON.features.entries()) {
-    const existingSiteDetails = getSiteDetailsBySite(existingCache, index)
-    const feature = coordinateData.geoJSON.features[index]
-
-    const updatedSite = withExtractedSiteName(
-      {
-        ...existingSiteDetails,
-        ...uploadSiteData,
-        extractedCoordinates: coordinateData.extractedCoordinates[index],
-        geoJSON: {
-          type: coordinateData.geoJSON.type,
-          features: [feature]
-        }
-      },
-      feature
-    )
-
-    updatedSiteDetails.push(updatedSite)
-  }
-
-  request.yar.set(MARINE_LICENCE_CACHE_KEY, {
-    ...existingCache,
-    siteDetails: updatedSiteDetails
-  })
-
-  return updatedSiteDetails
-}
+)
 
 export const updateSingleSiteLocation = (
   request,
@@ -227,10 +162,6 @@ export const updateSingleSiteLocation = (
     ...existingCache,
     siteDetails: updatedSiteDetails
   })
-}
-
-export const getMarineLicenceCache = (request) => {
-  return clone(request.yar.get(MARINE_LICENCE_CACHE_KEY) || {})
 }
 
 export const setSingleSiteMode = async (request, h, siteIndex) => {

--- a/src/server/common/helpers/marine-licence/session-cache/utils.js
+++ b/src/server/common/helpers/marine-licence/session-cache/utils.js
@@ -3,6 +3,7 @@ import { getSiteDetailsBySite } from '#src/server/common/helpers/exemptions/sess
 import { getSiteDetailsBySite as getSiteByIndex } from '#src/server/common/helpers/marine-licence/session-cache/site-details-utils.js'
 import { snapshotActivityLabels } from '#src/server/common/helpers/activity-details/snapshot-activity-labels.js'
 import { SINGLE_SITE_MODE_KEY } from '#src/server/common/constants/cache.js'
+import { withExtractedSiteName } from '#src/server/common/helpers/file-upload/extract-site-name.js'
 
 export const MARINE_LICENCE_CACHE_KEY = 'marineLicence'
 export const SAVED_SITE_DETAILS_CACHE_KEY = 'savedMarineLicenceSiteDetails'
@@ -146,11 +147,15 @@ export const updateMarineLicenceSiteDetailsBatch = (
   })
 
   if (!isMultipleSitesFile) {
-    const updatedSite = {
-      ...uploadSiteData,
-      extractedCoordinates: coordinateData.extractedCoordinates,
-      geoJSON: coordinateData.geoJSON
-    }
+    const updatedSite = withExtractedSiteName(
+      {
+        ...uploadSiteData,
+        extractedCoordinates: coordinateData.extractedCoordinates,
+        geoJSON: coordinateData.geoJSON
+      },
+      coordinateData.geoJSON.features[0],
+      uploadSiteData.fileUploadType
+    )
 
     request.yar.set(MARINE_LICENCE_CACHE_KEY, {
       ...existingCache,
@@ -164,16 +169,21 @@ export const updateMarineLicenceSiteDetailsBatch = (
 
   for (const [index] of coordinateData.geoJSON.features.entries()) {
     const existingSiteDetails = getSiteDetailsBySite(existingCache, index)
+    const feature = coordinateData.geoJSON.features[index]
 
-    const updatedSite = {
-      ...existingSiteDetails,
-      ...uploadSiteData,
-      extractedCoordinates: coordinateData.extractedCoordinates[index],
-      geoJSON: {
-        type: coordinateData.geoJSON.type,
-        features: [coordinateData.geoJSON.features[index]]
-      }
-    }
+    const updatedSite = withExtractedSiteName(
+      {
+        ...existingSiteDetails,
+        ...uploadSiteData,
+        extractedCoordinates: coordinateData.extractedCoordinates[index],
+        geoJSON: {
+          type: coordinateData.geoJSON.type,
+          features: [feature]
+        }
+      },
+      feature,
+      uploadSiteData.fileUploadType
+    )
 
     updatedSiteDetails.push(updatedSite)
   }
@@ -201,12 +211,17 @@ export const updateSingleSiteLocation = (
     siteDetails: targetSite
   })
 
-  const updatedSite = {
-    ...targetSite,
-    ...uploadSiteData,
-    extractedCoordinates: coordinateData.extractedCoordinates,
-    geoJSON: coordinateData.geoJSON
-  }
+  const updatedSite = withExtractedSiteName(
+    {
+      ...targetSite,
+      ...uploadSiteData,
+      extractedCoordinates: coordinateData.extractedCoordinates,
+      geoJSON: coordinateData.geoJSON
+    },
+    coordinateData.geoJSON.features[0],
+    uploadSiteData.fileUploadType,
+    { preserveExisting: true }
+  )
 
   const updatedSiteDetails = [...existingCache.siteDetails]
   updatedSiteDetails[targetSiteIndex] = updatedSite

--- a/src/server/common/helpers/marine-licence/session-cache/utils.test.js
+++ b/src/server/common/helpers/marine-licence/session-cache/utils.test.js
@@ -709,6 +709,76 @@ describe('#utils', () => {
 
       expect(result).toEqual([expected])
     })
+
+    test('should populate siteName from KML feature properties', () => {
+      const existingCache = {
+        projectName: 'Test Project',
+        siteDetails: [{ coordinatesType: 'file', fileUploadType: 'kml' }]
+      }
+      mockRequest.yar.get.mockReturnValue(existingCache)
+
+      const mockCoordinateData = {
+        extractedCoordinates: [],
+        geoJSON: {
+          type: 'FeatureCollection',
+          features: [
+            {
+              type: 'Feature',
+              geometry: { type: 'Polygon', coordinates: [] },
+              properties: { name: 'North Harbour' }
+            }
+          ]
+        }
+      }
+
+      const result = updateMarineLicenceSiteDetailsBatch(
+        mockRequest,
+        mockStatus,
+        mockCoordinateData,
+        mockS3Location,
+        { isMultipleSitesFile: false }
+      )
+
+      expect(result[0].siteName).toBe('North Harbour')
+    })
+
+    test('should populate site names from shapefile columns for multiple sites', () => {
+      const existingCache = {
+        projectName: 'Test Project',
+        siteDetails: [{ coordinatesType: 'file', fileUploadType: 'shapefile' }]
+      }
+      mockRequest.yar.get.mockReturnValue(existingCache)
+
+      const mockCoordinateData = {
+        extractedCoordinates: [[], []],
+        geoJSON: {
+          type: 'FeatureCollection',
+          features: [
+            {
+              type: 'Feature',
+              geometry: { type: 'Polygon', coordinates: [] },
+              properties: { Site_name: 'East Pier' }
+            },
+            {
+              type: 'Feature',
+              geometry: { type: 'Polygon', coordinates: [] },
+              properties: {}
+            }
+          ]
+        }
+      }
+
+      const result = updateMarineLicenceSiteDetailsBatch(
+        mockRequest,
+        mockStatus,
+        mockCoordinateData,
+        mockS3Location,
+        { isMultipleSitesFile: true }
+      )
+
+      expect(result[0].siteName).toBe('East Pier')
+      expect(result[1].siteName).toBeUndefined()
+    })
   })
 
   describe('clearSavedMarineLicenceSiteDetails', () => {
@@ -1009,6 +1079,46 @@ describe('#utils', () => {
         featureCount: 1,
         uploadConfig: null
       })
+    })
+
+    test('should populate siteName from the uploaded file when present', () => {
+      const existingCache = {
+        projectName: 'Test Project',
+        siteDetails: [
+          {
+            siteName: 'Site A',
+            coordinatesType: 'file',
+            fileUploadType: 'kml'
+          }
+        ]
+      }
+
+      const mockRequest = {
+        yar: { get: vi.fn().mockReturnValue(existingCache), set: vi.fn() }
+      }
+
+      updateSingleSiteLocation(
+        mockRequest,
+        mockStatus,
+        {
+          ...mockCoordinateData,
+          geoJSON: {
+            type: 'FeatureCollection',
+            features: [
+              {
+                type: 'Feature',
+                geometry: { type: 'Point', coordinates: [-1.23, 50.99] },
+                properties: { name: 'Updated from file' }
+              }
+            ]
+          }
+        },
+        mockS3Location,
+        0
+      )
+
+      const [, setCall] = mockRequest.yar.set.mock.calls[0]
+      expect(setCall.siteDetails[0].siteName).toBe('Updated from file')
     })
 
     test('should write updated siteDetails to the cache', () => {

--- a/src/server/common/helpers/marine-licence/session-cache/utils.test.js
+++ b/src/server/common/helpers/marine-licence/session-cache/utils.test.js
@@ -742,7 +742,7 @@ describe('#utils', () => {
       expect(result[0].siteName).toBe('North Harbour')
     })
 
-    test('should populate site names from shapefile columns for multiple sites', () => {
+    test('should populate site names from GeoJSON properties.name for multiple sites', () => {
       const existingCache = {
         projectName: 'Test Project',
         siteDetails: [{ coordinatesType: 'file', fileUploadType: 'shapefile' }]
@@ -757,7 +757,7 @@ describe('#utils', () => {
             {
               type: 'Feature',
               geometry: { type: 'Polygon', coordinates: [] },
-              properties: { Site_name: 'East Pier' }
+              properties: { name: 'East Pier' }
             },
             {
               type: 'Feature',

--- a/src/server/exemption/site-details/file-upload/controller.test.js
+++ b/src/server/exemption/site-details/file-upload/controller.test.js
@@ -6,6 +6,10 @@ import { fileUploadController } from '#src/server/exemption/site-details/file-up
 import { mockExemption } from '#src/server/test-helpers/mocks/exemption.js'
 import * as cdpUploadService from '#src/services/cdp-upload-service/index.js'
 import { FILE_UPLOAD_VIEW_ROUTE } from '#src/server/common/helpers/file-upload/constants.js'
+import {
+  KML_SITE_NAME_GUIDANCE,
+  SHAPEFILE_SITE_NAME_GUIDANCE
+} from '#src/server/common/helpers/file-upload/file-upload.js'
 
 vi.mock('~/src/server/common/helpers/exemptions/session-cache/utils.js')
 vi.mock('~/src/services/cdp-upload-service/index.js')
@@ -123,16 +127,23 @@ describe('#fileUpload', () => {
         {
           fileType: 'kml',
           expectedHeading: 'Upload a KML file',
-          expectedAccept: '.kml'
+          expectedAccept: '.kml',
+          expectedSiteNameGuidance: KML_SITE_NAME_GUIDANCE
         },
         {
           fileType: 'shapefile',
           expectedHeading: 'Upload a shapefile',
-          expectedAccept: '.zip'
+          expectedAccept: '.zip',
+          expectedSiteNameGuidance: SHAPEFILE_SITE_NAME_GUIDANCE
         }
       ])(
         'Should display $fileType upload page with correct title and content',
-        async ({ fileType, expectedHeading, expectedAccept }) => {
+        async ({
+          fileType,
+          expectedHeading,
+          expectedAccept,
+          expectedSiteNameGuidance
+        }) => {
           // Given - File type selected
           // When
           await setupStandardFileUploadTest(fileType, mockRequest, mockH)
@@ -144,6 +155,7 @@ describe('#fileUpload', () => {
             projectName: 'Test Project',
             acceptAttribute: expectedAccept,
             fileUploadType: fileType,
+            siteNameGuidance: expectedSiteNameGuidance,
             backLink: routes.CHOOSE_FILE_UPLOAD_TYPE,
             cancelLink: `${routes.TASK_LIST}?cancel=site-details`
           })

--- a/src/server/templates/before-you-start.njk
+++ b/src/server/templates/before-you-start.njk
@@ -49,6 +49,9 @@
         <li>enter the coordinates manually</li>
       </ul>
 
+      <p>We'll use a site name for each area in your file if one is included.</p>
+      <p>For shapefiles, put the name in a column such as ‘Name’ or ‘Site_name’ for each area. For KML files, use the name of each place.</p>
+
       <h3 class="govuk-heading-s">Projects with multiple sites</h3>
       <p>You need to give separate location details for each site if your project has multiple sites.</p>
       <p>If you're uploading a file you need to include all the sites in 1 file.</p>

--- a/src/server/templates/file-upload.njk
+++ b/src/server/templates/file-upload.njk
@@ -37,6 +37,12 @@
     <p class="govuk-body">The file you upload must be for a single site. Your file must only contain a site drawn as a polygon (shape), not a point or a line.</p>
   {% endif %}
 
+  {% if siteNameGuidance %}
+    {% for paragraph in siteNameGuidance %}
+      <p class="govuk-body">{{ paragraph }}</p>
+    {% endfor %}
+  {% endif %}
+
 {% endset %}
 
 {% block content %}

--- a/tests/integration/site-details/before-you-start-site-details/before-you-start-tests.js
+++ b/tests/integration/site-details/before-you-start-site-details/before-you-start-tests.js
@@ -137,6 +137,19 @@ export function sharedBeforeYouStartSiteDetailsTests({
     expect(
       getByText(document, 'enter the coordinates manually')
     ).toBeInTheDocument()
+
+    expect(
+      getByText(
+        document,
+        "We'll use a site name for each area in your file if one is included."
+      )
+    ).toBeInTheDocument()
+    expect(
+      getByText(
+        document,
+        'For shapefiles, put the name in a column such as ‘Name’ or ‘Site_name’ for each area. For KML files, use the name of each place.'
+      )
+    ).toBeInTheDocument()
   })
 
   test('should have properly structured lists for accessibility', async () => {

--- a/tests/integration/site-details/file-upload/file-upload-tests.js
+++ b/tests/integration/site-details/file-upload/file-upload-tests.js
@@ -19,6 +19,19 @@ export function sharedFileUploadTests({ loadPageWithFileType, projectType }) {
     expect(zipFileText).toBeInTheDocument()
 
     expect(
+      getByText(
+        document,
+        /We'll use a site name for each area in your file if one is included/i
+      )
+    ).toBeInTheDocument()
+    expect(
+      getByText(
+        document,
+        /In a shapefile, put the name in a column such as Name or Site_name for each area/i
+      )
+    ).toBeInTheDocument()
+
+    expect(
       getByText(document, /You can include more than one site/i)
     ).toBeInTheDocument()
 
@@ -43,6 +56,21 @@ export function sharedFileUploadTests({ loadPageWithFileType, projectType }) {
     expect(
       document.body.textContent.includes('You can include more than one site')
     ).toBe(true)
+
+    expect(
+      getByText(
+        document,
+        /We'll use a site name for each area in your file if one is included/i
+      )
+    ).toBeInTheDocument()
+    expect(
+      getByText(document, /In a KML file, use the name of each place/i)
+    ).toBeInTheDocument()
+    expect(
+      document.body.textContent.includes(
+        'In a shapefile, put the name in a column such as Name or Site_name'
+      )
+    ).toBe(false)
 
     expect(getByRole(document, 'link', { name: 'Cancel' })).toHaveAttribute(
       'href',
@@ -78,6 +106,19 @@ export function singleSiteModeTests({ loadPageWithFileType }) {
         'The file you upload must be for a single site.'
       )
     ).toBe(true)
+
+    expect(
+      getByText(
+        document,
+        /We'll use a site name for each area in your file if one is included/i
+      )
+    ).toBeInTheDocument()
+    expect(
+      getByText(
+        document,
+        /In a shapefile, put the name in a column such as Name or Site_name for each area/i
+      )
+    ).toBeInTheDocument()
   })
 
   test('should show KML heading and polygon guidance text only', async () => {
@@ -99,6 +140,16 @@ export function singleSiteModeTests({ loadPageWithFileType }) {
         'The file you upload must be for a single site.'
       )
     ).toBe(true)
+
+    expect(
+      getByText(
+        document,
+        /We'll use a site name for each area in your file if one is included/i
+      )
+    ).toBeInTheDocument()
+    expect(
+      getByText(document, /In a KML file, use the name of each place/i)
+    ).toBeInTheDocument()
 
     expect(getByRole(document, 'link', { name: 'Cancel' })).toHaveAttribute(
       'href',


### PR DESCRIPTION
- Extract site names from uploaded KML and shapefile files and pre-populate them when sites are created
- Leave the site name blank if the file does not include one
- Show how to include site names on the file upload page, with different wording for KML and shapefile
- Add the same guidance to the Before you start page for site details

Depends-On: https://github.com/DEFRA/marine-licensing-backend/pull/593
Depends-On: https://github.com/DEFRA/marine-licensing-journey-tests/pull/345